### PR TITLE
fix: use HTTPS instead of SSH for git deps in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY package.json .
 COPY pnpm-lock.yaml .
 
+# Force git to use HTTPS instead of SSH (electron/node-gyp uses git+ssh references
+# which fail in Docker where no SSH keys are available)
+RUN git config --global url."https://github.com/".insteadOf "git@github.com:" \
+    && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- `pnpm install` in the Docker build fails because `@electron/node-gyp` uses a `git@github.com:` (SSH) reference, and there are no SSH keys in the Docker build context
- Adds `git config --global url.insteadOf` to rewrite SSH URLs to HTTPS — standard Docker pattern for public GitHub dependencies
- Fixes https://github.com/iblai/mentorai/actions/runs/23350689836/job/67928260673

## Test plan
- [ ] Docker build completes successfully (`pnpm install` no longer fails on `electron/node-gyp`)
- [ ] Retrigger the failed workflow to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)