### PR TITLE
Add Playwright Docker image for PR validation

### DIFF
--- a/.github/workflows/spa-pr-validation.yml
+++ b/.github/workflows/spa-pr-validation.yml
@@ -50,7 +50,7 @@ jobs:
               - 'tailwind.config.*'
               - 'Dockerfile'
             tests:
-              - 'tests/**'
+              - 'e2e/**'
 
       - name: Decide build strategy
         id: decide
@@ -87,7 +87,7 @@ jobs:
     with:
       app-name: mentor
       pr-number: ${{ github.event.pull_request.number }}
-      test-dir: tests
+      test-dir: e2e/tests
     secrets:
       s3-bucket: ${{ secrets.S3_LOGS_BUCKET }}
       aws-access-key-id: ${{ secrets.S3_LOGS_ACCESS_KEY_ID }}
@@ -210,8 +210,8 @@ jobs:
     uses: iblai/ibl-web-ops/.github/workflows/reusable-pr-docker-build.yml@main
     secrets: inherit
     with:
-      dockerfile-path: tests/Dockerfile
-      build-context: tests/
+      dockerfile-path: e2e/Dockerfile
+      build-context: .
       image-name: ibl-mentor-playwright
       registry-type: ocir
       event-name: pull_request

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,32 @@
+# Playwright test image for CI/CD
+# Built from repo root: docker build -f e2e/Dockerfile .
+FROM mcr.microsoft.com/playwright:v1.52.0-jammy
+
+# Install AWS CLI for S3 log/report uploads
+RUN apt-get update && \
+    apt-get install -y python3-pip curl unzip && \
+    pip3 install --no-cache-dir awscli && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN aws --version
+
+WORKDIR /app
+
+# Enable pnpm via corepack
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+# Copy package manifests from repo root (deps live here, not in e2e/)
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies (skip optional like electron, skip postinstall scripts)
+RUN pnpm install --frozen-lockfile --ignore-scripts --no-optional
+
+# Copy e2e test suite
+COPY e2e/ ./e2e/
+
+# Copy entrypoint
+COPY e2e/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["test"]

