### PR TITLE
fix(ci): require run-tests label for all PRs to merge

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -20,16 +20,16 @@ jobs:
             const sha = context.payload.pull_request.head.sha;
 
             if (!labels.includes('run-tests')) {
-              // No validation required — allow merge
+              // No label — block merge until validation is triggered
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha,
-                state: 'success',
+                state: 'failure',
                 context: 'PR Validation',
-                description: 'Tests not required (add run-tests label to trigger)',
+                description: 'Add the run-tests label to trigger validation',
               });
-              core.info('No run-tests label — gate passes');
+              core.info('No run-tests label — gate blocks merge');
             } else {
               // Label present — block merge until validation workflow completes
               await github.rest.repos.createCommitStatus({


### PR DESCRIPTION
Gate now sets PR Validation status to failure (not success) when the run-tests label is missing, forcing every PR through full validation.


## Checklist
- [ ] Tests were added/updated according to the feature/bugfix/change made
- [ ] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
