### PR TITLE
refactor: call reusable workflow directly instead of repository_dispatch

### DIFF
--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -1,18 +1,20 @@
-name: Trigger Docker Build
+name: Docker Build
 
 on:
   push:
     tags:
       - 'v*'
 
-run-name: "Trigger build for ${{ github.ref_name }}"
+run-name: "Build mentor ${{ github.ref_name }}"
 
 jobs:
-  trigger-build:
+  prepare:
+    name: "Prepare"
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Checkout (to read version)
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Extract version from package.json
         id: version
@@ -21,33 +23,12 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
-      - name: Trigger ibl-web-ops build
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.OPS_DISPATCH_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/iblai/ibl-web-ops/dispatches \
-            -d '{
-              "event_type": "spa-docker-build",
-              "client_payload": {
-                "app_name": "mentor",
-                "source_repo": "${{ github.repository }}",
-                "source_ref": "${{ github.ref }}",
-                "version": "${{ steps.version.outputs.version }}"
-              }
-            }'
-
-          echo "Triggered ibl-web-ops build for mentor v${{ steps.version.outputs.version }}"
-
-      - name: Build link
-        run: |
-          OPS_URL="https://github.com/iblai/ibl-web-ops/actions/workflows/docker-build.yml"
-          echo "## Docker Build Dispatched" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| | |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| **App** | mentor |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Version** | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Tag** | ${{ github.ref_name }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Build** | [Track in ibl-web-ops Actions]($OPS_URL) |" >> $GITHUB_STEP_SUMMARY
+  build:
+    needs: prepare
+    uses: iblai/ibl-web-ops/.github/workflows/reusable-spa-docker-build.yml@main
+    with:
+      app_name: mentor
+      source_repo: ${{ github.repository }}
+      source_ref: ${{ github.ref }}
+      version: ${{ needs.prepare.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
Build now runs in source repo Actions tab instead of ibl-web-ops, consistent with PR validation. No more OPS_DISPATCH_TOKEN needed.


## Checklist
- [ ] Tests were added/updated according to the feature/bugfix/change made
- [ ] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