--- a/e2e/docker-entrypoint.sh
+++ b/e2e/docker-entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# docker-entrypoint.sh — Playwright test runner with S3 log/report uploads
+#
+# Environment variables (passed from OCI Container Instance):
+#   BROWSERS        Comma-separated browsers (default: chrome)
+#   PLATFORM        Playwright project platform (default: mentornextjs)
+#   TEST_FILES      Comma-separated test files for selective execution (optional)
+#   WORKERS         Playwright worker count (default: 1)
+#   S3_BUCKET       S3 bucket for logs/reports (optional)
+#   RUN_ID          Unique run identifier for S3 paths
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION  AWS credentials
+#   PR_NUMBER       PR number for test result caching
+
+set -e
+
+BROWSERS="${BROWSERS:-chrome}"
+PLATFORM="${PLATFORM:-mentornextjs}"
+TEST_FILES="${TEST_FILES:-}"
+WORKERS="${WORKERS:-1}"
+S3_BUCKET="${S3_BUCKET:-}"
+RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+PR_NUMBER="${PR_NUMBER:-}"
+
+BROWSER_LIST=$(echo "$BROWSERS" | tr ',' ' ')
+LOG_FILE="/tmp/test-run.log"
+REPORT_DIR="/app/playwright-report"
+
+# Determine app name for S3 paths
+APP_NAME="$PLATFORM"
+if [ "$PLATFORM" = "mentornextjs" ]; then
+  APP_NAME="mentor"
+fi
+
+echo "================================================================================"
+echo "Playwright Test Runner"
+echo "================================================================================"
+echo "Platform:   $PLATFORM"
+echo "Browser(s): $BROWSER_LIST"
+echo "Workers:    $WORKERS"
+echo "Test Files: ${TEST_FILES:-all tests}"
+echo "S3 Bucket:  ${S3_BUCKET:-(not set)}"
+echo "Run ID:     $RUN_ID"
+echo "PR Number:  ${PR_NUMBER:-(not set)}"
+echo "App Name:   $APP_NAME"
+echo "================================================================================"
+echo ""
+
+# --- S3 upload functions ---
+
+upload_logs() {
+  local exit_code=$1
+
+  if [ -z "$S3_BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    return 0
+  fi
+
+  echo "" >> "$LOG_FILE"
+  echo "================================================================================" >> "$LOG_FILE"
+  echo "Container Exit Code: $exit_code" >> "$LOG_FILE"
+  echo "Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_FILE"
+  echo "================================================================================" >> "$LOG_FILE"
+
+  S3_PATH="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/logs/test-run.log"
+  echo "Uploading log to $S3_PATH"
+  aws s3 cp "$LOG_FILE" "$S3_PATH" --region "$AWS_REGION" 2>&1 || echo "Failed to upload log"
+}
+
+upload_report() {
+  if [ ! -d "$REPORT_DIR" ] || [ -z "$S3_BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    return 0
+  fi
+
+  S3_PREFIX="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/reports"
+  echo "Uploading HTML report to $S3_PREFIX"
+  aws s3 cp "$REPORT_DIR" "$S3_PREFIX/" --recursive --region "$AWS_REGION" 2>&1 || echo "Failed to upload report"
+}
+
+upload_traces() {
+  local traces_dir="/app/test-results"
+  if [ ! -d "$traces_dir" ] || [ -z "$S3_BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    return 0
+  fi
+
+  TRACE_FILES=$(find "$traces_dir" -name "*.zip" 2>/dev/null || echo "")
+  if [ -z "$TRACE_FILES" ]; then
+    return 0
+  fi
+
+  S3_PREFIX="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/traces"
+  echo "Uploading trace files to $S3_PREFIX"
+  for trace_file in $TRACE_FILES; do
+    aws s3 cp "$trace_file" "$S3_PREFIX/$(basename "$trace_file")" --region "$AWS_REGION" 2>&1 || true
+  done
+}
+
+# Trap to ensure uploads happen even on failure
+trap 'EXIT_CODE=$?; echo ""; echo "Caught exit with code: $EXIT_CODE"; upload_logs $EXIT_CODE; upload_report; upload_traces; echo "Final exit code: $EXIT_CODE"; exit $EXIT_CODE' EXIT
+
+# --- Build test command ---
+
+TEST_FILES_ARGS=""
+if [ -n "$TEST_FILES" ]; then
+  TEST_FILES_ARGS=$(echo "$TEST_FILES" | tr ',' ' ')
+  echo "Selective execution: $TEST_FILES_ARGS"
+  echo ""
+fi
+
+# --- Run tests per browser ---
+
+OVERALL_EXIT_CODE=0
+
+for CURRENT_BROWSER in $BROWSER_LIST; do
+  PROJECT_NAME="${PLATFORM}-desktop-${CURRENT_BROWSER}"
+
+  echo "================================================================================" | tee -a "$LOG_FILE"
+  echo "Running: $PROJECT_NAME" | tee -a "$LOG_FILE"
+  echo "================================================================================" | tee -a "$LOG_FILE"
+
+  CMD="npx playwright test --config e2e/playwright.config.ts --project=$PROJECT_NAME --workers=$WORKERS"
+
+  if [ -n "$TEST_FILES_ARGS" ]; then
+    CMD="$CMD $TEST_FILES_ARGS"
+  fi
+
+  echo "Command: $CMD" | tee -a "$LOG_FILE"
+  echo "" | tee -a "$LOG_FILE"
+
+  set +e
+  CI=true NODE_ENV=production eval "$CMD" 2>&1 | tee -a "$LOG_FILE"
+  EXIT_CODE=${PIPESTATUS[0]}
+  set -e
+
+  if [ $EXIT_CODE -eq 0 ]; then
+    echo "PASSED: $CURRENT_BROWSER" | tee -a "$LOG_FILE"
+  else
+    echo "FAILED: $CURRENT_BROWSER (exit: $EXIT_CODE)" | tee -a "$LOG_FILE"
+    OVERALL_EXIT_CODE=1
+  fi
+  echo "" | tee -a "$LOG_FILE"
+done
+
+echo "================================================================================" | tee -a "$LOG_FILE"
+echo "Tests completed with exit code: $OVERALL_EXIT_CODE" | tee -a "$LOG_FILE"
+echo "================================================================================" | tee -a "$LOG_FILE"
+
+exit $OVERALL_EXIT_CODE


### PR DESCRIPTION
## Summary
- Adds `e2e/Dockerfile` — Playwright test image based on `mcr.microsoft.com/playwright:v1.52.0-jammy` with AWS CLI for S3 log/report uploads
- Adds `e2e/docker-entrypoint.sh` — multi-browser test runner supporting `BROWSERS`, `TEST_FILES`, `WORKERS` env vars with S3 upload of logs, reports, and traces
- Updates `spa-pr-validation.yml` — points Playwright image build to `e2e/Dockerfile` with repo root build context, changes `test-dir` to `e2e/tests` for test resumption

## Test plan
- [ ] Verify Playwright Docker image builds successfully
- [ ] Verify PR validation workflow passes static validation
- [ ] Test with `run-tests` label on a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)