### PR TITLE
fix(ci): pass NEXT_IMAGE_PATTERNS to docker build

### DIFF
--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -31,4 +31,5 @@ jobs:
       source_repo: ${{ github.repository }}
       source_ref: ${{ github.ref }}
       version: ${{ needs.prepare.outputs.version }}
+      next_image_patterns: ${{ vars.NEXT_IMAGE_PATTERNS }}
     secrets: inherit

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,8 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 import type { RemotePattern } from 'next/dist/shared/lib/image-config';
 
-const rawPatterns = process.env.NEXT_IMAGE_PATTERNS?.split(',') || [
+const envPatterns = process.env.NEXT_IMAGE_PATTERNS?.trim();
+const rawPatterns = envPatterns ? envPatterns.split(',') : [
   'https://hebbkx1anhila5yf.public.blob.vercel-storage.com',
   'https://s3.*.amazonaws.com',
   'https://base.manager.iblai.tech',


### PR DESCRIPTION
## Summary
- The reusable workflow in `ibl-web-ops` was reading `vars.NEXT_IMAGE_PATTERNS` from its own repo context (which has zero variables), so the build arg was never passed to the Docker build
- This caused `NEXT_IMAGE_PATTERNS` env var to be set as empty string at build time
- `''.split(',')` returns `['']` (not `[]`), so the `||` fallback to defaults never triggered
- Result: `remotePatterns` was empty, breaking `<Image>` loading for logos from `base.manager.iblai.app` etc.

## Changes
- **`trigger-docker-build.yml`**: Pass `next_image_patterns: ${{ vars.NEXT_IMAGE_PATTERNS }}` as input to the reusable workflow
- **`next.config.ts`**: Treat empty string as unset so defaults always kick in as a safety net

## Required
- Merge https://github.com/iblai/ibl-web-ops/pull/1 first (adds `next_image_patterns` input to the reusable workflow)
- Add `NEXT_IMAGE_PATTERNS` as a repo variable in mentorai (Settings > Secrets and variables > Actions > Variables) with value:
  ```
  https://hebbkx1anhila5yf.public.blob.vercel-storage.com,https://s3.*.amazonaws.com,https://base.manager.iblai.tech,https://base.manager.iblai.org,https://base.manager.iblai.app,https://base.manager.dev2.iblai.org,https://base.manager.ai.syr.edu,https://base.manager.stg.explainer.kaplan.ai
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)