### PR TITLE
fix(ci): PR validation pipeline fixes

### DIFF
--- a/.github/workflows/debug-e2e-test.yml
+++ b/.github/workflows/debug-e2e-test.yml
@@ -313,6 +313,20 @@ jobs:
           echo "--- Log URL ---"
           echo "https://${CLOUDFRONT}/runs/${RUN_ID}/mentor/logs/test-run.log"
 
+          echo ""
+          echo "--- Trace files ---"
+          TRACE_PREFIX="runs/$RUN_ID/mentor/traces/"
+          TRACE_FILES=$(aws s3 ls "s3://$S3_BUCKET/${TRACE_PREFIX}" --region "$AWS_REGION" 2>/dev/null | awk '{print $4}' | grep -E '\.zip$' || echo "")
+          if [ -n "$TRACE_FILES" ]; then
+            for trace_file in $TRACE_FILES; do
+              TRACE_URL="https://${CLOUDFRONT}/${TRACE_PREFIX}${trace_file}"
+              echo "Trace: $trace_file"
+              echo "  View: https://trace.playwright.dev/?trace=${TRACE_URL}"
+            done
+          else
+            echo "(no trace files found)"
+          fi
+
       - name: Fetch OCI container logs
         if: always()
         run: |
@@ -353,6 +367,11 @@ jobs:
           RUN_ID="${{ steps.launch.outputs.run-id }}"
           CLOUDFRONT="${{ vars.CLOUDFRONT_DOMAIN || 'tests.iblai.app' }}"
 
+          export AWS_ACCESS_KEY_ID="${{ secrets.S3_LOGS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.S3_LOGS_SECRET_ACCESS_KEY }}"
+          S3_BUCKET="${{ secrets.S3_LOGS_BUCKET }}"
+          AWS_REGION="${{ vars.AWS_REGION || 'us-east-1' }}"
+
           {
             echo "## Debug E2E Test Results"
             echo ""
@@ -361,8 +380,26 @@ jobs:
             echo "**Image:** ${{ steps.image.outputs.image }}"
             echo "**Exit Code:** ${EXIT_CODE:-unknown}"
             echo ""
-            echo "**Log:** https://${CLOUDFRONT}/runs/${RUN_ID}/mentor/logs/test-run.log"
+            echo "**Log:** [test-run.log](https://${CLOUDFRONT}/runs/${RUN_ID}/mentor/logs/test-run.log)"
           } >> $GITHUB_STEP_SUMMARY
+
+          # List trace files from S3 and add to summary
+          TRACE_PREFIX="runs/${RUN_ID}/mentor/traces/"
+          TRACE_FILES=$(aws s3 ls "s3://$S3_BUCKET/${TRACE_PREFIX}" --region "$AWS_REGION" 2>/dev/null | awk '{print $4}' | grep -E '\.zip$' || echo "")
+          if [ -n "$TRACE_FILES" ]; then
+            {
+              echo ""
+              echo "### Trace Viewer Links (Failed Tests)"
+              echo ""
+              echo "Click to open in [Playwright Trace Viewer](https://trace.playwright.dev/):"
+              echo ""
+            } >> $GITHUB_STEP_SUMMARY
+            for trace_file in $TRACE_FILES; do
+              TRACE_URL="https://${CLOUDFRONT}/${TRACE_PREFIX}${trace_file}"
+              VIEWER_URL="https://trace.playwright.dev/?trace=${TRACE_URL}"
+              echo "- [\`${trace_file}\`](${VIEWER_URL})" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
 
           if [ "$EXIT_CODE" != "0" ] && [ "$EXIT_CODE" != "null" ]; then
             echo ""

--- a/.github/workflows/spa-pr-validation.yml
+++ b/.github/workflows/spa-pr-validation.yml
@@ -238,6 +238,7 @@ jobs:
       venv-name: ${{ needs.gate.outputs.venv-name }}
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   # ============================================================
   # DEPLOY AUTH (uses prod auth image)
