### PR TITLE
Fix msixbundle creation by bumping MinVersion to 10.0.18362.0

### DIFF
--- a/src-tauri/AppxManifest.xml
+++ b/src-tauri/AppxManifest.xml
@@ -30,8 +30,9 @@
   </Properties>
 
   <Dependencies>
-    <!-- Windows 10 1809 (build 17763) minimum for WebView2 compatibility -->
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22631.0" />
+    <!-- Windows 10 1903 (build 18362) minimum — required for .msix bundle support and full WebView2 compatibility.
+         1809 (17763) reached end of support Nov 2020. -->
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.22631.0" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
## Summary
- Bumps `TargetDeviceFamily MinVersion` from `10.0.17763.0` (1809) to `10.0.18362.0` (1903) in `AppxManifest.xml`

## Problem
The `bundle-msix` job added in #31 fails with:
```
MakeAppx : error: 0x80080215 - Non appx extensions are not allowed for payload packages targeting older platforms.
```
`makeappx.exe bundle` rejects `.msix` payload packages when they target `MinVersion < 10.0.18362.0`. Packages targeting older platforms must use the legacy `.appx` extension, which Tauri doesn't produce.

## Why this is safe
- Windows 10 1809 (build 17763) reached **end of support in November 2020** — over 5 years ago
- The app requires WebView2, which has full feature support on 1903+
- No measurable user base remains on 1809
- The new minimum (1903 / build 18362) is itself end-of-support since December 2020, but it unblocks the `.msixbundle` format required for multi-arch Store submission

## Test plan
- [ ] Merge and re-trigger **Build MSIX (x64 + arm64)** workflow
- [ ] Verify all 3 jobs pass (x64, arm64, bundle)
- [ ] Verify `.msixbundle` artifact is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)