### PR TITLE
Fix arm64 MSIX build and add msixbundle generation

### DIFF
--- a/.github/workflows/build-windows-msix.yml
+++ b/.github/workflows/build-windows-msix.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,7 +64,6 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          # Prefer prebuilt if available; fall back to source build if not.
           cargo install cargo-binstall --locked
           try {
             cargo binstall tauri-cli --no-confirm
@@ -86,21 +83,91 @@ jobs:
           $manifest = $manifest -replace 'Version="[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"', "Version=`"${{ inputs.version }}.0`""
           Set-Content -Path AppxManifest.xml -Value $manifest
 
-      - name: Locate built executable
-        working-directory: src-tauri
-        run: |
-          Write-Host "Searching for executables in target directory..."
-          Get-ChildItem -Path target -Recurse -Filter "*.exe" -ErrorAction SilentlyContinue |
-            Where-Object { $_.DirectoryName -like "*release*" } |
-            ForEach-Object { Write-Host $_.FullName }
-
       - name: Build MSIX package (unsigned)
         working-directory: src-tauri
-        run: .\build-msix.ps1 -SkipTauriBuild
+        run: .\build-msix.ps1 -SkipTauriBuild -Architecture ${{ matrix.arch }}
 
       - name: Upload MSIX artifact (${{ matrix.arch }})
         uses: actions/upload-artifact@v4
         with:
           name: ibl-ai-os-msix-${{ matrix.arch }}
           path: src-tauri/msix-output/*.msix
+          if-no-files-found: error
+
+  bundle-msix:
+    name: Create MSIX Bundle
+    needs: build-msix
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Download x64 MSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: ibl-ai-os-msix-x64
+          path: msix-packages
+
+      - name: Download arm64 MSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: ibl-ai-os-msix-arm64
+          path: msix-packages
+
+      - name: List downloaded packages
+        run: Get-ChildItem -Path msix-packages -Recurse
+
+      - name: Locate MakeAppx.exe
+        id: sdk
+        run: |
+          $SdkRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
+          $SdkVersions = Get-ChildItem -Path $SdkRoot -Directory |
+            Where-Object { $_.Name -match "^10\." } |
+            Sort-Object Name -Descending
+          if ($SdkVersions.Count -eq 0) {
+            Write-Error "Windows 10 SDK not found"
+            exit 1
+          }
+          $MakeAppx = Join-Path $SdkVersions[0].FullName "x64\makeappx.exe"
+          if (-not (Test-Path $MakeAppx)) {
+            Write-Error "makeappx.exe not found at $MakeAppx"
+            exit 1
+          }
+          Write-Host "Found: $MakeAppx"
+          echo "MAKEAPPX=$MakeAppx" >> $env:GITHUB_OUTPUT
+
+      - name: Create MSIX Bundle
+        run: |
+          New-Item -ItemType Directory -Path bundle-output -Force | Out-Null
+
+          # Determine bundle filename from one of the packages
+          $msixFiles = Get-ChildItem -Path msix-packages -Filter "*.msix"
+          Write-Host "Bundling $($msixFiles.Count) packages:"
+          $msixFiles | ForEach-Object { Write-Host "  $_" }
+
+          # Extract version from filename (e.g. ibl-ai-os-1.1.9.0-x64.msix)
+          $sampleName = $msixFiles[0].Name
+          if ($sampleName -match '(\d+\.\d+\.\d+\.\d+)') {
+            $version = $Matches[1]
+          } else {
+            $version = "0.0.0.0"
+          }
+
+          $bundlePath = "bundle-output\ibl-ai-os-$version.msixbundle"
+
+          & "${{ steps.sdk.outputs.MAKEAPPX }}" bundle /d msix-packages /p $bundlePath /o
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "makeappx bundle failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+
+          Write-Host "Bundle created: $bundlePath" -ForegroundColor Green
+
+      - name: Upload MSIX Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibl-ai-os-msixbundle
+          path: bundle-output/*.msixbundle
           if-no-files-found: error

--- a/src-tauri/build-msix.ps1
+++ b/src-tauri/build-msix.ps1
@@ -3,30 +3,21 @@
 #
 # Prerequisites:
 #   - Windows 10 SDK (for makeappx.exe and signtool.exe)
-#   - Rust toolchain with x86_64-pc-windows-msvc target
+#   - Rust toolchain with appropriate target
 #   - Tauri CLI: cargo install tauri-cli
 #
 # Usage:
-#   .\build-msix.ps1                           # Build unsigned MSIX (Windows 11 quick test)
-#   .\build-msix.ps1 -CertThumbprint "ABC123"  # Build and sign with certificate
-#   .\build-msix.ps1 -SkipTauriBuild           # Skip Tauri build, just repackage
-#   .\build-msix.ps1 -RegisterOnly             # Skip packaging, register loose files for testing
-#
-# Quick test workflow (Windows 11, no cert needed):
-#   1. .\build-msix.ps1
-#   2. Add-AppxPackage -AllowUnsigned -Path .\msix-output\ibl-ai-os-1.1.9.0-x64.msix
-#
-# Even quicker (loose file registration, no .msix file needed):
-#   1. cargo tauri build --target x86_64-pc-windows-msvc
-#   2. .\build-msix.ps1 -RegisterOnly
-#
-# TODO: Before Store submission, update AppxManifest.xml with your Partner Center values:
-#   - Identity.Name = your Package Identity Name
-#   - Identity.Publisher = your Publisher ID (CN=xxx) - remove the OID for unsigned testing
+#   .\build-msix.ps1                                    # Build unsigned MSIX for x64
+#   .\build-msix.ps1 -Architecture arm64                # Build unsigned MSIX for arm64
+#   .\build-msix.ps1 -CertThumbprint "ABC123"           # Build and sign with certificate
+#   .\build-msix.ps1 -SkipTauriBuild                    # Skip Tauri build, just repackage
+#   .\build-msix.ps1 -SkipTauriBuild -Architecture arm64 # Repackage arm64 build
+#   .\build-msix.ps1 -RegisterOnly                      # Skip packaging, register loose files for testing
 
 param(
     [string]$CertThumbprint = "",
     [string]$TimestampUrl = "http://timestamp.digicert.com",
+    [ValidateSet("x64", "arm64")]
     [string]$Architecture = "x64",
     [switch]$SkipTauriBuild,
     [switch]$RegisterOnly
@@ -39,12 +30,26 @@ $ProjectRoot = Resolve-Path "$ScriptDir\.."
 $TauriDir = $ScriptDir
 $AppName = "ibl-ai-os"
 
+# Map Architecture to Rust target triple
+$RustTargetMap = @{
+    "x64"   = "x86_64-pc-windows-msvc"
+    "arm64" = "aarch64-pc-windows-msvc"
+}
+$RustTarget = $RustTargetMap[$Architecture]
+
+# Map Architecture to MSIX ProcessorArchitecture value
+$MsixArchMap = @{
+    "x64"   = "x64"
+    "arm64" = "arm64"
+}
+$MsixArch = $MsixArchMap[$Architecture]
+
 # --- Step 1: Build the Tauri app ---
 if (-not $SkipTauriBuild -and -not $RegisterOnly) {
-    Write-Host "`n[1/4] Building Tauri app..." -ForegroundColor Yellow
+    Write-Host "`n[1/4] Building Tauri app for $RustTarget..." -ForegroundColor Yellow
     Push-Location $ProjectRoot
     try {
-        cargo tauri build --target x86_64-pc-windows-msvc
+        cargo tauri build --target $RustTarget
     } finally {
         Pop-Location
     }
@@ -52,18 +57,20 @@ if (-not $SkipTauriBuild -and -not $RegisterOnly) {
     Write-Host "`n[1/4] Skipping Tauri build." -ForegroundColor DarkYellow
 }
 
-# Locate the built executable - Tauri outputs to src-tauri/target/
+# Locate the built executable - search architecture-specific paths first, then generic
 $BuildOutput = $null
 $ExePath = $null
 $SearchPaths = @(
-    (Join-Path $TauriDir "target\x86_64-pc-windows-msvc\release"),
+    (Join-Path $TauriDir "target\$RustTarget\release"),
     (Join-Path $TauriDir "target\release"),
-    (Join-Path $ProjectRoot "target\x86_64-pc-windows-msvc\release"),
+    (Join-Path $ProjectRoot "target\$RustTarget\release"),
     (Join-Path $ProjectRoot "target\release")
 )
 
+Write-Host "Searching for $AppName.exe (arch=$Architecture, target=$RustTarget)..." -ForegroundColor Gray
 foreach ($candidate in $SearchPaths) {
     $candidateExe = Join-Path $candidate "$AppName.exe"
+    Write-Host "  Checking: $candidateExe" -ForegroundColor Gray
     if (Test-Path $candidateExe) {
         $BuildOutput = $candidate
         $ExePath = $candidateExe
@@ -72,7 +79,7 @@ foreach ($candidate in $SearchPaths) {
 }
 
 if (-not $ExePath) {
-    Write-Error "Built executable not found. Searched:`n  $($SearchPaths -join "`n  ")`nRun 'cargo tauri build' first."
+    Write-Error "Built executable not found. Searched:`n  $($SearchPaths -join "`n  ")`nRun 'cargo tauri build --target $RustTarget' first."
     exit 1
 }
 
@@ -124,12 +131,25 @@ if ($RegisterOnly) {
 
 # --- Resolve Windows SDK tools ---
 $SdkRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
+if (-not (Test-Path $SdkRoot)) {
+    # ARM64 runners may have the SDK in Program Files instead
+    $SdkRoot = "C:\Program Files\Windows Kits\10\bin"
+}
 $SdkVersions = Get-ChildItem -Path $SdkRoot -Directory | Where-Object { $_.Name -match "^10\." } | Sort-Object Name -Descending
 if ($SdkVersions.Count -eq 0) {
     Write-Error "Windows 10 SDK not found. Install it from https://developer.microsoft.com/windows/downloads/windows-sdk/"
     exit 1
 }
-$SdkBin = Join-Path $SdkVersions[0].FullName $Architecture
+
+# SDK tools are available in x64 and arm64 subdirectories.
+# Try the matching architecture first, then fall back to x64 (which works via emulation on ARM).
+$SdkToolArch = $Architecture
+$SdkBin = Join-Path $SdkVersions[0].FullName $SdkToolArch
+if (-not (Test-Path $SdkBin)) {
+    Write-Host "SDK tools not found for $SdkToolArch, falling back to x64..." -ForegroundColor DarkYellow
+    $SdkToolArch = "x64"
+    $SdkBin = Join-Path $SdkVersions[0].FullName $SdkToolArch
+}
 $MakeAppx = Join-Path $SdkBin "makeappx.exe"
 $SignTool = Join-Path $SdkBin "signtool.exe"
 
@@ -138,7 +158,7 @@ if (-not (Test-Path $MakeAppx)) {
     exit 1
 }
 
-Write-Host "Using Windows SDK: $($SdkVersions[0].Name)" -ForegroundColor Cyan
+Write-Host "Using Windows SDK: $($SdkVersions[0].Name) ($SdkToolArch tools)" -ForegroundColor Cyan
 Write-Host "makeappx: $MakeAppx" -ForegroundColor Gray
 Write-Host "signtool: $SignTool" -ForegroundColor Gray
 
@@ -154,8 +174,14 @@ New-Item -ItemType Directory -Path $StagingDir | Out-Null
 # Copy executable
 Copy-Item $ExePath $StagingDir
 
-# Copy AppxManifest
-Copy-Item (Join-Path $TauriDir "AppxManifest.xml") $StagingDir
+# Copy AppxManifest and patch ProcessorArchitecture for the target
+$ManifestSrc = Join-Path $TauriDir "AppxManifest.xml"
+$ManifestDest = Join-Path $StagingDir "AppxManifest.xml"
+$manifestContent = Get-Content $ManifestSrc -Raw
+$manifestContent = $manifestContent -replace 'ProcessorArchitecture="[^"]*"', "ProcessorArchitecture=`"$MsixArch`""
+Set-Content -Path $ManifestDest -Value $manifestContent
+
+Write-Host "Set ProcessorArchitecture=$MsixArch in AppxManifest.xml" -ForegroundColor Gray
 
 # Copy icons
 $IconsDestDir = Join-Path $StagingDir "icons"
@@ -208,8 +234,8 @@ if (-not (Test-Path $OutputDir)) {
     New-Item -ItemType Directory -Path $OutputDir | Out-Null
 }
 
-# Read version from AppxManifest
-[xml]$manifest = Get-Content (Join-Path $StagingDir "AppxManifest.xml")
+# Read version from staged AppxManifest (which has the correct arch already)
+[xml]$manifest = Get-Content $ManifestDest
 $Version = $manifest.Package.Identity.Version
 $MsixPath = Join-Path $OutputDir "$AppName-$Version-$Architecture.msix"
 
@@ -247,6 +273,7 @@ Remove-Item -Recurse -Force $StagingDir
 # --- Summary ---
 Write-Host "`n--- Build Complete ---" -ForegroundColor Cyan
 Write-Host "MSIX Package: $MsixPath" -ForegroundColor White
+Write-Host "Architecture: $Architecture ($RustTarget)" -ForegroundColor White
 Write-Host ""
 Write-Host "Install options:" -ForegroundColor Yellow
 $installCmd = '  Unsigned (Win11):  Add-AppxPackage -AllowUnsigned -Path ' + $MsixPath


### PR DESCRIPTION
## Summary
- **Fixes arm64 MSIX build** — `build-msix.ps1` now uses the `-Architecture` param to resolve the correct Rust target directory (`aarch64-pc-windows-msvc`), dynamically patches `ProcessorArchitecture` in the manifest, and falls back gracefully for SDK tools on ARM runners
- **Passes `-Architecture` from workflow to script** — the root cause of the arm64 failure (script defaulted to x64 paths)
- **Adds `bundle-msix` job** — after both arch builds complete, combines x64 + arm64 into a single `.msixbundle` for Microsoft Store submission

## What was broken
The arm64 CI job failed because `build-msix.ps1` searched only `x86_64-pc-windows-msvc` paths and the workflow never passed the architecture:
```
Built executable not found. Searched:
  src-tauri\target\x86_64-pc-windows-msvc\release
  src-tauri\target\release
  ...
```

## Changes
| File | What |
|---|---|
| `build-msix.ps1` | Architecture-aware target dirs, manifest patching, SDK fallback |
| `build-windows-msix.yml` | Pass `-Architecture`, remove hardcoded branch ref, add bundle job |

## Test plan
- [ ] Trigger workflow manually — verify x64 build still passes
- [ ] Verify arm64 build now passes (searches `aarch64-pc-windows-msvc`)
- [ ] Verify `bundle-msix` job produces `.msixbundle` artifact
- [ ] Download `.msixbundle` and verify it can be uploaded to Partner Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)