@@ -254,6 +255,7 @@ jobs:
       venv-name: ${{ needs.gate.outputs.venv-name }}
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   # ============================================================
   # SEQUENTIAL BROWSER TESTS (default mode)
@@ -274,6 +276,7 @@ jobs:
       health-port: '5007'
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   test-chrome:
     needs: [gate, check-resumption, acquire-domain, deploy-auth, build-playwright-image, verify-chrome]
@@ -313,6 +316,7 @@ jobs:
       health-port: '5007'
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   test-firefox:
     needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-firefox]
@@ -352,6 +356,7 @@ jobs:
       health-port: '5007'
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   test-safari:
     needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-safari]
@@ -391,6 +396,7 @@ jobs:
       health-port: '5007'
     secrets:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_DEPLOY_OPS }}
+      git-token: ${{ secrets.GIT_TOKEN }}
 
   test-edge:
     needs: [gate, check-resumption, acquire-domain, build-playwright-image, verify-edge]

--- a/e2e/docker-entrypoint.sh
+++ b/e2e/docker-entrypoint.sh
@@ -3,13 +3,14 @@
 #
 # Environment variables (passed from OCI Container Instance):
 #   BROWSERS        Comma-separated browsers (default: chrome)
-#   PLATFORM        Playwright project platform (default: mentornextjs)
+#   PLATFORM        Playwright project platform (default: mentor)
 #   TEST_FILES      Comma-separated test files for selective execution (optional)
 #   WORKERS         Playwright worker count (default: 1)
 #   S3_BUCKET       S3 bucket for logs/reports (optional)
 #   RUN_ID          Unique run identifier for S3 paths
 #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION  AWS credentials
-#   PR_NUMBER       PR number for test result caching
+#   PR_NUMBER       PR number for test result caching (enables test resumption)
+#   CLOUDFRONT_DOMAIN  Domain for viewing logs/reports (default: tests.iblai.app)
 
 set -e
 
@@ -21,6 +22,7 @@ S3_BUCKET="${S3_BUCKET:-}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 AWS_REGION="${AWS_REGION:-us-east-1}"
 PR_NUMBER="${PR_NUMBER:-}"
+CLOUDFRONT_DOMAIN="${CLOUDFRONT_DOMAIN:-tests.iblai.app}"
 
 BROWSER_LIST=$(echo "$BROWSERS" | tr ',' ' ')
 LOG_FILE="/tmp/test-run.log"
@@ -28,6 +30,9 @@ REPORT_DIR="/app/playwright-report"
 
 # Determine app name for S3 paths
 APP_NAME="$PLATFORM"
+
+# Capture all output to log file while showing on console
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "================================================================================"
 echo "Playwright Test Runner"
@@ -40,6 +45,7 @@ echo "S3 Bucket:  ${S3_BUCKET:-(not set)}"
 echo "Run ID:     $RUN_ID"
 echo "PR Number:  ${PR_NUMBER:-(not set)}"
 echo "App Name:   $APP_NAME"
+echo "CloudFront: $CLOUDFRONT_DOMAIN"
 echo "================================================================================"
 echo ""
 
