### PR TITLE
Add iOS build workflow with App Store Connect signing

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,113 @@
+name: Build iOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version override (e.g. 1.2.0) - leave empty to use tauri.conf.json version"
+        required: false
+        type: string
+
+concurrency:
+  group: ios-build
+  cancel-in-progress: false
+
+jobs:
+  build-ios:
+    name: Build iOS (.ipa)
+    runs-on: macos-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: rust-ios-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            rust-ios-
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Tauri CLI
+        run: |
+          cargo install cargo-binstall --locked
+          cargo binstall tauri-cli --no-confirm || cargo install tauri-cli --locked
+
+      - name: Override version
+        if: inputs.version != ''
+        working-directory: src-tauri
+        run: |
+          sed -i '' 's/"version": "[^"]*"/"version": "${{ inputs.version }}"/' tauri.conf.json
+          echo "Version set to ${{ inputs.version }}"
+          grep '"version"' tauri.conf.json
+
+      - name: Decode App Store Connect API key
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          KEY_DIR="$RUNNER_TEMP/private_keys"
+          mkdir -p "$KEY_DIR"
+          echo -n "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_DIR/AuthKey_${APPLE_API_KEY_ID}.p8"
+          echo "APPLE_API_KEY_PATH=$KEY_DIR/AuthKey_${APPLE_API_KEY_ID}.p8" >> "$GITHUB_ENV"
+
+      - name: Initialize iOS project
+        run: cargo tauri ios init
+
+      - name: Build iOS app
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+        run: cargo tauri ios build --export-method app-store-connect
+
+      - name: Locate IPA
+        id: ipa
+        run: |
+          echo "Searching for IPA files..."
+          find src-tauri/gen/apple -name "*.ipa" -type f 2>/dev/null | while read f; do
+            echo "Found: $f ($(du -h "$f" | cut -f1))"
+          done
+          IPA_PATH=$(find src-tauri/gen/apple -name "*.ipa" -type f | head -1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "No IPA found. Listing build output for debugging:"
+            find src-tauri/gen/apple/build -type f 2>/dev/null | head -30
+            echo "::error::No IPA file found in build output"
+            exit 1
+          fi
+          echo "ipa_path=$IPA_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mentorai-ios-ipa
+          path: ${{ steps.ipa.outputs.ipa_path }}
+          if-no-files-found: error
+
+      - name: Clean up API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-ios.yml` — builds a signed `.ipa` for App Store / TestFlight submission

## How it works
Uses Tauri v2's built-in automatic signing via App Store Connect API keys. No manual certificate or provisioning profile management needed — Xcode handles it automatically.

```
cargo tauri ios init → cargo tauri ios build --export-method app-store-connect → signed .ipa
```

## Secrets required (one-time setup)
Create these in **Settings → Secrets → Actions**:

| Secret | Source |
|---|---|
| `APPLE_API_KEY_ID` | App Store Connect → Users and Access → Integrations → Key ID |
| `APPLE_API_ISSUER` | Same page → Issuer ID |
| `APPLE_API_KEY_BASE64` | `base64 -i AuthKey_XXXXXX.p8 \| pbcopy` (the downloaded .p8 file) |

Generate the API key at: App Store Connect → Users and Access → Integrations → App Store Connect API → "+" button.

## Workflow details
- **Trigger**: Manual (`workflow_dispatch`) with optional version override
- **Runner**: `macos-latest` (Apple Silicon)
- **Signing**: Automatic via App Store Connect API (recommended by Tauri docs)
- **Export method**: `app-store-connect` (produces .ipa ready for TestFlight)
- **Output**: `mentorai-ios-ipa` artifact
- **Timeout**: 60 minutes (Rust compile can be slow first time)

## Usage
After setting up secrets: **Actions → Build iOS → Run workflow**

Download the `.ipa` from the workflow artifacts, then upload to App Store Connect / TestFlight manually. (Auto-upload to TestFlight can be added later as Phase 2.)

## Test plan
- [ ] Configure the 3 Apple secrets in repo settings
- [ ] Trigger workflow manually
- [ ] Verify build produces a signed `.ipa` artifact
- [ ] Download `.ipa` and verify it can be uploaded to App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)