### PR TITLE
Fix msixbundle creation: rename .msix to .appx before bundling

### DIFF
--- a/.github/workflows/build-windows-msix.yml
+++ b/.github/workflows/build-windows-msix.yml
@@ -137,17 +137,28 @@ jobs:
           Write-Host "Found: $MakeAppx"
           echo "MAKEAPPX=$MakeAppx" >> $env:GITHUB_OUTPUT
 
+      - name: Rename .msix to .appx for bundle compatibility
+        run: |
+          # makeappx.exe bundle rejects .msix extensions for packages targeting older
+          # MinVersion platforms (error 0x80080215). The .msix and .appx formats are
+          # binary-identical — only the extension differs. Renaming to .appx before
+          # bundling is the standard workaround.
+          Get-ChildItem -Path msix-packages -Filter "*.msix" | ForEach-Object {
+            $newName = $_.FullName -replace '\.msix$', '.appx'
+            Rename-Item $_.FullName $newName
+            Write-Host "Renamed: $($_.Name) -> $(Split-Path $newName -Leaf)"
+          }
+
       - name: Create MSIX Bundle
         run: |
           New-Item -ItemType Directory -Path bundle-output -Force | Out-Null
 
-          # Determine bundle filename from one of the packages
-          $msixFiles = Get-ChildItem -Path msix-packages -Filter "*.msix"
-          Write-Host "Bundling $($msixFiles.Count) packages:"
-          $msixFiles | ForEach-Object { Write-Host "  $_" }
+          $appxFiles = Get-ChildItem -Path msix-packages -Filter "*.appx"
+          Write-Host "Bundling $($appxFiles.Count) packages:"
+          $appxFiles | ForEach-Object { Write-Host "  $_" }
 
-          # Extract version from filename (e.g. ibl-ai-os-1.1.9.0-x64.msix)
-          $sampleName = $msixFiles[0].Name
+          # Extract version from filename (e.g. ibl-ai-os-0.35.14.0-x64.appx)
+          $sampleName = $appxFiles[0].Name
           if ($sampleName -match '(\d+\.\d+\.\d+\.\d+)') {
             $version = $Matches[1]
           } else {


### PR DESCRIPTION
## Summary
- Renames `.msix` → `.appx` before calling `makeappx.exe bundle`, fixing the `0x80080215` error permanently

## Problem
`makeappx.exe bundle` fails with:
```
MakeAppx : error: 0x80080215 - Non appx extensions are not allowed for payload packages targeting older platforms.
```
This happens regardless of `MinVersion` — the tool rejects `.msix` extensions in bundle payloads for any platform it considers "older." Bumping MinVersion to `10.0.18362.0` in #33 did not resolve it.

## Solution
The `.msix` and `.appx` formats are **binary-identical** — the only difference is the file extension. This is [confirmed by Microsoft](https://learn.microsoft.com/en-us/archive/msdn-technet-forums/1187c277-1aaf-43af-a5c8-d62d528885a2):

> "Since the file format is unchanged - you can simply rename the file back to appx/appxbundle if the new file name is not supported."

The fix adds a step that renames `.msix` → `.appx` before bundling. The output `.msixbundle` is unaffected — it bundles the packages correctly regardless of payload extension.

## Why this is permanent
Unlike MinVersion bumps, this doesn't depend on guessing the right version threshold. It works for any MinVersion and any future SDK version of `makeappx.exe`.

## Test plan
- [ ] Merge and re-trigger **Build MSIX (x64 + arm64)** workflow with version `0.35.14`
- [ ] Verify all 3 jobs pass (x64, arm64, bundle)
- [ ] Verify `.msixbundle` artifact is produced
- [ ] Download and verify the bundle can be uploaded to Partner Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)