@@ -59,8 +65,17 @@ upload_logs() {
   echo "================================================================================" >> "$LOG_FILE"
 
   S3_PATH="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/logs/test-run.log"
-  echo "Uploading log to $S3_PATH"
-  aws s3 cp "$LOG_FILE" "$S3_PATH" --region "$AWS_REGION" 2>&1 || echo "Failed to upload log"
+  echo "Uploading log to $S3_PATH" | tee -a "$LOG_FILE"
+
+  if aws s3 cp "$LOG_FILE" "$S3_PATH" \
+    --region "$AWS_REGION" \
+    --content-type "text/plain; charset=utf-8" \
+    --content-disposition "inline" 2>&1 | tee -a "$LOG_FILE"; then
+    CLOUDFRONT_URL="https://${CLOUDFRONT_DOMAIN}/runs/${RUN_ID}/$APP_NAME/logs/test-run.log"
+    echo "Log uploaded: $CLOUDFRONT_URL" | tee -a "$LOG_FILE"
+  else
+    echo "Failed to upload log" | tee -a "$LOG_FILE"
+  fi
 }
 
 upload_report() {
@@ -79,20 +94,122 @@ upload_traces() {
     return 0
   fi
 
-  TRACE_FILES=$(find "$traces_dir" -name "*.zip" 2>/dev/null || echo "")
-  if [ -z "$TRACE_FILES" ]; then
+  echo ""
+  echo "================================================================================"
+  echo "Uploading Trace Files to S3"
+  echo "================================================================================"
+
+  TRACE_COUNT=0
+  UPLOAD_SUCCESS=0
+
+  while IFS= read -r -d '' trace_file; do
+    TRACE_COUNT=$((TRACE_COUNT + 1))
+    TEST_DIR=$(dirname "$trace_file")
+    TEST_NAME=$(basename "$TEST_DIR")
+    SAFE_NAME=$(echo "$TEST_NAME" | sed 's/[^a-zA-Z0-9._-]/_/g')
+    S3_TRACE_PATH="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/traces/${SAFE_NAME}-trace.zip"
+
+    if aws s3 cp "$trace_file" "$S3_TRACE_PATH" \
+      --region "$AWS_REGION" \
+      --content-type "application/zip" 2>&1; then
+      UPLOAD_SUCCESS=$((UPLOAD_SUCCESS + 1))
+      TRACE_URL="https://${CLOUDFRONT_DOMAIN}/runs/${RUN_ID}/$APP_NAME/traces/${SAFE_NAME}-trace.zip"
+      echo "Uploaded: $TEST_NAME -> https://trace.playwright.dev/?trace=${TRACE_URL}"
+    else
+      echo "Failed to upload trace: $TEST_NAME"
+    fi
+  done < <(find "$traces_dir" -name "trace.zip" -print0 2>/dev/null)
+
+  echo "Traces: $UPLOAD_SUCCESS/$TRACE_COUNT uploaded"
+  echo ""
+}
+
+upload_test_results() {
+  local exit_code=$1
+
+  if [ -z "$PR_NUMBER" ]; then
     return 0
   fi
 
-  S3_PREFIX="s3://$S3_BUCKET/runs/$RUN_ID/$APP_NAME/traces"
-  echo "Uploading trace files to $S3_PREFIX"
-  for trace_file in $TRACE_FILES; do
-    aws s3 cp "$trace_file" "$S3_PREFIX/$(basename "$trace_file")" --region "$AWS_REGION" 2>&1 || true
-  done
+  if [ -z "$S3_BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    return 0
+  fi
+
+  RESULTS_FILE="/app/test-results.json"
+  if [ ! -f "$RESULTS_FILE" ]; then
+    echo "No test-results.json found - skipping results upload"
+    return 0
+  fi
+
+  BROWSER_KEY=$(echo "$BROWSERS" | tr ',' '-' | tr '[:upper:]' '[:lower:]')
+  S3_RESULTS_PATH="s3://$S3_BUCKET/pr/$PR_NUMBER/$APP_NAME/test-results-${BROWSER_KEY}.json"
+
+  echo ""
+  echo "================================================================================"
+  echo "Uploading Per-File Test Results (test resumption)"
+  echo "================================================================================"
+  echo "Browser:   $BROWSER_KEY"
+  echo "PR Number: $PR_NUMBER"
+  echo "S3 Path:   $S3_RESULTS_PATH"
+
+  # Parse Playwright JSON results to extract per-file pass/fail
+  NEW_RESULTS=$(jq '
+    [.suites[] | recurse(.suites[]?) | .specs[]? | {file: .file, ok: .ok}] |
+    group_by(.file) |
+    map({key: .[0].file, value: (if all(.[]; .ok) then "passed" else "failed" end)}) |
+    from_entries |
+    {version: 1, tests: .}
+  ' "$RESULTS_FILE" 2>/dev/null) || {
+    echo "Failed to parse test-results.json - skipping"
+    return 0
+  }
+
+  NEW_COUNT=$(echo "$NEW_RESULTS" | jq '.tests | length')
+  NEW_PASSED=$(echo "$NEW_RESULTS" | jq '[.tests | to_entries[] | select(.value == "passed")] | length')
+  NEW_FAILED=$(echo "$NEW_RESULTS" | jq '[.tests | to_entries[] | select(.value == "failed")] | length')
+  echo "Current run: $NEW_COUNT files ($NEW_PASSED passed, $NEW_FAILED failed)"
+
+  # Merge logic: full run replaces, selective run overlays
+  if [ -z "$TEST_FILES" ]; then
+    echo "Mode: Full run - replacing results"
+    MERGED_RESULTS="$NEW_RESULTS"
+  else
+    echo "Mode: Selective run - merging with previous"
+    PREV_FILE="/tmp/prev-test-results.json"
+    if aws s3 cp "$S3_RESULTS_PATH" "$PREV_FILE" --region "$AWS_REGION" 2>/dev/null; then
+      PREV_COUNT=$(jq '.tests | length' "$PREV_FILE" 2>/dev/null || echo "0")
+      echo "Previous results: $PREV_COUNT files"
+      MERGED_RESULTS=$(jq -s '
+        {version: 1, tests: (.[0].tests // {} | to_entries | map({(.key): .value}) | add // {}) * (.[1].tests | to_entries | map({(.key): .value}) | add // {})} |
+        {version: .version, tests: .tests}
+      ' "$PREV_FILE" <(echo "$NEW_RESULTS") 2>/dev/null) || {
+        echo "Merge failed - using current results only"
+        MERGED_RESULTS="$NEW_RESULTS"
+      }
+    else
+      echo "No previous results - using current"
+      MERGED_RESULTS="$NEW_RESULTS"
+    fi
+  fi
+
+  MERGED_COUNT=$(echo "$MERGED_RESULTS" | jq '.tests | length')
+  MERGED_PASSED=$(echo "$MERGED_RESULTS" | jq '[.tests | to_entries[] | select(.value == "passed")] | length')
+  MERGED_FAILED=$(echo "$MERGED_RESULTS" | jq '[.tests | to_entries[] | select(.value == "failed")] | length')
+  echo "Merged: $MERGED_COUNT files ($MERGED_PASSED passed, $MERGED_FAILED failed)"
+
+  echo "$MERGED_RESULTS" > /tmp/test-results-upload.json
+  if aws s3 cp /tmp/test-results-upload.json "$S3_RESULTS_PATH" \
+    --region "$AWS_REGION" \
+    --content-type "application/json" 2>&1; then
+    echo "Test results uploaded: $S3_RESULTS_PATH"
+  else
+    echo "Failed to upload test results"
+  fi
+  echo ""
 }
 
-# Trap to ensure uploads happen even on failure
-trap 'EXIT_CODE=$?; echo ""; echo "Caught exit with code: $EXIT_CODE"; upload_logs $EXIT_CODE; upload_report; upload_traces; echo "Final exit code: $EXIT_CODE"; exit $EXIT_CODE' EXIT
+# Trap: traces first, then test results, then logs (logs last so they capture upload output)
+trap 'EXIT_CODE=$?; echo ""; echo "Caught exit with code: $EXIT_CODE"; upload_traces; upload_test_results $EXIT_CODE; upload_report; upload_logs $EXIT_CODE; echo "Final exit code: $EXIT_CODE"; exit $EXIT_CODE' EXIT
 
 # --- Build test command ---
 
@@ -106,13 +223,17 @@ fi
 # --- Run tests per browser ---
 
 OVERALL_EXIT_CODE=0
+BROWSER_COUNT=0
+BROWSER_PASSED=0
+BROWSER_FAILED=0
 
 for CURRENT_BROWSER in $BROWSER_LIST; do
+  BROWSER_COUNT=$((BROWSER_COUNT + 1))
   PROJECT_NAME="${PLATFORM}-desktop-${CURRENT_BROWSER}"
 
-  echo "================================================================================" | tee -a "$LOG_FILE"
-  echo "Running: $PROJECT_NAME" | tee -a "$LOG_FILE"
-  echo "================================================================================" | tee -a "$LOG_FILE"
+  echo "================================================================================"
+  echo "Browser $BROWSER_COUNT: $CURRENT_BROWSER (project: $PROJECT_NAME)"
+  echo "================================================================================"
 
   CMD="npx playwright test --config e2e/playwright.config.ts --project=$PROJECT_NAME --workers=$WORKERS"
 
@@ -120,25 +241,28 @@ for CURRENT_BROWSER in $BROWSER_LIST; do
     CMD="$CMD $TEST_FILES_ARGS"
   fi
 
-  echo "Command: $CMD" | tee -a "$LOG_FILE"
-  echo "" | tee -a "$LOG_FILE"
+  echo "Command: $CMD"
+  echo ""
 
   set +e
-  CI=true NODE_ENV=production eval "$CMD" 2>&1 | tee -a "$LOG_FILE"
-  EXIT_CODE=${PIPESTATUS[0]}
+  CI=true NODE_ENV=production eval "$CMD" 2>&1
+  EXIT_CODE=$?
   set -e
 
   if [ $EXIT_CODE -eq 0 ]; then
-    echo "PASSED: $CURRENT_BROWSER" | tee -a "$LOG_FILE"
+    echo "PASSED: $CURRENT_BROWSER"
+    BROWSER_PASSED=$((BROWSER_PASSED + 1))
   else
-    echo "FAILED: $CURRENT_BROWSER (exit: $EXIT_CODE)" | tee -a "$LOG_FILE"
+    echo "FAILED: $CURRENT_BROWSER (exit: $EXIT_CODE)"
+    BROWSER_FAILED=$((BROWSER_FAILED + 1))
     OVERALL_EXIT_CODE=1
   fi
-  echo "" | tee -a "$LOG_FILE"
+  echo ""
 done
 
-echo "================================================================================" | tee -a "$LOG_FILE"
-echo "Tests completed with exit code: $OVERALL_EXIT_CODE" | tee -a "$LOG_FILE"
-echo "================================================================================" | tee -a "$LOG_FILE"
+echo "================================================================================"
+echo "Test Summary: $BROWSER_COUNT browsers ($BROWSER_PASSED passed, $BROWSER_FAILED failed)"
+echo "Exit code: $OVERALL_EXIT_CODE"
+echo "================================================================================"
 
 exit $OVERALL_EXIT_CODE


### PR DESCRIPTION
## Summary

Fixes for the PR validation pipeline discovered during end-to-end testing:

- **Pass `git-token` to deploy and health check reusable workflows** — The `reusable-spa-deployment.yml` and `reusable-pre-test-health-check.yml` workflows need `GIT_TOKEN` to checkout ibl-web-ops. Without it, the checkout fails with "Not Found" because `github.token` can't access cross-repo.

### Companion changes already on main in ibl-web-ops:

- **Add `git-token` optional secret input** to `reusable-spa-deployment.yml` and `reusable-pre-test-health-check.yml`
- **Fix PLATFORM mapping** — removed `mentor → mentornextjs` mapping so project names match `playwright.config.ts` (`mentor-desktop-chrome` not `mentornextjs-desktop-chrome`)
- **Add `--image-pull-secrets`** to OCI container instance creation (base64 encoded OCIR credentials required for private registry)
- **Fix domain URL** in report step (`mentorai` not `mentornextjs`)
- **Fix domain lock** working directory and script paths

### Companion changes already on main in skillsai:

- Same `git-token` fix applied to all deploy and health check jobs

## Test plan

- [x] Verified Docker image builds and runs locally (299 tests found, auth setup runs)
- [x] Verified OCI container instance reaches ACTIVE state with image-pull-secrets fix
- [ ] Full PR validation pipeline end-to-end test via `run-tests` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)