### PR TITLE
fix: disable preview for custom app

### DIFF
--- a/components/chat/__tests__/index.test.tsx
+++ b/components/chat/__tests__/index.test.tsx
@@ -1,17 +1,23 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
-import { Chat } from '../index';
-import { chatInputSliceReducer } from '@/features/chat-input/api-slice';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { Chat } from "../index";
+import { chatInputSliceReducer } from "@/features/chat-input/api-slice";
 
 // Mock all the complex dependencies
-vi.mock('next/dynamic', () => ({
+vi.mock("next/dynamic", () => ({
   default: (loader: () => Promise<any>) => {
     // Inspect the loader function to determine which component is being loaded
     const loaderStr = loader.toString();
 
-    if (loaderStr.includes('canvas-view') || loaderStr.includes('CanvasView')) {
+    if (loaderStr.includes("canvas-view") || loaderStr.includes("CanvasView")) {
       // CanvasView component
       const Component = (props: {
         onClose?: () => void;
@@ -24,16 +30,19 @@ vi.mock('next/dynamic', () => ({
             </button>
             <button
               data-testid="canvas-send-btn"
-              onClick={() => props.sendMessage?.('test message', {})}
+              onClick={() => props.sendMessage?.("test message", {})}
             >
               Send from Canvas
             </button>
           </div>
         );
       };
-      Component.displayName = 'CanvasView';
+      Component.displayName = "CanvasView";
       return Component;
-    } else if (loaderStr.includes('disclaimer-modal') || loaderStr.includes('DisclaimerModal')) {
+    } else if (
+      loaderStr.includes("disclaimer-modal") ||
+      loaderStr.includes("DisclaimerModal")
+    ) {
       // DisclaimerModal component
       const Component = (props: {
         isOpen?: boolean;
@@ -45,13 +54,17 @@ vi.mock('next/dynamic', () => ({
         return (
           <div data-testid="disclaimer-modal">
             <span data-testid="disclaimer-content">{props.content}</span>
-            <button data-testid="agree-btn" onClick={props.onAgree} disabled={props.isAgreeing}>
+            <button
+              data-testid="agree-btn"
+              onClick={props.onAgree}
+              disabled={props.isAgreeing}
+            >
               Agree
             </button>
           </div>
         );
       };
-      Component.displayName = 'DisclaimerModal';
+      Component.displayName = "DisclaimerModal";
       return Component;
     } else {
       // Default fallback (CanvasView for backward compatibility)
@@ -66,41 +79,50 @@ vi.mock('next/dynamic', () => ({
             </button>
             <button
               data-testid="canvas-send-btn"
-              onClick={() => props.sendMessage?.('test message', {})}
+              onClick={() => props.sendMessage?.("test message", {})}
             >
               Send from Canvas
             </button>
           </div>
         );
       };
-      Component.displayName = 'DynamicComponent';
+      Component.displayName = "DynamicComponent";
       return Component;
     }
   },
 }));
 
-vi.mock('next/navigation', () => ({
+vi.mock("next/navigation", () => ({
   useParams: vi.fn(() => ({
-    tenantKey: 'test-tenant',
-    mentorId: 'mentor-123',
+    tenantKey: "test-tenant",
+    mentorId: "mentor-123",
   })),
   useSearchParams: vi.fn(() => new URLSearchParams()),
 }));
 
-vi.mock('@iblai/iblai-js/web-utils', async () => {
-  const actual = await vi.importActual('@iblai/iblai-js/web-utils');
+vi.mock("@iblai/iblai-js/web-utils", async () => {
+  const actual = await vi.importActual("@iblai/iblai-js/web-utils");
   return {
     ...actual,
-    ANONYMOUS_USERNAME: 'anonymous',
+    ANONYMOUS_USERNAME: "anonymous",
     chatActions: {
-      updateSessionIds: vi.fn((id) => ({ type: 'chat/updateSessionIds', payload: id })),
-      setShowingSharedChat: vi.fn((val) => ({ type: 'chat/setShowingSharedChat', payload: val })),
-      addUserMessage: vi.fn((payload) => ({ type: 'chat/addUserMessage', payload })),
+      updateSessionIds: vi.fn((id) => ({
+        type: "chat/updateSessionIds",
+        payload: id,
+      })),
+      setShowingSharedChat: vi.fn((val) => ({
+        type: "chat/setShowingSharedChat",
+        payload: val,
+      })),
+      addUserMessage: vi.fn((payload) => ({
+        type: "chat/addUserMessage",
+        payload,
+      })),
     },
     selectToken: () => null,
     selectTokenEnabled: () => false,
     selectShowingSharedChat: () => false,
-    selectActiveTab: () => 'default',
+    selectActiveTab: () => "default",
     useMentorTools: vi.fn(() => ({
       enableWebBrowsing: true,
       updateSessionTools: vi.fn().mockResolvedValue(undefined),
@@ -116,29 +138,29 @@ vi.mock('@iblai/iblai-js/web-utils', async () => {
       artifactsEnabled: false,
     })),
     useTenantContext: vi.fn(() => ({
-      metadata: { support_email: 'support@test.com' },
+      metadata: { support_email: "support@test.com" },
     })),
     useAuthContext: vi.fn(() => ({
       userIsAccessingPublicRoute: false,
     })),
     useTenantMetadata: vi.fn(() => ({
-      platformName: 'Test Platform',
+      platformName: "Test Platform",
       metadata: { chat_area_size: 850 }, // Use 850 (within bounds 600-1200, different from DEFAULT 800) to cover lines 220-223
     })),
     useAdvancedChat: vi.fn(() => ({
       changeTab: vi.fn(),
-      activeTab: 'chat',
+      activeTab: "chat",
       currentStreamingMessage: null,
       enabledGuidedPrompts: [],
       isStreaming: false,
-      mentorName: 'Test Mentor',
+      mentorName: "Test Mentor",
       messages: [],
-      profileImage: '/avatar.png',
+      profileImage: "/avatar.png",
       sendMessage: vi.fn(),
       setMessage: vi.fn(),
       stopGenerating: vi.fn(),
-      uniqueMentorId: 'unique-mentor-123',
-      sessionId: 'session-123',
+      uniqueMentorId: "unique-mentor-123",
+      sessionId: "session-123",
       startNewChat: vi.fn(),
       enableSafetyDisclaimer: false,
       isPending: false,
@@ -151,83 +173,87 @@ vi.mock('@iblai/iblai-js/web-utils', async () => {
       DEFAULT: 800,
     },
     TOOLS: {
-      CANVAS: 'canvas',
-      DEEP_RESEARCH: 'deep_research',
+      CANVAS: "canvas",
+      DEEP_RESEARCH: "deep_research",
     },
-    clearFiles: vi.fn(() => ({ type: 'files/clearFiles' })),
-    removeFile: vi.fn((id: string) => ({ type: 'files/removeFile', payload: id })),
+    clearFiles: vi.fn(() => ({ type: "files/clearFiles" })),
+    removeFile: vi.fn((id: string) => ({
+      type: "files/removeFile",
+      payload: id,
+    })),
   };
 });
 
-vi.mock('@/lib/utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/lib/utils')>();
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils")>();
   return {
     ...actual,
-    cn: (...args: (string | boolean | undefined)[]) => args.filter(Boolean).join(' '),
+    cn: (...args: (string | boolean | undefined)[]) =>
+      args.filter(Boolean).join(" "),
     isLoggedIn: vi.fn(() => true),
-    getAuthSpaJoinUrl: vi.fn(() => 'http://auth.test/join'),
+    getAuthSpaJoinUrl: vi.fn(() => "http://auth.test/join"),
     isInIframe: vi.fn(() => false),
     redirectToAuthSpa: vi.fn(),
     sendMessageToParentWebsite: vi.fn(),
   };
 });
 
-vi.mock('@/lib/config', () => ({
+vi.mock("@/lib/config", () => ({
   config: {
-    baseWsUrl: () => 'wss://test.com',
-    supportEmail: () => 'support@test.com',
-    iblTemplateMentor: () => 'default-agent',
+    baseWsUrl: () => "wss://test.com",
+    supportEmail: () => "support@test.com",
+    iblTemplateMentor: () => "default-agent",
   },
 }));
 
-vi.mock('@/hooks/use-user', () => ({
-  useUsername: vi.fn(() => 'test-user'),
+vi.mock("@/hooks/use-user", () => ({
+  useUsername: vi.fn(() => "test-user"),
   useUserTenants: vi.fn(() => ({
-    userTenants: [{ key: 'test-tenant' }],
+    userTenants: [{ key: "test-tenant" }],
   })),
   useVisitingTenant: vi.fn(() => ({ visitingTenant: null })),
 }));
 
-vi.mock('@/hooks/use-tokens', () => ({
-  useAxdToken: vi.fn(() => 'test-token'),
+vi.mock("@/hooks/use-tokens", () => ({
+  useAxdToken: vi.fn(() => "test-token"),
 }));
 
-vi.mock('@/hooks/user-navigate', () => ({
+vi.mock("@/hooks/user-navigate", () => ({
   useNavigate: vi.fn(() => ({
-    getMentorId: vi.fn(() => 'mentor-123'),
+    getMentorId: vi.fn(() => "mentor-123"),
   })),
 }));
 
-vi.mock('@/hooks/use-embed-mode', () => ({
+vi.mock("@/hooks/use-embed-mode", () => ({
   useEmbedMode: vi.fn(() => false),
 }));
 
-vi.mock('@/hooks/subscription/use-402-error-check', () => ({
+vi.mock("@/hooks/subscription/use-402-error-check", () => ({
   use402ErrorCheck: vi.fn(() => ({
     handle402Error: vi.fn(),
   })),
 }));
 
-vi.mock('@/hooks/use-mentors/use-mentor-settings', () => ({
+vi.mock("@/hooks/use-mentors/use-mentor-settings", () => ({
   useMentorSettings: vi.fn(() => ({
     data: {
       allowAnonymous: false,
-      mentorVisibility: 'PRIVATE',
+      mentorVisibility: "PRIVATE",
     },
   })),
 }));
 
-vi.mock('@/hooks/use-local-storage', () => ({
+vi.mock("@/hooks/use-local-storage", () => ({
   useLocalStorage: vi.fn(() => [{}, vi.fn()]),
 }));
 
-vi.mock('@/components/service-worker-provider', () => ({
+vi.mock("@/components/service-worker-provider", () => ({
   useServiceWorker: vi.fn(() => ({
     status: { isOnline: true },
   })),
 }));
 
-vi.mock('@/hooks/user-user-actions', () => ({
+vi.mock("@/hooks/user-user-actions", () => ({
   useShowFreeTrialDialog: vi.fn(() => ({
     FreeTrialDialog: null,
     closeModal: vi.fn(),
@@ -236,29 +262,31 @@ vi.mock('@/hooks/user-user-actions', () => ({
   })),
 }));
 
-vi.mock('@/hooks/use-user-agreement', () => ({
+vi.mock("@/hooks/use-user-agreement", () => ({
   useUserAgreement: vi.fn(() => ({
     showDisclaimerModal: false,
     isAgreeing: false,
     userAgreement: null,
     hasUserAgreement: false,
     handleDisclaimerAgree: vi.fn(),
-    checkAgreementAndExecute: vi.fn((content: string, fn: (c: string) => void) => fn(content)),
+    checkAgreementAndExecute: vi.fn(
+      (content: string, fn: (c: string) => void) => fn(content),
+    ),
     executePendingSubmit: vi.fn(),
   })),
 }));
 
-vi.mock('use-debounce', () => ({
+vi.mock("use-debounce", () => ({
   useDebouncedCallback: vi.fn((fn) => fn),
 }));
 
-vi.mock('sonner', () => ({
+vi.mock("sonner", () => ({
   toast: {
     error: vi.fn(),
   },
 }));
 
-vi.mock('@/lib/eventBus', () => ({
+vi.mock("@/lib/eventBus", () => ({
   default: {
     on: vi.fn(),
     off: vi.fn(),
@@ -270,22 +298,24 @@ vi.mock('@/lib/eventBus', () => ({
     emit: vi.fn(),
   },
   RemoteEvents: {
-    newChat: 'newChat',
-    stopChatGenerating: 'stopChatGenerating',
+    newChat: "newChat",
+    stopChatGenerating: "stopChatGenerating",
   },
 }));
 
 const mockSelectEnableChatActionsPopup = vi.fn(() => false);
-vi.mock('@/features/chat/chatSlice', () => ({
-  addMessage: vi.fn((payload) => ({ type: 'chat/addMessage', payload })),
+vi.mock("@/features/chat/chatSlice", () => ({
+  addMessage: vi.fn((payload) => ({ type: "chat/addMessage", payload })),
   selectEnableChatActionsPopup: () => mockSelectEnableChatActionsPopup(),
 }));
 
-vi.mock('@/components/guided-suggested-prompts', () => ({
-  GuidedSuggestedPrompts: () => <div data-testid="guided-prompts">Guided Prompts</div>,
+vi.mock("@/components/guided-suggested-prompts", () => ({
+  GuidedSuggestedPrompts: () => (
+    <div data-testid="guided-prompts">Guided Prompts</div>
+  ),
 }));
 
-vi.mock('@/hooks/use-file-drag-drop', () => ({
+vi.mock("@/hooks/use-file-drag-drop", () => ({
   useFileDragDrop: vi.fn(() => ({
     isDraggingFile: false,
     handleDragOver: vi.fn(),
@@ -294,7 +324,7 @@ vi.mock('@/hooks/use-file-drag-drop', () => ({
   })),
 }));
 
-vi.mock('@/components/chat-input-form', () => ({
+vi.mock("@/components/chat-input-form", () => ({
   ChatInputForm: ({
     onSubmit,
     sessionId,
@@ -313,11 +343,16 @@ vi.mock('@/components/chat-input-form', () => ({
     <div data-testid="chat-input-form">
       <span data-testid="session-id">{sessionId}</span>
       <span data-testid="is-streaming">{String(isStreaming)}</span>
-      <span data-testid="screen-sharing-modal-open">{String(isScreenSharingModalOpen)}</span>
-      <button data-testid="submit-btn" onClick={() => onSubmit('Test message')}>
+      <span data-testid="screen-sharing-modal-open">
+        {String(isScreenSharingModalOpen)}
+      </span>
+      <button data-testid="submit-btn" onClick={() => onSubmit("Test message")}>
         Submit
       </button>
-      <button data-testid="input-screen-sharing-btn" onClick={onScreenSharingClick}>
+      <button
+        data-testid="input-screen-sharing-btn"
+        onClick={onScreenSharingClick}
+      >
         Screen Share
       </button>
       <button data-testid="input-phone-call-btn" onClick={onPhoneCallClick}>
@@ -327,7 +362,7 @@ vi.mock('@/components/chat-input-form', () => ({
   ),
 }));
 
-vi.mock('@/components/chat/chat-messages', () => ({
+vi.mock("@/components/chat/chat-messages", () => ({
   ChatMessages: ({
     messages,
     handleSubmit,
@@ -343,16 +378,16 @@ vi.mock('@/components/chat/chat-messages', () => ({
   }) => (
     <div data-testid="chat-messages">
       <span data-testid="message-count">{messages.length}</span>
-      <button data-testid="retry-btn" onClick={() => handleSubmit('Retry')}>
+      <button data-testid="retry-btn" onClick={() => handleSubmit("Retry")}>
         Retry
       </button>
       <button
         data-testid="open-canvas-btn"
         onClick={() =>
           onOpenCanvas?.({
-            title: 'Test Canvas',
-            content: 'Canvas content',
-            toolType: 'canvas',
+            title: "Test Canvas",
+            content: "Canvas content",
+            toolType: "canvas",
             artifactId: 123,
           })
         }
@@ -363,9 +398,9 @@ vi.mock('@/components/chat/chat-messages', () => ({
         data-testid="open-code-canvas-btn"
         onClick={() =>
           onOpenCanvas?.({
-            title: 'Code Canvas',
+            title: "Code Canvas",
             content: 'console.log("hello")',
-            toolType: 'code',
+            toolType: "code",
             artifactId: 456,
           })
         }
@@ -376,11 +411,11 @@ vi.mock('@/components/chat/chat-messages', () => ({
         data-testid="open-file-ext-canvas-btn"
         onClick={() =>
           onOpenCanvas?.({
-            title: 'JavaScript File',
-            content: 'const x = 1;',
-            toolType: 'document',
+            title: "JavaScript File",
+            content: "const x = 1;",
+            toolType: "document",
             artifactId: 789,
-            fileExtension: 'js',
+            fileExtension: "js",
           })
         }
       >
@@ -390,38 +425,47 @@ vi.mock('@/components/chat/chat-messages', () => ({
         data-testid="reply-btn"
         onClick={() =>
           onReply?.({
-            id: '1',
-            role: 'assistant',
-            content: 'Test message',
+            id: "1",
+            role: "assistant",
+            content: "Test message",
           })
         }
       >
         Reply
       </button>
-      <button data-testid="highlight-btn" onClick={() => handleHighlightMessage?.(0)}>
+      <button
+        data-testid="highlight-btn"
+        onClick={() => handleHighlightMessage?.(0)}
+      >
         Highlight
       </button>
       <button
         data-testid="open-canvas-no-artifact-btn"
         onClick={() =>
           onOpenCanvas?.({
-            title: 'No Artifact Canvas',
+            title: "No Artifact Canvas",
             content: null,
-            toolType: 'canvas',
+            toolType: "canvas",
           })
         }
       >
         Open Canvas No Artifact
       </button>
-      <button data-testid="submit-empty-btn" onClick={() => handleSubmit('')}>
+      <button data-testid="submit-empty-btn" onClick={() => handleSubmit("")}>
         Submit Empty
       </button>
     </div>
   ),
 }));
 
-vi.mock('@/components/live-kit-voice-chat', () => ({
-  LiveKitChat: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+vi.mock("@/components/live-kit-voice-chat", () => ({
+  LiveKitChat: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
     isOpen ? (
       <div data-testid="live-kit-chat">
         <button onClick={onClose}>Close</button>
@@ -429,8 +473,14 @@ vi.mock('@/components/live-kit-voice-chat', () => ({
     ) : null,
 }));
 
-vi.mock('@/components/live-kit-screen-sharing', () => ({
-  LiveKitScreenSharing: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+vi.mock("@/components/live-kit-screen-sharing", () => ({
+  LiveKitScreenSharing: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
     isOpen ? (
       <div data-testid="live-kit-screen-sharing">
         <button onClick={onClose}>Close</button>
@@ -438,11 +488,11 @@ vi.mock('@/components/live-kit-screen-sharing', () => ({
     ) : null,
 }));
 
-vi.mock('@/components/guided-suggested-prompts', () => ({
+vi.mock("@/components/guided-suggested-prompts", () => ({
   GuidedSuggestedPrompts: () => <div data-testid="guided-prompts">Prompts</div>,
 }));
 
-vi.mock('@/components/welcome-chat-new', () => ({
+vi.mock("@/components/welcome-chat-new", () => ({
   WelcomeChatNew: ({
     onSubmit,
     mentorName,
@@ -456,7 +506,7 @@ vi.mock('@/components/welcome-chat-new', () => ({
   }) => (
     <div data-testid="welcome-chat">
       <span data-testid="mentor-name">{mentorName}</span>
-      <button data-testid="welcome-submit" onClick={() => onSubmit('Hello!')}>
+      <button data-testid="welcome-submit" onClick={() => onSubmit("Hello!")}>
         Submit
       </button>
       <button data-testid="screen-sharing-btn" onClick={onScreenSharingClick}>
@@ -469,26 +519,36 @@ vi.mock('@/components/welcome-chat-new', () => ({
   ),
 }));
 
-vi.mock('@/components/error-boundary', () => ({
+vi.mock("@/components/error-boundary", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="error-boundary">{children}</div>
   ),
 }));
 
-vi.mock('@/components/advanced-chat/advanced-chat-header', () => ({
-  AdvancedChatHeader: () => <div data-testid="advanced-chat-header">Header</div>,
+vi.mock("@/components/advanced-chat/advanced-chat-header", () => ({
+  AdvancedChatHeader: () => (
+    <div data-testid="advanced-chat-header">Header</div>
+  ),
 }));
 
-vi.mock('@/components/advanced-chat/advanced-chat-builder', () => ({
-  AdvancedStaticChatBuilder: () => <div data-testid="advanced-chat-builder">Builder</div>,
+vi.mock("@/components/advanced-chat/advanced-chat-builder", () => ({
+  AdvancedStaticChatBuilder: () => (
+    <div data-testid="advanced-chat-builder">Builder</div>
+  ),
 }));
 
-vi.mock('@/components/chat/loading-message', () => ({
+vi.mock("@/components/chat/loading-message", () => ({
   LoadingMessage: () => <div data-testid="loading-message">Loading...</div>,
 }));
 
-vi.mock('@/components/chat/canvas-view', () => ({
-  CanvasView: ({ onClose, canvasTitle }: { onClose: () => void; canvasTitle: string }) => (
+vi.mock("@/components/chat/canvas-view", () => ({
+  CanvasView: ({
+    onClose,
+    canvasTitle,
+  }: {
+    onClose: () => void;
+    canvasTitle: string;
+  }) => (
     <div data-testid="canvas-view">
       <span data-testid="canvas-title">{canvasTitle}</span>
       <button data-testid="close-canvas-btn" onClick={onClose}>
@@ -498,7 +558,7 @@ vi.mock('@/components/chat/canvas-view', () => ({
   ),
 }));
 
-vi.mock('@/components/modals/disclaimer-modal', () => ({
+vi.mock("@/components/modals/disclaimer-modal", () => ({
   DisclaimerModal: ({
     isOpen,
     onAgree,
@@ -520,7 +580,7 @@ vi.mock('@/components/modals/disclaimer-modal', () => ({
     ) : null,
 }));
 
-vi.mock('@/components/ui/dialog', () => ({
+vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({
     open,
     onOpenChange,
@@ -552,7 +612,7 @@ vi.mock('@/components/ui/dialog', () => ({
   ),
 }));
 
-vi.mock('@/components/ui/button', () => ({
+vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
     onClick,
@@ -567,7 +627,7 @@ vi.mock('@/components/ui/button', () => ({
     disabled?: boolean;
   }) => (
     <button
-      data-testid={`button-${variant || 'default'}`}
+      data-testid={`button-${variant || "default"}`}
       onClick={onClick}
       className={className}
       disabled={disabled}
@@ -577,20 +637,26 @@ vi.mock('@/components/ui/button', () => ({
   ),
 }));
 
-vi.mock('@/components/ui/tooltip', () => ({
+vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
-    <>{children}</>
-  ),
-  TooltipContent: ({ children }: { children: React.ReactNode; className?: string }) => (
-    <div data-testid="tooltip-content">{children}</div>
-  ),
+  TooltipTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+  TooltipContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div data-testid="tooltip-content">{children}</div>,
 }));
 
 const defaultChatSliceState = {
   showingSharedChat: false,
   enableChatActionsPopup: false,
-  activeTab: 'default',
+  activeTab: "default",
   chats: {
     default: [],
   },
@@ -615,7 +681,7 @@ const createMockStore = (preloadedState: Record<string, unknown> = {}) =>
       },
     },
     preloadedState: {
-      chatInput: { textareaInput: '' },
+      chatInput: { textareaInput: "" },
       files: { attachedFiles: [] },
       chatSliceShared: defaultChatSliceState,
       chat: defaultChatState,
@@ -623,23 +689,23 @@ const createMockStore = (preloadedState: Record<string, unknown> = {}) =>
     },
   });
 
-describe('Chat', () => {
+describe("Chat", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset the chat actions popup mock
     mockSelectEnableChatActionsPopup.mockReturnValue(false);
     // Reset window scroll
-    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
-    Object.defineProperty(window, 'pageYOffset', { value: 0, writable: true });
+    Object.defineProperty(window, "scrollY", { value: 0, writable: true });
+    Object.defineProperty(window, "pageYOffset", { value: 0, writable: true });
     // Mock scrollTo to prevent errors
     Element.prototype.scrollTo = vi.fn();
     window.scrollTo = vi.fn();
     // Mock window.opener for modal close behavior
-    Object.defineProperty(window, 'opener', { value: null, writable: true });
+    Object.defineProperty(window, "opener", { value: null, writable: true });
     // Mock window.close
     window.close = vi.fn();
     // Mock requestAnimationFrame
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
       cb(0);
       return 0;
     });
@@ -649,58 +715,65 @@ describe('Chat', () => {
     vi.restoreAllMocks();
   });
 
-  const renderWithRedux = (component: React.ReactElement, preloadedState = {}) => {
-    return render(<Provider store={createMockStore(preloadedState)}>{component}</Provider>);
+  const renderWithRedux = (
+    component: React.ReactElement,
+    preloadedState = {},
+  ) => {
+    return render(
+      <Provider store={createMockStore(preloadedState)}>{component}</Provider>,
+    );
   };
 
-  describe('rendering', () => {
-    it('should render without crashing', () => {
+  describe("rendering", () => {
+    it("should render without crashing", () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
       // Component should render without error
       expect(document.body).toBeDefined();
     });
 
-    it('should render welcome chat when no messages', () => {
+    it("should render welcome chat when no messages", () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should render mentor name from useAdvancedChat', () => {
+    it("should render mentor name from useAdvancedChat", () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      expect(screen.getByTestId('mentor-name')).toHaveTextContent('Test Mentor');
+      expect(screen.getByTestId("mentor-name")).toHaveTextContent(
+        "Test Mentor",
+      );
     });
 
-    it('should render chat input form when messages exist', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render chat input form when messages exist", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -708,64 +781,66 @@ describe('Chat', () => {
       });
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('advanced mode', () => {
-    it('should render advanced chat header in advanced mode', () => {
+  describe("advanced mode", () => {
+    it("should render advanced chat header in advanced mode", () => {
       renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
-      expect(screen.getByTestId('advanced-chat-header')).toBeInTheDocument();
+      expect(screen.getByTestId("advanced-chat-header")).toBeInTheDocument();
     });
 
-    it('should render advanced chat builder when no messages in advanced mode', () => {
+    it("should render advanced chat builder when no messages in advanced mode", () => {
       renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
-      expect(screen.getByTestId('advanced-chat-builder')).toBeInTheDocument();
+      expect(screen.getByTestId("advanced-chat-builder")).toBeInTheDocument();
     });
   });
 
-  describe('preview mode', () => {
-    it('should pass isPreviewMode to children components', () => {
+  describe("preview mode", () => {
+    it("should pass isPreviewMode to children components", () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={true} />);
       // Component should handle preview mode without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('border styling', () => {
-    it('should apply border by default', () => {
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+  describe("border styling", () => {
+    it("should apply border by default", () => {
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
       const chatContainer = container.firstChild as HTMLElement;
-      expect(chatContainer).toHaveClass('border');
+      expect(chatContainer).toHaveClass("border");
     });
 
-    it('should not apply border when hasBorder is false', () => {
+    it("should not apply border when hasBorder is false", () => {
       const { container } = renderWithRedux(
         <Chat mode="default" isPreviewMode={false} hasBorder={false} />,
       );
       const chatContainer = container.firstChild as HTMLElement;
-      expect(chatContainer).not.toHaveClass('border-gray-200');
+      expect(chatContainer).not.toHaveClass("border-gray-200");
     });
   });
 
-  describe('message handling', () => {
-    it('should handle message submission from welcome chat', async () => {
+  describe("message handling", () => {
+    it("should handle message submission from welcome chat", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -774,45 +849,45 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
       });
     });
 
-    it('should handle retry from chat messages', async () => {
+    it("should handle retry from chat messages", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -821,7 +896,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('retry-btn'));
+      fireEvent.click(screen.getByTestId("retry-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -829,38 +904,38 @@ describe('Chat', () => {
     });
   });
 
-  describe('streaming state', () => {
-    it('should pass isStreaming to chat input form', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("streaming state", () => {
+    it("should pass isStreaming to chat input form", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -869,33 +944,33 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('is-streaming')).toHaveTextContent('true');
+      expect(screen.getByTestId("is-streaming")).toHaveTextContent("true");
     });
 
-    it('should show loading message when pending', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading message when pending", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -904,42 +979,42 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
   });
 
-  describe('canvas interaction', () => {
-    it('should handle open canvas from chat messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas interaction", () => {
+    it("should handle open canvas from chat messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -949,38 +1024,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click open canvas button
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Canvas should be opened (we can't verify the internal state directly,
       // but we can verify no errors are thrown)
     });
   });
 
-  describe('session id', () => {
-    it('should pass sessionId to chat input form', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("session id", () => {
+    it("should pass sessionId to chat input form", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'my-session-456',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "my-session-456",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -989,21 +1064,25 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('session-id')).toHaveTextContent('my-session-456');
+      expect(screen.getByTestId("session-id")).toHaveTextContent(
+        "my-session-456",
+      );
     });
   });
 
-  describe('isInCanvasView prop', () => {
-    it('should handle isInCanvasView prop', () => {
-      renderWithRedux(<Chat mode="default" isPreviewMode={false} isInCanvasView={true} />);
+  describe("isInCanvasView prop", () => {
+    it("should handle isInCanvasView prop", () => {
+      renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} isInCanvasView={true} />,
+      );
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('event listeners', () => {
-    it('should set up event listeners on mount', async () => {
-      const eventBus = await import('@/lib/eventBus');
+  describe("event listeners", () => {
+    it("should set up event listeners on mount", async () => {
+      const eventBus = await import("@/lib/eventBus");
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
@@ -1011,31 +1090,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('error handling', () => {
-    it('should wrap messages in ErrorBoundary', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("error handling", () => {
+    it("should wrap messages in ErrorBoundary", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1044,35 +1123,35 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('error-boundary')).toBeInTheDocument();
+      expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
     });
   });
 
-  describe('guided prompts', () => {
-    it('should render guided prompts when not in shared chat', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("guided prompts", () => {
+    it("should render guided prompts when not in shared chat", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
-        enabledGuidedPrompts: ['prompt1', 'prompt2'],
+        enabledGuidedPrompts: ["prompt1", "prompt2"],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1081,49 +1160,49 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('guided-prompts')).toBeInTheDocument();
+      expect(screen.getByTestId("guided-prompts")).toBeInTheDocument();
     });
   });
 
-  describe('message count', () => {
-    it('should show correct message count in chat messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("message count", () => {
+    it("should show correct message count in chat messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '3',
-            role: 'user',
-            content: 'How are you?',
+            id: "3",
+            role: "user",
+            content: "How are you?",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1132,36 +1211,36 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('message-count')).toHaveTextContent('3');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("3");
     });
   });
 
-  describe('form submission from chat input', () => {
-    it('should handle form submission from chat input form', async () => {
+  describe("form submission from chat input", () => {
+    it("should handle form submission from chat input form", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1170,7 +1249,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('submit-btn'));
+      fireEvent.click(screen.getByTestId("submit-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -1178,23 +1257,23 @@ describe('Chat', () => {
     });
   });
 
-  describe('loading chats state', () => {
-    it('should handle loading chats state', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading chats state", () => {
+    it("should handle loading chats state", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1204,41 +1283,41 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('streaming message state', () => {
-    it('should handle current streaming message', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("streaming message state", () => {
+    it("should handle current streaming message", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: {
-          id: 'streaming-1',
-          role: 'assistant',
-          content: 'I am responding...',
+          id: "streaming-1",
+          role: "assistant",
+          content: "I am responding...",
           timestamp: new Date().toISOString(),
           visible: true,
         },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1248,35 +1327,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render with streaming state
-      expect(screen.getByTestId('is-streaming')).toHaveTextContent('true');
+      expect(screen.getByTestId("is-streaming")).toHaveTextContent("true");
     });
   });
 
-  describe('empty guided prompts', () => {
-    it('should handle empty guided prompts array', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("empty guided prompts", () => {
+    it("should handle empty guided prompts array", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1286,35 +1365,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('profile image', () => {
-    it('should handle missing profile image', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("profile image", () => {
+    it("should handle missing profile image", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '',
+        profileImage: "",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1324,36 +1403,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('stop generating', () => {
-    it('should call stopGenerating when stop button is used', async () => {
+  describe("stop generating", () => {
+    it("should call stopGenerating when stop button is used", async () => {
       const mockStopGenerating = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: mockStopGenerating,
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1363,27 +1442,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render with streaming state
-      expect(screen.getByTestId('is-streaming')).toHaveTextContent('true');
+      expect(screen.getByTestId("is-streaming")).toHaveTextContent("true");
     });
   });
 
-  describe('unique mentor id', () => {
-    it('should handle different unique mentor ids', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("unique mentor id", () => {
+    it("should handle different unique mentor ids", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Different Mentor',
+        mentorName: "Different Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'different-mentor-id',
-        sessionId: 'session-789',
+        uniqueMentorId: "different-mentor-id",
+        sessionId: "session-789",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1392,28 +1471,30 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('mentor-name')).toHaveTextContent('Different Mentor');
+      expect(screen.getByTestId("mentor-name")).toHaveTextContent(
+        "Different Mentor",
+      );
     });
   });
 
-  describe('change tab', () => {
-    it('should handle changeTab function', async () => {
+  describe("change tab", () => {
+    it("should handle changeTab function", async () => {
       const mockChangeTab = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: mockChangeTab,
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1423,28 +1504,28 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('setMessage', () => {
-    it('should handle setMessage function', async () => {
+  describe("setMessage", () => {
+    it("should handle setMessage function", async () => {
       const mockSetMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: mockSetMessage,
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1454,28 +1535,28 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('start new chat', () => {
-    it('should handle startNewChat function', async () => {
+  describe("start new chat", () => {
+    it("should handle startNewChat function", async () => {
       const mockStartNewChat = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: mockStartNewChat,
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1485,27 +1566,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('safety disclaimer', () => {
-    it('should handle enableSafetyDisclaimer true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("safety disclaimer", () => {
+    it("should handle enableSafetyDisclaimer true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: true,
         isPending: false,
@@ -1515,30 +1596,32 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('authentication flows', () => {
-    it('should show login message when user is not logged in', async () => {
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("authentication flows", () => {
+    it("should show login message when user is not logged in", async () => {
+      const { isLoggedIn } = await import("@/lib/utils");
       (isLoggedIn as any).mockReturnValue(false);
 
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1547,45 +1630,49 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalled();
       });
     });
 
-    it('should handle user not in tenant', async () => {
-      const { isLoggedIn } = await import('@/lib/utils');
+    it("should handle user not in tenant", async () => {
+      const { isLoggedIn } = await import("@/lib/utils");
       (isLoggedIn as any).mockReturnValue(true);
 
-      const { useUserTenants } = await import('@/hooks/use-user');
+      const { useUserTenants } = await import("@/hooks/use-user");
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'different-tenant' }],
+        userTenants: [{ key: "different-tenant" }],
       });
 
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1594,7 +1681,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalled();
@@ -1602,24 +1689,24 @@ describe('Chat', () => {
     });
   });
 
-  describe('preview mode', () => {
-    it('should block submission in preview mode', async () => {
+  describe("preview mode", () => {
+    it("should block submission in preview mode", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1628,7 +1715,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={true} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       // Message should not be sent in preview mode
       await waitFor(() => {
@@ -1637,32 +1724,32 @@ describe('Chat', () => {
     });
   });
 
-  describe('file attachments', () => {
-    it('should allow submission with files attached', async () => {
+  describe("file attachments", () => {
+    it("should allow submission with files attached", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1673,19 +1760,19 @@ describe('Chat', () => {
         files: {
           attachedFiles: [
             {
-              id: 'file-1',
-              fileId: 'file-id-1',
-              fileKey: 'file-key-1',
-              fileName: 'test.txt',
-              fileType: 'text/plain',
+              id: "file-1",
+              fileId: "file-id-1",
+              fileKey: "file-key-1",
+              fileName: "test.txt",
+              fileType: "text/plain",
               fileSize: 100,
-              uploadStatus: 'success',
+              uploadStatus: "success",
             },
           ],
         },
       });
 
-      fireEvent.click(screen.getByTestId('submit-btn'));
+      fireEvent.click(screen.getByTestId("submit-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -1693,45 +1780,45 @@ describe('Chat', () => {
     });
   });
 
-  describe('messages filtering', () => {
-    it('should filter out assistant welcome message when first message is assistant', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("messages filtering", () => {
+    it("should filter out assistant welcome message when first message is assistant", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'assistant',
-            content: 'Welcome!',
+            id: "1",
+            role: "assistant",
+            content: "Welcome!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'user',
-            content: 'Hello',
+            id: "2",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '3',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "3",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1741,40 +1828,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Messages should be filtered to exclude welcome message
-      expect(screen.getByTestId('message-count')).toHaveTextContent('2');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
     });
 
-    it('should include all messages when first message is user', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should include all messages when first message is user", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1783,44 +1870,47 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('message-count')).toHaveTextContent('2');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
     });
   });
 
-  describe('welcome chat with ai welcome message', () => {
-    it('should show welcome chat when only one assistant welcome message exists and not a new session', async () => {
+  describe("welcome chat with ai welcome message", () => {
+    it("should show welcome chat when only one assistant welcome message exists and not a new session", async () => {
       // This test verifies a complex condition where welcome chat is shown when:
       // 1. messages.length === 1
       // 2. first message is assistant
       // 3. isNewSession.current is false (not a new session)
       // The component logic uses a ref `isNewSession` which defaults to true unless
       // cachedSessionId is found. We need to mock local storage to have a cached session.
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
-      (useLocalStorage as any).mockReturnValue([{ 'mentor-123': 'cached-session' }, vi.fn()]);
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
+      (useLocalStorage as any).mockReturnValue([
+        { "mentor-123": "cached-session" },
+        vi.fn(),
+      ]);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'assistant',
-            content: 'Welcome to the chat!',
+            id: "1",
+            role: "assistant",
+            content: "Welcome to the chat!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1831,30 +1921,30 @@ describe('Chat', () => {
 
       // When isNewSession is false (has cached session) and only AI welcome message exists,
       // the welcome chat should be displayed
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('embedded mode', () => {
-    it('should render chat input form in embedded mode even without messages', async () => {
-      const { useEmbedMode } = await import('@/hooks/use-embed-mode');
+  describe("embedded mode", () => {
+    it("should render chat input form in embedded mode even without messages", async () => {
+      const { useEmbedMode } = await import("@/hooks/use-embed-mode");
       (useEmbedMode as any).mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1863,33 +1953,33 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('chat area max width', () => {
-    it('should use chat area size from tenant metadata', async () => {
-      const { useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
+  describe("chat area max width", () => {
+    it("should use chat area size from tenant metadata", async () => {
+      const { useTenantMetadata } = await import("@iblai/iblai-js/web-utils");
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 900 },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1899,31 +1989,31 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should use default chat area size when metadata is invalid', async () => {
-      const { useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
+    it("should use default chat area size when metadata is invalid", async () => {
+      const { useTenantMetadata } = await import("@iblai/iblai-js/web-utils");
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
-        metadata: { chat_area_size: 'invalid' },
+        platformName: "Test Platform",
+        metadata: { chat_area_size: "invalid" },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1933,31 +2023,31 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should use default when chat area size is below minimum', async () => {
-      const { useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
+    it("should use default when chat area size is below minimum", async () => {
+      const { useTenantMetadata } = await import("@iblai/iblai-js/web-utils");
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 100 },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1966,31 +2056,31 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should use default when chat area size is above maximum', async () => {
-      const { useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
+    it("should use default when chat area size is above maximum", async () => {
+      const { useTenantMetadata } = await import("@iblai/iblai-js/web-utils");
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 5000 },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -1999,43 +2089,43 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('artifacts loading indicator', () => {
-    it('should hide loading message when last message has artifact versions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifacts loading indicator", () => {
+    it("should hide loading message when last message has artifact versions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: '',
+            id: "2",
+            role: "assistant",
+            content: "",
             timestamp: new Date().toISOString(),
             visible: true,
-            artifactVersions: [{ id: 1, content: 'artifact' }],
+            artifactVersions: [{ id: 1, content: "artifact" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2045,32 +2135,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should not be shown when last message has artifact versions
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('service worker status', () => {
-    it('should handle offline status', async () => {
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+  describe("service worker status", () => {
+    it("should handle offline status", async () => {
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: false },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2079,30 +2171,32 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('visiting tenant', () => {
-    it('should handle visiting tenant scenario', async () => {
-      const { useVisitingTenant } = await import('@/hooks/use-user');
-      (useVisitingTenant as any).mockReturnValue({ visitingTenant: 'visiting-tenant' });
+  describe("visiting tenant", () => {
+    it("should handle visiting tenant scenario", async () => {
+      const { useVisitingTenant } = await import("@/hooks/use-user");
+      (useVisitingTenant as any).mockReturnValue({
+        visitingTenant: "visiting-tenant",
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2111,36 +2205,36 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('empty content submission', () => {
-    it('should not submit empty content without attachments', async () => {
+  describe("empty content submission", () => {
+    it("should not submit empty content without attachments", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2150,35 +2244,37 @@ describe('Chat', () => {
       // The mock ChatInputForm sends 'Test message' so this tests the path
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('mentor settings', () => {
-    it('should handle allowAnonymous mentor setting', async () => {
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
+  describe("mentor settings", () => {
+    it("should handle allowAnonymous mentor setting", async () => {
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: true,
-          mentorVisibility: 'VIEWABLE_BY_ANYONE',
+          mentorVisibility: "VIEWABLE_BY_ANYONE",
         },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2187,30 +2283,33 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('local storage cached session', () => {
-    it('should use cached session id from local storage', async () => {
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
-      (useLocalStorage as any).mockReturnValue([{ 'mentor-123': 'cached-session-456' }, vi.fn()]);
+  describe("local storage cached session", () => {
+    it("should use cached session id from local storage", async () => {
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
+      (useLocalStorage as any).mockReturnValue([
+        { "mentor-123": "cached-session-456" },
+        vi.fn(),
+      ]);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2219,14 +2318,18 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('free trial dialog', () => {
-    it('should show free trial dialog when modal is open', async () => {
-      const { useShowFreeTrialDialog } = await import('@/hooks/user-user-actions');
-      const MockFreeTrialDialog = () => <div data-testid="free-trial-dialog">Free Trial</div>;
+  describe("free trial dialog", () => {
+    it("should show free trial dialog when modal is open", async () => {
+      const { useShowFreeTrialDialog } = await import(
+        "@/hooks/user-user-actions"
+      );
+      const MockFreeTrialDialog = () => (
+        <div data-testid="free-trial-dialog">Free Trial</div>
+      );
       (useShowFreeTrialDialog as any).mockReturnValue({
         FreeTrialDialog: MockFreeTrialDialog,
         closeModal: vi.fn(),
@@ -2234,21 +2337,21 @@ describe('Chat', () => {
         executeWithTrialCheck: vi.fn((fn: () => void) => fn()),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2257,38 +2360,40 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('free-trial-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId("free-trial-dialog")).toBeInTheDocument();
     });
   });
 
-  describe('user agreement', () => {
-    it('should handle user agreement modal', async () => {
-      const { useUserAgreement } = await import('@/hooks/use-user-agreement');
+  describe("user agreement", () => {
+    it("should handle user agreement modal", async () => {
+      const { useUserAgreement } = await import("@/hooks/use-user-agreement");
       (useUserAgreement as any).mockReturnValue({
         showDisclaimerModal: true,
         isAgreeing: false,
-        userAgreement: { content: 'Please agree to terms' },
+        userAgreement: { content: "Please agree to terms" },
         hasUserAgreement: true,
         handleDisclaimerAgree: vi.fn(),
-        checkAgreementAndExecute: vi.fn((content: string, fn: (c: string) => void) => fn(content)),
+        checkAgreementAndExecute: vi.fn(
+          (content: string, fn: (c: string) => void) => fn(content),
+        ),
         executePendingSubmit: vi.fn(),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2298,39 +2403,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Disclaimer modal should be rendered
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('shared chat', () => {
-    it('should hide guided prompts when showing shared chat', async () => {
+  describe("shared chat", () => {
+    it("should hide guided prompts when showing shared chat", async () => {
       // Shared chat state is controlled via Redux store state
       // The selectShowingSharedChat selector is already mocked at the top level
       // We need to render with the preloaded state that has showingSharedChat: true
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
-        enabledGuidedPrompts: ['prompt1'],
+        enabledGuidedPrompts: ["prompt1"],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2340,27 +2445,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // In default mode (not shared chat), guided prompts should be present
-      expect(screen.getByTestId('guided-prompts')).toBeInTheDocument();
+      expect(screen.getByTestId("guided-prompts")).toBeInTheDocument();
     });
   });
 
-  describe('screen sharing modal', () => {
-    it('should open screen sharing modal on button click', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("screen sharing modal", () => {
+    it("should open screen sharing modal on button click", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2370,29 +2475,31 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
     });
 
-    it('should toggle screen sharing modal when already open', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should toggle screen sharing modal when already open", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2402,38 +2509,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Click again to toggle (close it)
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('live-kit-screen-sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("live-kit-screen-sharing"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('phone call modal', () => {
-    it('should open phone call modal on button click', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("phone call modal", () => {
+    it("should open phone call modal on button click", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2443,34 +2554,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click phone call button
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
   });
 
-  describe('iframe and chat popup actions', () => {
-    it('should render when in iframe', async () => {
-      const { isInIframe } = await import('@/lib/utils');
+  describe("iframe and chat popup actions", () => {
+    it("should render when in iframe", async () => {
+      const { isInIframe } = await import("@/lib/utils");
       (isInIframe as any).mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2480,35 +2591,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component renders without errors when in iframe
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('input form screen sharing and phone call', () => {
-    it('should handle screen sharing click from input form', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("input form screen sharing and phone call", () => {
+    it("should handle screen sharing click from input form", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2518,37 +2629,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button from input form
-      fireEvent.click(screen.getByTestId('input-screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("input-screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
     });
 
-    it('should handle phone call click from input form', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle phone call click from input form", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2558,41 +2671,43 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click phone call button from input form
-      fireEvent.click(screen.getByTestId('input-phone-call-btn'));
+      fireEvent.click(screen.getByTestId("input-phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
 
-    it('should handle phone call click in iframe mode with popup actions', async () => {
-      const { isInIframe, sendMessageToParentWebsite } = await import('@/lib/utils');
+    it("should handle phone call click in iframe mode with popup actions", async () => {
+      const { isInIframe, sendMessageToParentWebsite } = await import(
+        "@/lib/utils"
+      );
       (isInIframe as any).mockReturnValue(true);
       mockSelectEnableChatActionsPopup.mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2602,46 +2717,48 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click phone call button from input form
-      fireEvent.click(screen.getByTestId('input-phone-call-btn'));
+      fireEvent.click(screen.getByTestId("input-phone-call-btn"));
 
       // Should send message to parent website
       expect(sendMessageToParentWebsite).toHaveBeenCalledWith({
-        type: 'MENTOR:CHAT_ACTION_VOICECALL',
-        sessionId: 'session-123',
+        type: "MENTOR:CHAT_ACTION_VOICECALL",
+        sessionId: "session-123",
       });
 
       // Reset mock
       mockSelectEnableChatActionsPopup.mockReturnValue(false);
     });
 
-    it('should handle screen share click in iframe mode with popup actions', async () => {
-      const { isInIframe, sendMessageToParentWebsite } = await import('@/lib/utils');
+    it("should handle screen share click in iframe mode with popup actions", async () => {
+      const { isInIframe, sendMessageToParentWebsite } = await import(
+        "@/lib/utils"
+      );
       (isInIframe as any).mockReturnValue(true);
       mockSelectEnableChatActionsPopup.mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2651,12 +2768,12 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button from input form
-      fireEvent.click(screen.getByTestId('input-screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("input-screen-sharing-btn"));
 
       // Should send message to parent website
       expect(sendMessageToParentWebsite).toHaveBeenCalledWith({
-        type: 'MENTOR:CHAT_ACTION_SCREENSHARE',
-        sessionId: 'session-123',
+        type: "MENTOR:CHAT_ACTION_SCREENSHARE",
+        sessionId: "session-123",
       });
 
       // Reset mock
@@ -2664,23 +2781,23 @@ describe('Chat', () => {
     });
   });
 
-  describe('modal close handlers', () => {
-    it('should close phone call modal via close button', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("modal close handlers", () => {
+    it("should close phone call modal via close button", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2690,36 +2807,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open phone call modal
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
 
       // Close via button
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('live-kit-chat')).not.toBeInTheDocument();
+        expect(screen.queryByTestId("live-kit-chat")).not.toBeInTheDocument();
       });
     });
 
-    it('should close screen sharing modal via close button', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should close screen sharing modal via close button", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2730,38 +2847,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Close via button
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('live-kit-screen-sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("live-kit-screen-sharing"),
+        ).not.toBeInTheDocument();
       });
     });
 
-    it('should call window.close for phone call modal if window.opener exists', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+    it("should call window.close for phone call modal if window.opener exists", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2771,36 +2892,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open phone call modal
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
 
       // Close via button - should call window.close
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should call window.close for screen sharing modal if window.opener exists', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+    it("should call window.close for screen sharing modal if window.opener exists", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2810,36 +2931,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Close via button - should call window.close
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       expect(window.close).toHaveBeenCalled();
     });
   });
 
-  describe('search params handling', () => {
-    it('should handle search params without errors', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("search params handling", () => {
+    it("should handle search params without errors", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2849,30 +2972,32 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component renders without errors
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should show voice call dialog when chat-action=voice-call', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should show voice call dialog when chat-action=voice-call", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2883,31 +3008,33 @@ describe('Chat', () => {
 
       // Voice call confirmation dialog should be shown
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
     });
 
-    it('should show screen share dialog when chat-action=screen-share', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should show screen share dialog when chat-action=screen-share", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2918,31 +3045,33 @@ describe('Chat', () => {
 
       // Screen share confirmation dialog should be shown
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
     });
 
-    it('should confirm voice call and open modal when confirm button clicked', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should confirm voice call and open modal when confirm button clicked", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2953,39 +3082,41 @@ describe('Chat', () => {
 
       // Wait for dialog to show
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Click confirm button
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       // Phone call modal should open
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
 
-    it('should cancel voice call dialog when cancel button clicked', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should cancel voice call dialog when cancel button clicked", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -2996,39 +3127,43 @@ describe('Chat', () => {
 
       // Wait for dialog to show
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Click cancel button
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       // Dialog should close
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Voice Call')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Voice Call"),
+        ).not.toBeInTheDocument();
       });
     });
 
-    it('should confirm screen share and open modal when confirm button clicked', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should confirm screen share and open modal when confirm button clicked", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3039,39 +3174,43 @@ describe('Chat', () => {
 
       // Wait for dialog to show
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Click confirm button
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       // Screen sharing modal should open
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
     });
 
-    it('should cancel screen share dialog when cancel button clicked', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should cancel screen share dialog when cancel button clicked", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3082,41 +3221,45 @@ describe('Chat', () => {
 
       // Wait for dialog to show
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Click cancel button
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       // Dialog should close
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Screen Sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Screen Sharing"),
+        ).not.toBeInTheDocument();
       });
     });
 
-    it('should call window.close on voice call cancel when window.opener exists', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+    it("should call window.close on voice call cancel when window.opener exists", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3127,45 +3270,45 @@ describe('Chat', () => {
 
       // Wait for dialog to show
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Click cancel button
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       // Should call window.close
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should cache session ID when chat-action=voice-call with session-id param', async () => {
+    it("should cache session ID when chat-action=voice-call with session-id param", async () => {
       const mockSaveCachedSessionId = vi.fn();
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
       (useLocalStorage as any).mockReturnValue([{}, mockSaveCachedSessionId]);
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
         get: vi.fn((param: string) => {
-          if (param === 'chat-action') return 'voice-call';
-          if (param === 'session-id') return 'popup-session-abc';
+          if (param === "chat-action") return "voice-call";
+          if (param === "session-id") return "popup-session-abc";
           return null;
         }),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3176,42 +3319,44 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Session ID should be cached
-      expect(mockSaveCachedSessionId).toHaveBeenCalledWith({ 'mentor-123': 'popup-session-abc' });
+      expect(mockSaveCachedSessionId).toHaveBeenCalledWith({
+        "mentor-123": "popup-session-abc",
+      });
     });
 
-    it('should cache session ID when chat-action=screen-share with session-id param', async () => {
+    it("should cache session ID when chat-action=screen-share with session-id param", async () => {
       const mockSaveCachedSessionId = vi.fn();
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
       (useLocalStorage as any).mockReturnValue([{}, mockSaveCachedSessionId]);
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
         get: vi.fn((param: string) => {
-          if (param === 'chat-action') return 'screen-share';
-          if (param === 'session-id') return 'popup-session-xyz';
+          if (param === "chat-action") return "screen-share";
+          if (param === "session-id") return "popup-session-xyz";
           return null;
         }),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3222,36 +3367,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Session ID should be cached
-      expect(mockSaveCachedSessionId).toHaveBeenCalledWith({ 'mentor-123': 'popup-session-xyz' });
+      expect(mockSaveCachedSessionId).toHaveBeenCalledWith({
+        "mentor-123": "popup-session-xyz",
+      });
     });
 
-    it('should show blocking overlay when confirming voice call with window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+    it("should show blocking overlay when confirming voice call with window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3262,43 +3411,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Click confirm
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       // Blocking overlay should appear with voice call active text
       await waitFor(() => {
-        expect(screen.getByText('Voice Call Active')).toBeInTheDocument();
+        expect(screen.getByText("Voice Call Active")).toBeInTheDocument();
       });
 
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+      Object.defineProperty(window, "opener", { value: null, writable: true });
     });
 
-    it('should show blocking overlay when confirming screen share with window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+    it("should show blocking overlay when confirming screen share with window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3309,43 +3460,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Click confirm
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       // Blocking overlay should appear with screen sharing active text
       await waitFor(() => {
-        expect(screen.getByText('Screen Sharing Active')).toBeInTheDocument();
+        expect(screen.getByText("Screen Sharing Active")).toBeInTheDocument();
       });
 
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+      Object.defineProperty(window, "opener", { value: null, writable: true });
     });
 
-    it('should close screen sharing modal without notifying opener when window.opener is null', async () => {
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+    it("should close screen sharing modal without notifying opener when window.opener is null", async () => {
+      Object.defineProperty(window, "opener", { value: null, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3356,45 +3509,54 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Confirm to open screen sharing — no blocking overlay since no window.opener
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       // Screen sharing modal should open
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Blocking overlay should NOT appear since window.opener is null
-      expect(screen.queryByText('Screen Sharing Active')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Screen Sharing Active"),
+      ).not.toBeInTheDocument();
     });
 
-    it('should notify opener and close window when stopping screen share from blocking overlay', async () => {
+    it("should notify opener and close window when stopping screen share from blocking overlay", async () => {
       const mockOpener = { postMessage: vi.fn(), closed: false };
-      Object.defineProperty(window, 'opener', { value: mockOpener, writable: true });
-
-      const { useSearchParams } = await import('next/navigation');
-      (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+      Object.defineProperty(window, "opener", {
+        value: mockOpener,
+        writable: true,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useSearchParams } = await import("next/navigation");
+      (useSearchParams as any).mockReturnValue({
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
+      });
+
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3405,61 +3567,68 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Confirm to open screen sharing and show blocking overlay
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       await waitFor(() => {
-        expect(screen.getByText('Screen Sharing Active')).toBeInTheDocument();
+        expect(screen.getByText("Screen Sharing Active")).toBeInTheDocument();
       });
 
       // Click Stop Screen Sharing on the blocking overlay
-      fireEvent.click(screen.getByText('Stop Screen Sharing'));
+      fireEvent.click(screen.getByText("Stop Screen Sharing"));
 
       // Should notify opener
       expect(mockOpener.postMessage).toHaveBeenCalledWith(
-        { type: 'MENTOR:SCREENSHARING_STOPPED' },
-        '*',
+        { type: "MENTOR:SCREENSHARING_STOPPED" },
+        "*",
       );
 
       // Should call window.close
       expect(window.close).toHaveBeenCalled();
 
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+      Object.defineProperty(window, "opener", { value: null, writable: true });
     });
 
-    it('should handle postMessage error when stopping screen share from blocking overlay', async () => {
+    it("should handle postMessage error when stopping screen share from blocking overlay", async () => {
       const mockOpener = {
         postMessage: vi.fn(() => {
-          throw new Error('postMessage failed');
+          throw new Error("postMessage failed");
         }),
         closed: false,
       };
-      Object.defineProperty(window, 'opener', { value: mockOpener, writable: true });
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      Object.defineProperty(window, "opener", {
+        value: mockOpener,
+        writable: true,
+      });
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3470,21 +3639,21 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       await waitFor(() => {
-        expect(screen.getByText('Screen Sharing Active')).toBeInTheDocument();
+        expect(screen.getByText("Screen Sharing Active")).toBeInTheDocument();
       });
 
       // Click Stop Screen Sharing — postMessage will throw
-      fireEvent.click(screen.getByText('Stop Screen Sharing'));
+      fireEvent.click(screen.getByText("Stop Screen Sharing"));
 
       // Should log error
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to post screen sharing stopped to opener:',
+        "Failed to post screen sharing stopped to opener:",
         expect.any(Error),
       );
 
@@ -3492,28 +3661,28 @@ describe('Chat', () => {
       expect(window.close).toHaveBeenCalled();
 
       consoleSpy.mockRestore();
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+      Object.defineProperty(window, "opener", { value: null, writable: true });
     });
   });
 
-  describe('SCREENSHARING_STOPPED message listener', () => {
-    it('should call refetchChats when SCREENSHARING_STOPPED message is received', async () => {
+  describe("SCREENSHARING_STOPPED message listener", () => {
+    it("should call refetchChats when SCREENSHARING_STOPPED message is received", async () => {
       const mockRefetchChats = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3525,31 +3694,31 @@ describe('Chat', () => {
 
       // Dispatch a SCREENSHARING_STOPPED message event
       window.dispatchEvent(
-        new MessageEvent('message', {
-          data: { type: 'MENTOR:SCREENSHARING_STOPPED' },
+        new MessageEvent("message", {
+          data: { type: "MENTOR:SCREENSHARING_STOPPED" },
         }),
       );
 
       expect(mockRefetchChats).toHaveBeenCalled();
     });
 
-    it('should not call refetchChats for unrelated message events', async () => {
+    it("should not call refetchChats for unrelated message events", async () => {
       const mockRefetchChats = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3561,8 +3730,8 @@ describe('Chat', () => {
 
       // Dispatch an unrelated message event
       window.dispatchEvent(
-        new MessageEvent('message', {
-          data: { type: 'SOME_OTHER_EVENT' },
+        new MessageEvent("message", {
+          data: { type: "SOME_OTHER_EVENT" },
         }),
       );
 
@@ -3570,38 +3739,38 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas state', () => {
-    it('should render canvas open button in messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas state", () => {
+    it("should render canvas open button in messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3611,33 +3780,33 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas button should exist
-      expect(screen.getByTestId('open-canvas-btn')).toBeInTheDocument();
+      expect(screen.getByTestId("open-canvas-btn")).toBeInTheDocument();
     });
 
-    it('should handle canvas open action without errors', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle canvas open action without errors", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3647,38 +3816,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click open canvas button - tests the handleOpenCanvas function is triggered
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Component should still be rendered
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('reply functionality', () => {
-    it('should set replying to message when reply button is clicked', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("reply functionality", () => {
+    it("should set replying to message when reply button is clicked", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3688,37 +3857,37 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component renders, this tests the reply path setup
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('highlight message', () => {
-    it('should handle message highlighting', async () => {
+  describe("highlight message", () => {
+    it("should handle message highlighting", async () => {
       vi.useFakeTimers();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3728,32 +3897,32 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component should render
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
 
       vi.useRealTimers();
     });
   });
 
-  describe('token and anonymous access', () => {
-    it('should render when user is not logged in', async () => {
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("token and anonymous access", () => {
+    it("should render when user is not logged in", async () => {
+      const { isLoggedIn } = await import("@/lib/utils");
       (isLoggedIn as any).mockReturnValue(false);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3762,36 +3931,38 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('event bus subscriptions', () => {
-    it('should clean up event listeners on unmount', async () => {
-      const eventBus = await import('@/lib/eventBus');
+  describe("event bus subscriptions", () => {
+    it("should clean up event listeners on unmount", async () => {
+      const eventBus = await import("@/lib/eventBus");
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { unmount } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { unmount } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       unmount();
 
@@ -3799,29 +3970,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('402 error handling', () => {
-    it('should set up 402 error handler', async () => {
-      const { use402ErrorCheck } = await import('@/hooks/subscription/use-402-error-check');
+  describe("402 error handling", () => {
+    it("should set up 402 error handler", async () => {
+      const { use402ErrorCheck } = await import(
+        "@/hooks/subscription/use-402-error-check"
+      );
       const mockHandle402Error = vi.fn();
       (use402ErrorCheck as any).mockReturnValue({
         handle402Error: mockHandle402Error,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3834,31 +4007,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('debounced scroll handler', () => {
-    it('should handle scroll events', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("debounced scroll handler", () => {
+    it("should handle scroll events", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3868,30 +4041,30 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Trigger scroll event - component should handle it without errors
-      const chatMessages = screen.getByTestId('chat-messages');
+      const chatMessages = screen.getByTestId("chat-messages");
       fireEvent.scroll(chatMessages);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('useMediaQuery breakpoint', () => {
-    it('should handle different screen sizes', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("useMediaQuery breakpoint", () => {
+    it("should handle different screen sizes", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3900,68 +4073,70 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('isInCanvasView prop', () => {
-    it('should handle isInCanvasView true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("isInCanvasView prop", () => {
+    it("should handle isInCanvasView true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      renderWithRedux(<Chat mode="default" isPreviewMode={false} isInCanvasView={true} />);
+      renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} isInCanvasView={true} />,
+      );
 
       // When isInCanvasView is true, the split layout should not render
-      expect(screen.queryByTestId('canvas-view')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("canvas-view")).not.toBeInTheDocument();
     });
   });
 
-  describe('new session detection', () => {
-    it('should detect new session based on local storage', async () => {
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
+  describe("new session detection", () => {
+    it("should detect new session based on local storage", async () => {
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
       (useLocalStorage as any).mockReturnValue([{}, vi.fn()]);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -3971,35 +4146,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // New session should show welcome chat
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('canvas artifact events', () => {
-    it('should handle canvas artifact state updates', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas artifact events", () => {
+    it("should handle canvas artifact state updates", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Create a document',
+            id: "1",
+            role: "user",
+            content: "Create a document",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4009,42 +4184,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component renders with canvas open button available
-      expect(screen.getByTestId('open-canvas-btn')).toBeInTheDocument();
+      expect(screen.getByTestId("open-canvas-btn")).toBeInTheDocument();
     });
   });
 
-  describe('streaming artifact id', () => {
-    it('should handle streaming artifact state', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("streaming artifact id", () => {
+    it("should handle streaming artifact state", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: {
-          id: 'streaming-msg',
-          role: 'assistant',
-          content: 'Generating...',
+          id: "streaming-msg",
+          role: "assistant",
+          content: "Generating...",
           timestamp: new Date().toISOString(),
           visible: true,
-          artifactVersions: [{ id: 456, content: 'Streaming artifact' }],
+          artifactVersions: [{ id: 456, content: "Streaming artifact" }],
         },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4053,50 +4228,50 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('canvas state management', () => {
-    it('should pass onOpenCanvas callback to ChatMessages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas state management", () => {
+    it("should pass onOpenCanvas callback to ChatMessages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Here is a document',
+            id: "2",
+            role: "assistant",
+            content: "Here is a document",
             timestamp: new Date().toISOString(),
             visible: true,
             artifactVersions: [
               {
                 id: 123,
-                title: 'Test Document',
-                content: 'Test content',
-                tool_type: 'canvas',
+                title: "Test Document",
+                content: "Test content",
+                tool_type: "canvas",
               },
             ],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4106,35 +4281,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // The open canvas button should be available
-      expect(screen.getByTestId('open-canvas-btn')).toBeInTheDocument();
+      expect(screen.getByTestId("open-canvas-btn")).toBeInTheDocument();
     });
   });
 
-  describe('scroll functionality', () => {
-    it('should handle scroll events', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll functionality", () => {
+    it("should handle scroll events", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4144,34 +4319,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Verify messages are rendered
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('voice call dialog behavior', () => {
-    it('should handle dialog close via onOpenChange with window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+  describe("voice call dialog behavior", () => {
+    it("should handle dialog close via onOpenChange with window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4181,38 +4358,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Close dialog by clicking the backdrop (dialog)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should handle dialog close via onOpenChange without window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+    it("should handle dialog close via onOpenChange without window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: null, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4222,43 +4401,47 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Close dialog by clicking the backdrop (dialog)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       // Dialog should close
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Voice Call')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Voice Call"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('screen share dialog behavior', () => {
-    it('should handle dialog close via onOpenChange with window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: {}, writable: true });
+  describe("screen share dialog behavior", () => {
+    it("should handle dialog close via onOpenChange with window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: {}, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4268,38 +4451,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Close dialog by clicking the backdrop (dialog)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should handle dialog close via onOpenChange without window.opener', async () => {
-      Object.defineProperty(window, 'opener', { value: null, writable: true });
+    it("should handle dialog close via onOpenChange without window.opener", async () => {
+      Object.defineProperty(window, "opener", { value: null, writable: true });
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4309,44 +4494,46 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Close dialog by clicking the backdrop (dialog)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       // Dialog should close
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Screen Sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Screen Sharing"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('screen sharing toggle in input form', () => {
-    it('should toggle screen sharing modal off when already open', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("screen sharing toggle in input form", () => {
+    it("should toggle screen sharing modal off when already open", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4356,60 +4543,64 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal
-      fireEvent.click(screen.getByTestId('input-screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("input-screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Click again to toggle off
-      fireEvent.click(screen.getByTestId('input-screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("input-screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('live-kit-screen-sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("live-kit-screen-sharing"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('assistant first message filtering', () => {
-    it('should filter out first assistant message when displaying messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("assistant first message filtering", () => {
+    it("should filter out first assistant message when displaying messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '0',
-            role: 'assistant',
-            content: 'Welcome message',
+            id: "0",
+            role: "assistant",
+            content: "Welcome message",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4419,42 +4610,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render chat messages (filtering first assistant message)
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
       // The message count should be 2 (first assistant message filtered out)
-      expect(screen.getByTestId('message-count')).toHaveTextContent('2');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
     });
 
-    it('should not filter when first message is from user', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should not filter when first message is from user", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4464,43 +4655,43 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render all messages
-      expect(screen.getByTestId('message-count')).toHaveTextContent('2');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
     });
   });
 
-  describe('loading states with artifact versions', () => {
-    it('should hide loading message when last message has artifact versions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading states with artifact versions", () => {
+    it("should hide loading message when last message has artifact versions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Creating...',
+            id: "2",
+            role: "assistant",
+            content: "Creating...",
             timestamp: new Date().toISOString(),
             visible: true,
-            artifactVersions: [{ id: 123, content: 'test' }],
+            artifactVersions: [{ id: 123, content: "test" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4510,31 +4701,33 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should NOT be shown because last message has artifact versions
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('welcome screen popup actions', () => {
-    it('should send screen share message to parent from welcome screen when popup actions enabled', async () => {
-      const { isInIframe, sendMessageToParentWebsite } = await import('@/lib/utils');
+  describe("welcome screen popup actions", () => {
+    it("should send screen share message to parent from welcome screen when popup actions enabled", async () => {
+      const { isInIframe, sendMessageToParentWebsite } = await import(
+        "@/lib/utils"
+      );
       (isInIframe as any).mockReturnValue(true);
       mockSelectEnableChatActionsPopup.mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [], // Empty messages so welcome screen is shown
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4545,37 +4738,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button from welcome screen
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       // Should send message to parent website
       expect(sendMessageToParentWebsite).toHaveBeenCalledWith({
-        type: 'MENTOR:CHAT_ACTION_SCREENSHARE',
-        sessionId: 'session-123',
+        type: "MENTOR:CHAT_ACTION_SCREENSHARE",
+        sessionId: "session-123",
       });
 
       mockSelectEnableChatActionsPopup.mockReturnValue(false);
     });
 
-    it('should send phone call message to parent from welcome screen when popup actions enabled', async () => {
-      const { isInIframe, sendMessageToParentWebsite } = await import('@/lib/utils');
+    it("should send phone call message to parent from welcome screen when popup actions enabled", async () => {
+      const { isInIframe, sendMessageToParentWebsite } = await import(
+        "@/lib/utils"
+      );
       (isInIframe as any).mockReturnValue(true);
       mockSelectEnableChatActionsPopup.mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [], // Empty messages so welcome screen is shown
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4586,37 +4781,37 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click phone call button from welcome screen
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       // Should send message to parent website
       expect(sendMessageToParentWebsite).toHaveBeenCalledWith({
-        type: 'MENTOR:CHAT_ACTION_VOICECALL',
-        sessionId: 'session-123',
+        type: "MENTOR:CHAT_ACTION_VOICECALL",
+        sessionId: "session-123",
       });
 
       mockSelectEnableChatActionsPopup.mockReturnValue(false);
     });
 
-    it('should toggle screen sharing modal from welcome screen without popup actions', async () => {
-      const { isInIframe } = await import('@/lib/utils');
+    it("should toggle screen sharing modal from welcome screen without popup actions", async () => {
+      const { isInIframe } = await import("@/lib/utils");
       (isInIframe as any).mockReturnValue(false);
       mockSelectEnableChatActionsPopup.mockReturnValue(false);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [], // Empty messages so welcome screen is shown
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4626,41 +4821,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button from welcome screen
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       // Screen sharing modal should open
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Click again to close
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('live-kit-screen-sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("live-kit-screen-sharing"),
+        ).not.toBeInTheDocument();
       });
     });
 
-    it('should open phone call modal from welcome screen without popup actions', async () => {
-      const { isInIframe } = await import('@/lib/utils');
+    it("should open phone call modal from welcome screen without popup actions", async () => {
+      const { isInIframe } = await import("@/lib/utils");
       (isInIframe as any).mockReturnValue(false);
       mockSelectEnableChatActionsPopup.mockReturnValue(false);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [], // Empty messages so welcome screen is shown
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4670,46 +4869,48 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click phone call button from welcome screen
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       // Phone call modal should open
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
   });
 
-  describe('user not in tenant', () => {
-    it('should show join tenant message when user is not in tenant and allowAnonymous is false', async () => {
-      const { useUserTenants } = await import('@/hooks/use-user');
+  describe("user not in tenant", () => {
+    it("should show join tenant message when user is not in tenant and allowAnonymous is false", async () => {
+      const { useUserTenants } = await import("@/hooks/use-user");
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'different-tenant' }], // User is in different tenant
+        userTenants: [{ key: "different-tenant" }], // User is in different tenant
       });
 
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4719,7 +4920,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Submit a message
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       // sendMessage should not be called directly since user not in tenant
       // The component should dispatch addUserMessage action instead
@@ -4727,37 +4928,37 @@ describe('Chat', () => {
     });
   });
 
-  describe('current streaming message content', () => {
-    it('should not show loading message when currentStreamingMessage has content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("current streaming message content", () => {
+    it("should not show loading message when currentStreamingMessage has content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: {
-          id: 'streaming-msg',
-          role: 'assistant',
-          content: 'Streaming response...',
+          id: "streaming-msg",
+          role: "assistant",
+          content: "Streaming response...",
           timestamp: new Date().toISOString(),
           visible: true,
         },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4767,27 +4968,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should NOT be shown when currentStreamingMessage has content
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('window resize handling', () => {
-    it('should handle window resize event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("window resize handling", () => {
+    it("should handle window resize event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4797,39 +4998,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Trigger resize event
-      Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true });
-      window.dispatchEvent(new Event('resize'));
+      Object.defineProperty(window, "innerWidth", {
+        value: 1200,
+        writable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
 
       // Component should still render
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('canvas split view', () => {
-    it('should handle open canvas button click', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas split view", () => {
+    it("should handle open canvas button click", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4839,48 +5043,48 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas button should be clickable
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Wait for canvas view to appear (split view renders)
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Chat messages should still be visible in split view
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should render chat messages with multiple messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render chat messages with multiple messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4890,26 +5094,26 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Messages should be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
-      expect(screen.getByTestId('message-count')).toHaveTextContent('2');
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
+      expect(screen.getByTestId("message-count")).toHaveTextContent("2");
     });
 
-    it('should handle artifact-stream-start event dispatch', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-start event dispatch", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -4919,45 +5123,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start event
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 123,
-          title: 'Test Artifact',
-          fileExtension: 'txt',
-          sessionId: 'session-123',
+          title: "Test Artifact",
+          fileExtension: "txt",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
       window.dispatchEvent(event);
 
       // Welcome chat should be visible (canvas doesn't render in mock)
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should show loading indicator when pending', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading indicator when pending", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -4967,36 +5171,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas button should be clickable
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Chat messages should be visible (canvas split view state is set)
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should show chat input form in canvas split view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show chat input form in canvas split view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5006,33 +5210,33 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Chat input should be visible
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
 
-    it('should render chat component with open canvas button', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render chat component with open canvas button", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5042,56 +5246,67 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas button should be present
-      expect(screen.getByTestId('open-canvas-btn')).toBeInTheDocument();
+      expect(screen.getByTestId("open-canvas-btn")).toBeInTheDocument();
     });
   });
 
-  describe('scroll to bottom button', () => {
-    it('should show scroll to bottom button when scrolled up', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll to bottom button", () => {
+    it("should show scroll to bottom button when scrolled up", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find chat container and simulate scroll
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
-        Object.defineProperty(chatContainer, 'scrollTop', { value: 0, writable: true });
-        Object.defineProperty(chatContainer, 'scrollHeight', { value: 1000, writable: true });
-        Object.defineProperty(chatContainer, 'clientHeight', { value: 500, writable: true });
+        Object.defineProperty(chatContainer, "scrollTop", {
+          value: 0,
+          writable: true,
+        });
+        Object.defineProperty(chatContainer, "scrollHeight", {
+          value: 1000,
+          writable: true,
+        });
+        Object.defineProperty(chatContainer, "clientHeight", {
+          value: 500,
+          writable: true,
+        });
 
         fireEvent.scroll(chatContainer);
       }
@@ -5100,30 +5315,30 @@ describe('Chat', () => {
       expect(container).toBeInTheDocument();
     });
 
-    it('should not show scroll to bottom button in preview mode', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should not show scroll to bottom button in preview mode", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5133,35 +5348,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={true} />);
 
       // Scroll to bottom button should not appear in preview mode
-      expect(screen.queryByText('Scroll to Bottom')).not.toBeInTheDocument();
+      expect(screen.queryByText("Scroll to Bottom")).not.toBeInTheDocument();
     });
   });
 
-  describe('artifact events', () => {
-    it('should handle artifact-stream-start event dispatch', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact events", () => {
+    it("should handle artifact-stream-start event dispatch", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5171,45 +5386,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start event
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 456,
-          title: 'New Artifact',
-          fileExtension: 'py',
-          sessionId: 'session-123',
+          title: "New Artifact",
+          fileExtension: "py",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
       window.dispatchEvent(event);
 
       // Chat messages should still be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle artifact-stream-end event dispatch', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-end event dispatch", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5219,13 +5434,13 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-end event
-      const endEvent = new CustomEvent('artifact-stream-end', {
+      const endEvent = new CustomEvent("artifact-stream-end", {
         detail: {
           artifactId: 789,
-          title: 'Streaming Artifact',
-          content: 'const x = 1;',
-          fileExtension: 'js',
-          sessionId: 'session-123',
+          title: "Streaming Artifact",
+          content: "const x = 1;",
+          fileExtension: "js",
+          sessionId: "session-123",
           isUpdate: false,
           isPartial: false,
           versionNumber: 1,
@@ -5234,33 +5449,33 @@ describe('Chat', () => {
       window.dispatchEvent(endEvent);
 
       // Chat messages should still be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle artifact-update event dispatch', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-update event dispatch", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5270,44 +5485,44 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-update event
-      const updateEvent = new CustomEvent('artifact-update', {
+      const updateEvent = new CustomEvent("artifact-update", {
         detail: {
           artifactId: 123,
-          title: 'Updated Title',
-          content: 'Updated content',
-          fileExtension: 'txt',
+          title: "Updated Title",
+          content: "Updated content",
+          fileExtension: "txt",
         },
       });
       window.dispatchEvent(updateEvent);
 
       // Chat messages should still be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle artifact-title-updated event dispatch', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-title-updated event dispatch", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5317,42 +5532,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch title update event
-      const titleEvent = new CustomEvent('artifact-title-updated', {
+      const titleEvent = new CustomEvent("artifact-title-updated", {
         detail: {
           artifactId: 123,
-          title: 'New Title',
+          title: "New Title",
         },
       });
       window.dispatchEvent(titleEvent);
 
       // Chat messages should still be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle canvas-active event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle canvas-active event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5362,43 +5577,43 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch canvas-active event
-      const activeEvent = new CustomEvent('canvas-active', {
+      const activeEvent = new CustomEvent("canvas-active", {
         detail: {
           artifactId: 999,
-          title: 'Active Canvas',
-          file_extension: 'md',
+          title: "Active Canvas",
+          file_extension: "md",
         },
       });
       window.dispatchEvent(activeEvent);
 
       // No errors should occur
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle canvas-inactive event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle canvas-inactive event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5408,39 +5623,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch canvas-inactive event
-      const inactiveEvent = new CustomEvent('canvas-inactive', {});
+      const inactiveEvent = new CustomEvent("canvas-inactive", {});
       window.dispatchEvent(inactiveEvent);
 
       // No errors should occur
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('code file extensions', () => {
-    it('should handle code file extension in artifact event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("code file extensions", () => {
+    it("should handle code file extension in artifact event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5450,47 +5665,47 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start with code file extension
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 111,
-          title: 'Code File',
-          fileExtension: 'ts',
-          sessionId: 'session-123',
+          title: "Code File",
+          fileExtension: "ts",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
       window.dispatchEvent(event);
 
       // Event should be dispatched without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('session change behavior', () => {
-    it('should handle session ID in hooks', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("session change behavior", () => {
+    it("should handle session ID in hooks", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5500,35 +5715,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should render chat messages with session ID
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('handleOpenCanvas with code toolType', () => {
-    it('should handle code file extension in artifact streaming', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("handleOpenCanvas with code toolType", () => {
+    it("should handle code file extension in artifact streaming", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5538,39 +5753,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start with code file extension
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 789,
-          title: 'Code File',
-          fileExtension: 'py',
-          sessionId: 'session-123',
+          title: "Code File",
+          fileExtension: "py",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
       window.dispatchEvent(event);
 
       // Event should be dispatched without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('disclaimer modal agree with pending submit', () => {
-    it('should render chat component with user agreement hook', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("disclaimer modal agree with pending submit", () => {
+    it("should render chat component with user agreement hook", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5580,36 +5795,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Welcome chat should be rendered
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('highlight message functionality', () => {
-    it('should trigger handleHighlightMessage when highlight button is clicked', async () => {
+  describe("highlight message functionality", () => {
+    it("should trigger handleHighlightMessage when highlight button is clicked", async () => {
       vi.useFakeTimers();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5619,43 +5834,46 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click highlight button to trigger handleHighlightMessage
-      fireEvent.click(screen.getByTestId('highlight-btn'));
+      fireEvent.click(screen.getByTestId("highlight-btn"));
 
       // Advance timers to trigger the setTimeout that clears the highlight
       vi.advanceTimersByTime(2000);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
       vi.useRealTimers();
     });
   });
 
-  describe('mobile responsive behavior', () => {
-    it('should handle mobile screen size', async () => {
-      Object.defineProperty(window, 'innerWidth', { value: 375, writable: true });
+  describe("mobile responsive behavior", () => {
+    it("should handle mobile screen size", async () => {
+      Object.defineProperty(window, "innerWidth", {
+        value: 375,
+        writable: true,
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5665,42 +5883,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Trigger resize to mobile
-      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event("resize"));
 
       // Should render without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
 
       // Reset window width
-      Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+      Object.defineProperty(window, "innerWidth", {
+        value: 1024,
+        writable: true,
+      });
     });
   });
 
-  describe('canvas with artifact reference in message', () => {
-    it('should submit message with sendMessage handler', async () => {
+  describe("canvas with artifact reference in message", () => {
+    it("should submit message with sendMessage handler", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5710,7 +5931,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Submit a message
-      fireEvent.click(screen.getByTestId('submit-btn'));
+      fireEvent.click(screen.getByTestId("submit-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -5718,31 +5939,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('stream end without canvas open', () => {
-    it('should handle artifact-stream-end event without errors', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("stream end without canvas open", () => {
+    it("should handle artifact-stream-end event without errors", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5752,13 +5973,13 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-end event
-      const endEvent = new CustomEvent('artifact-stream-end', {
+      const endEvent = new CustomEvent("artifact-stream-end", {
         detail: {
           artifactId: 999,
-          title: 'Fallback Artifact',
-          content: 'Some content',
-          fileExtension: 'txt',
-          sessionId: 'session-123',
+          title: "Fallback Artifact",
+          content: "Some content",
+          fileExtension: "txt",
+          sessionId: "session-123",
           isUpdate: false,
           isPartial: false,
           versionNumber: 1,
@@ -5767,35 +5988,35 @@ describe('Chat', () => {
       window.dispatchEvent(endEvent);
 
       // Should render without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('reply to message', () => {
-    it('should trigger onReply callback when reply button is clicked', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("reply to message", () => {
+    it("should trigger onReply callback when reply button is clicked", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5805,36 +6026,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click reply button to trigger onReply callback
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
       // ChatMessages should be rendered and reply state should be set
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should trigger onReply in canvas split view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should trigger onReply in canvas split view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5844,45 +6065,47 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to get into split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Click reply button to trigger onReply callback in canvas view
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('eventbus cleanup', () => {
-    it('should clean up all event listeners on unmount', async () => {
-      const eventBus = await import('@/lib/eventBus');
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("eventbus cleanup", () => {
+    it("should clean up all event listeners on unmount", async () => {
+      const eventBus = await import("@/lib/eventBus");
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { unmount } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { unmount } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Verify event listeners were registered
       expect(eventBus.default.on).toHaveBeenCalled();
@@ -5895,23 +6118,23 @@ describe('Chat', () => {
     });
   });
 
-  describe('welcome screen toggle', () => {
-    it('should open screen sharing modal from welcome screen', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("welcome screen toggle", () => {
+    it("should open screen sharing modal from welcome screen", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5921,38 +6144,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click screen sharing button
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       // Modal should open
-      expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+      expect(screen.getByTestId("live-kit-screen-sharing")).toBeInTheDocument();
     });
   });
 
-  describe('resize handle interaction', () => {
-    it('should render resize handle in canvas split view and handle mouse events', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("resize handle interaction", () => {
+    it("should render resize handle in canvas split view and handle mouse events", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -5962,40 +6185,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to get split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Chat messages should be rendered
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle resize start and mouse move events', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle resize start and mouse move events", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6005,45 +6228,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Simulate window mouse move and mouse up events
       fireEvent.mouseMove(window, { clientX: 500 });
       fireEvent.mouseUp(window);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('loading indicator in canvas split view', () => {
-    it('should show loading message when isPending and no streaming content in canvas view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator in canvas split view", () => {
+    it("should show loading message when isPending and no streaming content in canvas view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -6053,39 +6276,39 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should show loading when isStreaming and no content in canvas view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading when isStreaming and no content in canvas view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6095,33 +6318,33 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('empty messages state in canvas split view', () => {
-    it('should render empty state UI when no messages in canvas split view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("empty messages state in canvas split view", () => {
+    it("should render empty state UI when no messages in canvas split view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6131,55 +6354,55 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start to open canvas (since there's no messages to trigger open-canvas-btn)
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 888,
-          title: 'Empty Test',
-          fileExtension: 'txt',
-          sessionId: 'session-123',
+          title: "Empty Test",
+          fileExtension: "txt",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
       window.dispatchEvent(event);
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('normal chat layout with messages', () => {
-    it('should render normal chat layout when not in canvas view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("normal chat layout with messages", () => {
+    it("should render normal chat layout when not in canvas view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6189,40 +6412,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Normal chat layout should render
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should trigger onReply in normal chat layout', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should trigger onReply in normal chat layout", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6232,35 +6455,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click reply button
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should show loading indicator in normal view when isPending', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading indicator in normal view when isPending", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -6269,33 +6492,33 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should show loading when isStreaming in normal view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading when isStreaming in normal view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6304,35 +6527,35 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('canvas close functionality', () => {
-    it('should close canvas when close button is clicked', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas close functionality", () => {
+    it("should close canvas when close button is clicked", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6342,39 +6565,41 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Close canvas
-      fireEvent.click(screen.getByTestId('close-canvas-btn'));
+      fireEvent.click(screen.getByTestId("close-canvas-btn"));
 
       // Canvas should close and welcome/chat view should return
       await waitFor(() => {
-        expect(screen.queryByTestId('canvas-view')).not.toBeInTheDocument();
+        expect(screen.queryByTestId("canvas-view")).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('disclaimer agree with pending submit', () => {
-    it('should handle disclaimer agree with pending submit', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("disclaimer agree with pending submit", () => {
+    it("should handle disclaimer agree with pending submit", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: true,
         isPending: false,
@@ -6399,36 +6624,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Welcome chat should be visible
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('canvas sendMessage callback', () => {
-    it('should trigger sendMessage from canvas view', async () => {
+  describe("canvas sendMessage callback", () => {
+    it("should trigger sendMessage from canvas view", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6438,52 +6663,52 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Click send button in canvas
-      fireEvent.click(screen.getByTestId('canvas-send-btn'));
+      fireEvent.click(screen.getByTestId("canvas-send-btn"));
 
       // sendMessage should be called
       expect(mockSendMessage).toHaveBeenCalled();
     });
   });
 
-  describe('scroll handler in normal chat view', () => {
-    it('should handle scroll events in normal chat view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll handler in normal chat view", () => {
+    it("should handle scroll events in normal chat view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6493,42 +6718,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component should render in normal chat view
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('assistant first message filtering in normal view', () => {
-    it('should filter out assistant first message in normal view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("assistant first message filtering in normal view", () => {
+    it("should filter out assistant first message in normal view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'assistant',
-            content: 'Welcome!',
+            id: "1",
+            role: "assistant",
+            content: "Welcome!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'user',
-            content: 'Hello',
+            id: "2",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6538,35 +6763,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Messages filtered to 1 (first assistant message removed)
-      expect(screen.getByTestId('message-count')).toHaveTextContent('1');
+      expect(screen.getByTestId("message-count")).toHaveTextContent("1");
     });
   });
 
-  describe('cached session id', () => {
-    it('should use cached session id for normal chat view', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("cached session id", () => {
+    it("should use cached session id for normal chat view", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6575,132 +6800,157 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('scroll to bottom button', () => {
-    it('should show scroll to bottom button when scrolled up with messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll to bottom button", () => {
+    it("should show scroll to bottom button when scrolled up with messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the chat container and simulate scroll
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
         // Mock scrollHeight, scrollTop, clientHeight to simulate scrolled up state
-        Object.defineProperty(chatContainer, 'scrollHeight', { value: 1000, configurable: true });
-        Object.defineProperty(chatContainer, 'scrollTop', { value: 0, configurable: true });
-        Object.defineProperty(chatContainer, 'clientHeight', { value: 300, configurable: true });
+        Object.defineProperty(chatContainer, "scrollHeight", {
+          value: 1000,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "scrollTop", {
+          value: 0,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "clientHeight", {
+          value: 300,
+          configurable: true,
+        });
 
         // Trigger scroll event
         fireEvent.scroll(chatContainer);
       }
 
       // Component should render properly even with scroll state
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should hide scroll button when at bottom of chat', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide scroll button when at bottom of chat", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the chat container and simulate scroll at bottom
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
-        Object.defineProperty(chatContainer, 'scrollHeight', { value: 500, configurable: true });
-        Object.defineProperty(chatContainer, 'scrollTop', { value: 450, configurable: true });
-        Object.defineProperty(chatContainer, 'clientHeight', { value: 500, configurable: true });
+        Object.defineProperty(chatContainer, "scrollHeight", {
+          value: 500,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "scrollTop", {
+          value: 450,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "clientHeight", {
+          value: 500,
+          configurable: true,
+        });
 
         fireEvent.scroll(chatContainer);
       }
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('Tauri and offline mode handling', () => {
-    it('should handle Tauri app environment', async () => {
+  describe("Tauri and offline mode handling", () => {
+    it("should handle Tauri app environment", async () => {
       // Simulate Tauri environment
-      Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+      Object.defineProperty(window, "__TAURI__", {
+        value: {},
+        configurable: true,
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6709,31 +6959,34 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
 
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
     });
 
-    it('should handle offline mode with local storage', async () => {
-      Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
-      localStorage.setItem('tauri_offline_mode', 'true');
+    it("should handle offline mode with local storage", async () => {
+      Object.defineProperty(window, "__TAURI__", {
+        value: {},
+        configurable: true,
+      });
+      localStorage.setItem("tauri_offline_mode", "true");
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6742,33 +6995,36 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
 
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
-      localStorage.removeItem('tauri_offline_mode');
+      localStorage.removeItem("tauri_offline_mode");
     });
 
-    it('should handle navigator.onLine being false', async () => {
+    it("should handle navigator.onLine being false", async () => {
       // Mock navigator.onLine
       const originalOnLine = navigator.onLine;
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      Object.defineProperty(navigator, "onLine", {
+        value: false,
+        configurable: true,
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6777,29 +7033,32 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
 
       // Restore
-      Object.defineProperty(navigator, 'onLine', { value: originalOnLine, configurable: true });
+      Object.defineProperty(navigator, "onLine", {
+        value: originalOnLine,
+        configurable: true,
+      });
     });
 
-    it('should handle offline server origin check', async () => {
+    it("should handle offline server origin check", async () => {
       // The isOfflineServerOrigin checks for specific localhost:3456 origins
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -6808,37 +7067,43 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('error handler in useAdvancedChat', () => {
-    it('should handle errors through errorHandler callback', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  describe("error handler in useAdvancedChat", () => {
+    it("should handle errors through errorHandler callback", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       const mockToastError = vi.fn();
-      const { toast } = await import('sonner');
+      const { toast } = await import("sonner");
       (toast.error as any) = mockToastError;
 
-      let capturedErrorHandler: ((message: string, error?: unknown) => void) | undefined;
+      let capturedErrorHandler:
+        | ((message: string, error?: unknown) => void)
+        | undefined;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation(
-        (options: { errorHandler?: (message: string, error?: unknown) => void }) => {
+        (options: {
+          errorHandler?: (message: string, error?: unknown) => void;
+        }) => {
           capturedErrorHandler = options.errorHandler;
           return {
             changeTab: vi.fn(),
-            activeTab: 'chat',
+            activeTab: "chat",
             currentStreamingMessage: null,
             enabledGuidedPrompts: [],
             isStreaming: false,
-            mentorName: 'Test Mentor',
+            mentorName: "Test Mentor",
             messages: [],
-            profileImage: '/avatar.png',
+            profileImage: "/avatar.png",
             sendMessage: vi.fn(),
             setMessage: vi.fn(),
             stopGenerating: vi.fn(),
-            uniqueMentorId: 'unique-mentor-123',
-            sessionId: 'session-123',
+            uniqueMentorId: "unique-mentor-123",
+            sessionId: "session-123",
             startNewChat: vi.fn(),
             enableSafetyDisclaimer: false,
             isPending: false,
@@ -6851,37 +7116,50 @@ describe('Chat', () => {
 
       // Call the error handler
       if (capturedErrorHandler) {
-        await capturedErrorHandler('Test error message', new Error('Test error'));
+        await capturedErrorHandler(
+          "Test error message",
+          new Error("Test error"),
+        );
       }
 
       consoleSpy.mockRestore();
     });
 
-    it('should suppress errors in Tauri offline mode', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    it("should suppress errors in Tauri offline mode", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      Object.defineProperty(window, "__TAURI__", {
+        value: {},
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "onLine", {
+        value: false,
+        configurable: true,
+      });
 
-      let capturedErrorHandler: ((message: string, error?: unknown) => Promise<void>) | undefined;
+      let capturedErrorHandler:
+        | ((message: string, error?: unknown) => Promise<void>)
+        | undefined;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation(
-        (options: { errorHandler?: (message: string, error?: unknown) => Promise<void> }) => {
+        (options: {
+          errorHandler?: (message: string, error?: unknown) => Promise<void>;
+        }) => {
           capturedErrorHandler = options.errorHandler;
           return {
             changeTab: vi.fn(),
-            activeTab: 'chat',
+            activeTab: "chat",
             currentStreamingMessage: null,
             enabledGuidedPrompts: [],
             isStreaming: false,
-            mentorName: 'Test Mentor',
+            mentorName: "Test Mentor",
             messages: [],
-            profileImage: '/avatar.png',
+            profileImage: "/avatar.png",
             sendMessage: vi.fn(),
             setMessage: vi.fn(),
             stopGenerating: vi.fn(),
-            uniqueMentorId: 'unique-mentor-123',
-            sessionId: 'session-123',
+            uniqueMentorId: "unique-mentor-123",
+            sessionId: "session-123",
             startNewChat: vi.fn(),
             enableSafetyDisclaimer: false,
             isPending: false,
@@ -6894,42 +7172,45 @@ describe('Chat', () => {
 
       // The error handler should suppress errors when in Tauri offline mode
       if (capturedErrorHandler) {
-        await capturedErrorHandler('Test error message');
+        await capturedErrorHandler("Test error message");
       }
 
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
-      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+      Object.defineProperty(navigator, "onLine", {
+        value: true,
+        configurable: true,
+      });
       consoleSpy.mockRestore();
     });
   });
 
-  describe('handleOfflineWithoutLocalLLM', () => {
-    it('should show offline toast when callback is called', async () => {
+  describe("handleOfflineWithoutLocalLLM", () => {
+    it("should show offline toast when callback is called", async () => {
       const mockToastError = vi.fn();
-      const { toast } = await import('sonner');
+      const { toast } = await import("sonner");
       (toast.error as any) = mockToastError;
 
       let capturedOnOfflineCallback: (() => void) | undefined;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation(
         (options: { onOfflineWithoutLocalLLM?: () => void }) => {
           capturedOnOfflineCallback = options.onOfflineWithoutLocalLLM;
           return {
             changeTab: vi.fn(),
-            activeTab: 'chat',
+            activeTab: "chat",
             currentStreamingMessage: null,
             enabledGuidedPrompts: [],
             isStreaming: false,
-            mentorName: 'Test Mentor',
+            mentorName: "Test Mentor",
             messages: [],
-            profileImage: '/avatar.png',
+            profileImage: "/avatar.png",
             sendMessage: vi.fn(),
             setMessage: vi.fn(),
             stopGenerating: vi.fn(),
-            uniqueMentorId: 'unique-mentor-123',
-            sessionId: 'session-123',
+            uniqueMentorId: "unique-mentor-123",
+            sessionId: "session-123",
             startNewChat: vi.fn(),
             enableSafetyDisclaimer: false,
             isPending: false,
@@ -6946,7 +7227,7 @@ describe('Chat', () => {
       }
 
       expect(mockToastError).toHaveBeenCalledWith(
-        'You are offline',
+        "You are offline",
         expect.objectContaining({
           description: expect.any(String),
           duration: 10000,
@@ -6956,42 +7237,46 @@ describe('Chat', () => {
     });
   });
 
-  describe('requireUserToJoinTenantOnChat', () => {
-    it('should dispatch messages when user not in tenant', async () => {
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("requireUserToJoinTenantOnChat", () => {
+    it("should dispatch messages when user not in tenant", async () => {
+      const { isLoggedIn } = await import("@/lib/utils");
       (isLoggedIn as any).mockReturnValue(true);
 
-      const { useUserTenants } = await import('@/hooks/use-user');
+      const { useUserTenants } = await import("@/hooks/use-user");
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'different-tenant-key' }],
+        userTenants: [{ key: "different-tenant-key" }],
       });
 
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
-      const { useAdvancedChat, chatActions, useTenantContext } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, chatActions, useTenantContext } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useTenantContext as any).mockReturnValue({
-        metadata: { support_email: 'test@example.com' },
+        metadata: { support_email: "test@example.com" },
       });
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7001,7 +7286,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click submit to trigger the check
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalled();
@@ -7009,20 +7294,22 @@ describe('Chat', () => {
     });
   });
 
-  describe('handleDisclaimerAgreeWithPendingSubmit', () => {
-    it('should handle user agreement state', async () => {
+  describe("handleDisclaimerAgreeWithPendingSubmit", () => {
+    it("should handle user agreement state", async () => {
       const mockHandleDisclaimerAgree = vi.fn().mockResolvedValue(undefined);
       const mockExecutePendingSubmit = vi.fn();
-      const mockCheckAgreementAndExecute = vi.fn((content: string, fn: (c: string) => void) => {
-        // This simulates calling executePendingSubmit when disclaimer is agreed
-        fn(content);
-      });
+      const mockCheckAgreementAndExecute = vi.fn(
+        (content: string, fn: (c: string) => void) => {
+          // This simulates calling executePendingSubmit when disclaimer is agreed
+          fn(content);
+        },
+      );
 
-      const { useUserAgreement } = await import('@/hooks/use-user-agreement');
+      const { useUserAgreement } = await import("@/hooks/use-user-agreement");
       (useUserAgreement as any).mockReturnValue({
         showDisclaimerModal: false,
         isAgreeing: false,
-        userAgreement: { content: 'Please agree to terms' },
+        userAgreement: { content: "Please agree to terms" },
         hasUserAgreement: true,
         handleDisclaimerAgree: mockHandleDisclaimerAgree,
         checkAgreementAndExecute: mockCheckAgreementAndExecute,
@@ -7030,21 +7317,21 @@ describe('Chat', () => {
       });
 
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7054,7 +7341,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Submit a message - checkAgreementAndExecute will be called
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(mockCheckAgreementAndExecute).toHaveBeenCalled();
@@ -7062,31 +7349,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas with code file extension', () => {
-    it('should detect code type for code file extensions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas with code file extension", () => {
+    it("should detect code type for code file extensions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7096,35 +7383,37 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component renders with chat-messages
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('resize handlers in canvas view', () => {
-    it('should handle resize start event', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("resize handlers in canvas view", () => {
+    it("should handle resize start event", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7149,31 +7438,31 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('window resize handling', () => {
-    it('should handle window resize events', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("window resize handling", () => {
+    it("should handle window resize events", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7183,21 +7472,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Trigger window resize
-      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event("resize"));
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('mentor tools error handler', () => {
-    it('should handle errors from useMentorTools', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  describe("mentor tools error handler", () => {
+    it("should handle errors from useMentorTools", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
-      let capturedMentorToolsErrorHandler: ((message: string, error?: unknown) => void) | undefined;
+      let capturedMentorToolsErrorHandler:
+        | ((message: string, error?: unknown) => void)
+        | undefined;
 
-      const { useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useMentorTools } = await import("@iblai/iblai-js/web-utils");
       (useMentorTools as any).mockImplementation(
-        (options: { errorHandler?: (message: string, error?: unknown) => void }) => {
+        (options: {
+          errorHandler?: (message: string, error?: unknown) => void;
+        }) => {
           capturedMentorToolsErrorHandler = options.errorHandler;
           return {
             enableWebBrowsing: true,
@@ -7216,21 +7511,21 @@ describe('Chat', () => {
         },
       );
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7241,38 +7536,41 @@ describe('Chat', () => {
 
       // Call the error handler
       if (capturedMentorToolsErrorHandler) {
-        await capturedMentorToolsErrorHandler('Tool error', new Error('Test tool error'));
+        await capturedMentorToolsErrorHandler(
+          "Tool error",
+          new Error("Test tool error"),
+        );
       }
 
       consoleSpy.mockRestore();
     });
   });
 
-  describe('canvas event handlers', () => {
-    it('should handle canvas-active custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas event handlers", () => {
+    it("should handle canvas-active custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7283,38 +7581,42 @@ describe('Chat', () => {
 
       // Dispatch canvas-active event
       window.dispatchEvent(
-        new CustomEvent('canvas-active', {
-          detail: { artifactId: 789, title: 'Active Canvas', file_extension: 'md' },
+        new CustomEvent("canvas-active", {
+          detail: {
+            artifactId: 789,
+            title: "Active Canvas",
+            file_extension: "md",
+          },
         }),
       );
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle canvas-inactive custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle canvas-inactive custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7324,35 +7626,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch canvas-inactive event
-      window.dispatchEvent(new CustomEvent('canvas-inactive'));
+      window.dispatchEvent(new CustomEvent("canvas-inactive"));
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle artifact-update custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-update custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7362,49 +7664,49 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Dispatch artifact-update event
       window.dispatchEvent(
-        new CustomEvent('artifact-update', {
+        new CustomEvent("artifact-update", {
           detail: {
             artifactId: 123,
-            title: 'Updated Title',
-            content: 'Updated content',
-            fileExtension: 'md',
+            title: "Updated Title",
+            content: "Updated content",
+            fileExtension: "md",
           },
         }),
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle artifact-title-updated custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-title-updated custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7415,38 +7717,38 @@ describe('Chat', () => {
 
       // Dispatch artifact-title-updated event
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
-          detail: { artifactId: 123, title: 'New Title' },
+        new CustomEvent("artifact-title-updated", {
+          detail: { artifactId: 123, title: "New Title" },
         }),
       );
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle artifact-stream-start custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-start custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7457,11 +7759,11 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-start event for new artifact
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 999,
-            title: 'Streaming Artifact',
-            fileExtension: 'py',
+            title: "Streaming Artifact",
+            fileExtension: "py",
             isUpdate: false,
           },
         }),
@@ -7469,34 +7771,34 @@ describe('Chat', () => {
 
       // Canvas should open for new artifacts
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle artifact-stream-end custom event', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-end custom event", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7507,12 +7809,12 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-end event
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 999,
-            title: 'Completed Artifact',
-            content: 'Final content',
-            fileExtension: 'py',
+            title: "Completed Artifact",
+            content: "Final content",
+            fileExtension: "py",
             isUpdate: false,
             versionNumber: 1,
           },
@@ -7521,16 +7823,18 @@ describe('Chat', () => {
 
       // Canvas should open when stream ends if not already open
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('session ID change handling', () => {
-    it('should handle session ID changes', async () => {
+  describe("session ID change handling", () => {
+    it("should handle session ID changes", async () => {
       const mockUpdateSessionTools = vi.fn().mockResolvedValue(undefined);
 
-      const { useMentorTools, useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useMentorTools, useAdvancedChat } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useMentorTools as any).mockReturnValue({
         enableWebBrowsing: true,
         updateSessionTools: mockUpdateSessionTools,
@@ -7548,26 +7852,26 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7577,32 +7881,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Verify component renders with proper session
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('onStartNewChat callback', () => {
-    it('should update session IDs when starting new chat', async () => {
+  describe("onStartNewChat callback", () => {
+    it("should update session IDs when starting new chat", async () => {
       let capturedOnStartNewChat: ((sessionId: string) => void) | undefined;
 
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockImplementation(
         (options: { onStartNewChat?: (sessionId: string) => void }) => {
           capturedOnStartNewChat = options.onStartNewChat;
           return {
             changeTab: vi.fn(),
-            activeTab: 'chat',
+            activeTab: "chat",
             currentStreamingMessage: null,
             enabledGuidedPrompts: [],
             isStreaming: false,
-            mentorName: 'Test Mentor',
+            mentorName: "Test Mentor",
             messages: [],
-            profileImage: '/avatar.png',
+            profileImage: "/avatar.png",
             sendMessage: vi.fn(),
             setMessage: vi.fn(),
             stopGenerating: vi.fn(),
-            uniqueMentorId: 'unique-mentor-123',
-            sessionId: 'session-123',
+            uniqueMentorId: "unique-mentor-123",
+            sessionId: "session-123",
             startNewChat: vi.fn(),
             enableSafetyDisclaimer: false,
             isPending: false,
@@ -7615,39 +7921,43 @@ describe('Chat', () => {
 
       // Call the onStartNewChat callback
       if (capturedOnStartNewChat) {
-        capturedOnStartNewChat('new-session-id-789');
+        capturedOnStartNewChat("new-session-id-789");
       }
 
-      expect(chatActions.updateSessionIds).toHaveBeenCalledWith('new-session-id-789');
+      expect(chatActions.updateSessionIds).toHaveBeenCalledWith(
+        "new-session-id-789",
+      );
     });
   });
 
-  describe('executeSubmit with canvas open', () => {
-    it('should include artifact payload when canvas is open', async () => {
+  describe("executeSubmit with canvas open", () => {
+    it("should include artifact payload when canvas is open", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7672,14 +7982,14 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Submit a message while canvas is open - use first submit button (desktop)
-      const submitButtons = screen.getAllByTestId('submit-btn');
+      const submitButtons = screen.getAllByTestId("submit-btn");
       fireEvent.click(submitButtons[0]);
 
       await waitFor(() => {
@@ -7696,23 +8006,25 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas empty messages state', () => {
-    it('should show empty state message in canvas view when no messages', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas empty messages state", () => {
+    it("should show empty state message in canvas view when no messages", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7737,35 +8049,35 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Should show welcome chat since no messages
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('loading indicator visibility', () => {
-    it('should show loading message when streaming without content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator visibility", () => {
+    it("should show loading message when streaming without content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7774,39 +8086,39 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should hide loading when currentStreamingMessage has content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide loading when currentStreamingMessage has content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: {
-          id: 'streaming',
-          role: 'assistant',
-          content: 'Partial response...',
+          id: "streaming",
+          role: "assistant",
+          content: "Partial response...",
           timestamp: new Date().toISOString(),
           visible: true,
         },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7816,60 +8128,62 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should be hidden when streaming has content
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('messages clear scroll reset', () => {
-    it('should reset scroll state when messages are cleared', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("messages clear scroll reset", () => {
+    it("should reset scroll state when messages are cleared", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       // First render with messages
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Now clear messages
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7883,35 +8197,35 @@ describe('Chat', () => {
       );
 
       // Should show welcome chat again
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('canvas toolType code', () => {
-    it('should handle canvas with code toolType', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas toolType code", () => {
+    it("should handle canvas with code toolType", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7922,51 +8236,54 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-start with code file extension
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 123,
-            title: 'Code File',
-            fileExtension: 'ts',
+            title: "Code File",
+            fileExtension: "ts",
             isUpdate: false,
           },
         }),
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('first canvas open with scroll position', () => {
-    it('should handle first canvas open when page is scrolled', async () => {
+  describe("first canvas open with scroll position", () => {
+    it("should handle first canvas open when page is scrolled", async () => {
       // Set window scroll position
-      Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
-      Object.defineProperty(window, 'pageYOffset', { value: 500, writable: true });
+      Object.defineProperty(window, "scrollY", { value: 500, writable: true });
+      Object.defineProperty(window, "pageYOffset", {
+        value: 500,
+        writable: true,
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -7976,43 +8293,46 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Reset
-      Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
-      Object.defineProperty(window, 'pageYOffset', { value: 0, writable: true });
+      Object.defineProperty(window, "scrollY", { value: 0, writable: true });
+      Object.defineProperty(window, "pageYOffset", {
+        value: 0,
+        writable: true,
+      });
     });
   });
 
-  describe('canvas with empty title', () => {
-    it('should use Untitled Artifact for empty title', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas with empty title", () => {
+    it("should use Untitled Artifact for empty title", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8023,47 +8343,47 @@ describe('Chat', () => {
 
       // Dispatch with empty title
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 999,
-            title: '',
-            fileExtension: 'txt',
+            title: "",
+            fileExtension: "txt",
             isUpdate: false,
           },
         }),
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('artifact stream update', () => {
-    it('should handle artifact stream update for existing artifact', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream update", () => {
+    it("should handle artifact stream update for existing artifact", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8073,54 +8393,54 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch update event (isUpdate: true)
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 123,
-            title: 'Updated Artifact',
-            fileExtension: 'txt',
+            title: "Updated Artifact",
+            fileExtension: "txt",
             isUpdate: true,
           },
         }),
       );
 
       // Canvas should still be open
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('artifact stream end when canvas not open', () => {
-    it('should open canvas on artifact stream end if not already open', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream end when canvas not open", () => {
+    it("should open canvas on artifact stream end if not already open", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8131,12 +8451,12 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-end without having started stream
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 456,
-            title: 'New Artifact',
-            content: 'Some content',
-            fileExtension: 'md',
+            title: "New Artifact",
+            content: "Some content",
+            fileExtension: "md",
             isUpdate: false,
             versionNumber: 1,
           },
@@ -8144,36 +8464,38 @@ describe('Chat', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('canvas width clamping', () => {
-    it('should handle canvas resize bounds', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas width clamping", () => {
+    it("should handle canvas resize bounds", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8198,42 +8520,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Trigger window resize
-      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event("resize"));
     });
   });
 
-  describe('accessibility message updates', () => {
-    it('should update accessibility message when streaming', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("accessibility message updates", () => {
+    it("should update accessibility message when streaming", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8247,37 +8569,37 @@ describe('Chat', () => {
       expect(srOnlyElement).toBeInTheDocument();
     });
 
-    it('should update accessibility message when new assistant message arrives', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should update accessibility message when new assistant message arrives", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8291,31 +8613,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('onReply handler', () => {
-    it('should handle reply to message', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply handler", () => {
+    it("should handle reply to message", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8325,40 +8647,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click reply button
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
       // The reply state should be set (verified by the component not crashing)
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('highlight message handler', () => {
-    it('should highlight message when clicked', async () => {
+  describe("highlight message handler", () => {
+    it("should highlight message when clicked", async () => {
       vi.useFakeTimers();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8368,42 +8690,44 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click highlight button
-      fireEvent.click(screen.getByTestId('highlight-btn'));
+      fireEvent.click(screen.getByTestId("highlight-btn"));
 
       // Wait for timeout that removes highlight
       vi.advanceTimersByTime(2000);
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
 
       vi.useRealTimers();
     });
   });
 
-  describe('canvas split view resize', () => {
-    it('should handle resize drag in canvas view', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas split view resize", () => {
+    it("should handle resize drag in canvas view", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8425,17 +8749,19 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Find resize handle
-      const resizeHandle = container.querySelector('.cursor-col-resize');
+      const resizeHandle = container.querySelector(".cursor-col-resize");
       if (resizeHandle) {
         // Start resize
         fireEvent.mouseDown(resizeHandle);
@@ -8443,7 +8769,7 @@ describe('Chat', () => {
         // Mock mouse move
         fireEvent(
           window,
-          new MouseEvent('mousemove', {
+          new MouseEvent("mousemove", {
             bubbles: true,
             clientX: 400,
           }),
@@ -8452,41 +8778,43 @@ describe('Chat', () => {
         // End resize
         fireEvent(
           window,
-          new MouseEvent('mouseup', {
+          new MouseEvent("mouseup", {
             bubbles: true,
           }),
         );
       }
 
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('close canvas resets state', () => {
-    it('should reset canvas state when closed', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("close canvas resets state", () => {
+    it("should reset canvas state when closed", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8511,47 +8839,47 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Close canvas
-      fireEvent.click(screen.getByTestId('close-canvas-btn'));
+      fireEvent.click(screen.getByTestId("close-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.queryByTestId('canvas-view')).not.toBeInTheDocument();
+        expect(screen.queryByTestId("canvas-view")).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('empty content with files submission', () => {
-    it('should allow submission with only files attached (no text)', async () => {
+  describe("empty content with files submission", () => {
+    it("should allow submission with only files attached (no text)", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8562,20 +8890,20 @@ describe('Chat', () => {
         files: {
           attachedFiles: [
             {
-              id: 'file-2',
-              fileId: 'file-id-2',
-              fileKey: 'file-key-2',
-              fileName: 'document.pdf',
-              fileType: 'application/pdf',
+              id: "file-2",
+              fileId: "file-id-2",
+              fileKey: "file-key-2",
+              fileName: "document.pdf",
+              fileType: "application/pdf",
               fileSize: 5000,
-              uploadStatus: 'success',
-              fileUrl: 'https://example.com/file.pdf',
+              uploadStatus: "success",
+              fileUrl: "https://example.com/file.pdf",
             },
           ],
         },
       });
 
-      fireEvent.click(screen.getByTestId('submit-btn'));
+      fireEvent.click(screen.getByTestId("submit-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -8583,28 +8911,30 @@ describe('Chat', () => {
     });
   });
 
-  describe('chat-action query params', () => {
-    it('should handle voice-call chat action with dialog confirmation', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("chat-action query params", () => {
+    it("should handle voice-call chat action with dialog confirmation", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8615,38 +8945,40 @@ describe('Chat', () => {
 
       // Dialog should be shown
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Confirm the dialog
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
 
-    it('should handle cancel in voice call confirmation dialog', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should handle cancel in voice call confirmation dialog", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8656,40 +8988,44 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Cancel the dialog
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Voice Call')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Voice Call"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('screen share confirmation dialog', () => {
-    it('should handle screen share confirmation dialog', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("screen share confirmation dialog", () => {
+    it("should handle screen share confirmation dialog", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8699,38 +9035,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Confirm the dialog
-      fireEvent.click(screen.getByText('Confirm'));
+      fireEvent.click(screen.getByText("Confirm"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
     });
 
-    it('should handle cancel in screen share confirmation dialog', async () => {
-      const { useSearchParams } = await import('next/navigation');
+    it("should handle cancel in screen share confirmation dialog", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -8740,53 +9080,68 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Cancel the dialog
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       await waitFor(() => {
-        expect(screen.queryByText('Confirm Screen Sharing')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Confirm Screen Sharing"),
+        ).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('scroll to bottom button', () => {
-    it('should show scroll to bottom button when scrolled up with messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll to bottom button", () => {
+    it("should show scroll to bottom button when scrolled up with messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
-          { role: 'user', content: 'Hello', id: 1 },
-          { role: 'assistant', content: 'Hi there', id: 2 },
+          { role: "user", content: "Hello", id: 1 },
+          { role: "assistant", content: "Hi there", id: 2 },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Get the scrollable container
-      const scrollContainer = container.querySelector('[data-testid="chat-container"]');
+      const scrollContainer = container.querySelector(
+        '[data-testid="chat-container"]',
+      );
       if (scrollContainer) {
         // Simulate scroll up
-        Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, writable: true });
-        Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000, writable: true });
-        Object.defineProperty(scrollContainer, 'clientHeight', { value: 500, writable: true });
+        Object.defineProperty(scrollContainer, "scrollTop", {
+          value: 0,
+          writable: true,
+        });
+        Object.defineProperty(scrollContainer, "scrollHeight", {
+          value: 1000,
+          writable: true,
+        });
+        Object.defineProperty(scrollContainer, "clientHeight", {
+          value: 500,
+          writable: true,
+        });
 
         // Trigger scroll event to set isScrolledUp to true
         fireEvent.scroll(scrollContainer, {
@@ -8799,125 +9154,139 @@ describe('Chat', () => {
       expect(container).toBeInTheDocument();
     });
 
-    it('should not show scroll to bottom button in preview mode', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should not show scroll to bottom button in preview mode", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={true} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={true} />,
+      );
 
       // In preview mode, scroll button should not show even if scrolled up
-      const scrollButton = container.querySelector('button[aria-label*="scroll"]');
+      const scrollButton = container.querySelector(
+        'button[aria-label*="scroll"]',
+      );
       expect(scrollButton).not.toBeInTheDocument();
     });
 
-    it('should not show scroll to bottom button when no messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should not show scroll to bottom button when no messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // With no messages, scroll button should not show
-      const scrollButton = container.querySelector('button[aria-label*="scroll"]');
+      const scrollButton = container.querySelector(
+        'button[aria-label*="scroll"]',
+      );
       expect(scrollButton).not.toBeInTheDocument();
     });
   });
 
-  describe('onReply handler with textarea focus', () => {
-    it('should render component with messages for reply functionality', async () => {
+  describe("onReply handler with textarea focus", () => {
+    it("should render component with messages for reply functionality", async () => {
       const mockMessages = [
-        { role: 'user' as const, content: 'Hello', id: 1 },
-        { role: 'assistant' as const, content: 'Hi there', id: 2 },
+        { role: "user" as const, content: "Hello", id: 1 },
+        { role: "assistant" as const, content: "Hi there", id: 2 },
       ];
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: mockMessages,
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Component should render with messages - onReply is passed to MessageList
       expect(container).toBeInTheDocument();
     });
   });
 
-  describe('useAdvancedChat errorHandler callback', () => {
-    it('should suppress errors when in Tauri offline mode', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  describe("useAdvancedChat errorHandler callback", () => {
+    it("should suppress errors when in Tauri offline mode", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       // Store the errorHandler callback
-      let capturedErrorHandler: ((message: string, error?: Error) => Promise<void>) | null = null;
+      let capturedErrorHandler:
+        | ((message: string, error?: Error) => Promise<void>)
+        | null = null;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedErrorHandler = options.errorHandler;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -8925,7 +9294,9 @@ describe('Chat', () => {
         };
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: false },
       });
@@ -8939,31 +9310,35 @@ describe('Chat', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('should show toast error when not in offline mode', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const { toast } = await import('sonner');
+    it("should show toast error when not in offline mode", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { toast } = await import("sonner");
       const mockToastError = vi.mocked(toast.error);
       mockToastError.mockClear();
 
-      let capturedErrorHandler: ((message: string, error?: Error) => Promise<void>) | null = null;
+      let capturedErrorHandler:
+        | ((message: string, error?: Error) => Promise<void>)
+        | null = null;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedErrorHandler = options.errorHandler;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -8971,7 +9346,9 @@ describe('Chat', () => {
         };
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: true },
       });
@@ -8982,10 +9359,9 @@ describe('Chat', () => {
 
       // Call the error handler - it should call toast.error
       if (capturedErrorHandler) {
-        await (capturedErrorHandler as (msg: string, err?: Error) => Promise<void>)(
-          'Test error message',
-          new Error('test'),
-        );
+        await (
+          capturedErrorHandler as (msg: string, err?: Error) => Promise<void>
+        )("Test error message", new Error("test"));
       }
 
       // Verify console.error was called with the error
@@ -8997,31 +9373,35 @@ describe('Chat', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('should handle error handler without error object', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const { toast } = await import('sonner');
+    it("should handle error handler without error object", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { toast } = await import("sonner");
       const mockToastError = vi.mocked(toast.error);
       mockToastError.mockClear();
 
-      let capturedErrorHandler: ((message: string, error?: Error) => Promise<void>) | null = null;
+      let capturedErrorHandler:
+        | ((message: string, error?: Error) => Promise<void>)
+        | null = null;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedErrorHandler = options.errorHandler;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -9029,7 +9409,9 @@ describe('Chat', () => {
         };
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: true },
       });
@@ -9040,9 +9422,9 @@ describe('Chat', () => {
 
       // Call the error handler without an error object
       if (capturedErrorHandler) {
-        await (capturedErrorHandler as (msg: string, err?: Error) => Promise<void>)(
-          'Test error message without error object',
-        );
+        await (
+          capturedErrorHandler as (msg: string, err?: Error) => Promise<void>
+        )("Test error message without error object");
       }
 
       // Verify console.error was NOT called (no error object)
@@ -9055,15 +9437,17 @@ describe('Chat', () => {
     });
   });
 
-  describe('useMentorTools errorHandler callback', () => {
-    it('should show toast error and log to console', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  describe("useMentorTools errorHandler callback", () => {
+    it("should show toast error and log to console", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       let capturedMentorToolsErrorHandler:
         | ((message: string, error?: Error) => Promise<void>)
         | null = null;
 
-      const { useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useMentorTools } = await import("@iblai/iblai-js/web-utils");
       (useMentorTools as any).mockImplementation((options: any) => {
         capturedMentorToolsErrorHandler = options.errorHandler;
         return {
@@ -9087,24 +9471,28 @@ describe('Chat', () => {
       expect(capturedMentorToolsErrorHandler).toBeDefined();
 
       if (capturedMentorToolsErrorHandler) {
-        await (capturedMentorToolsErrorHandler as (msg: string, err?: Error) => Promise<void>)(
-          'Mentor tools error',
-          new Error('tool error'),
-        );
+        await (
+          capturedMentorToolsErrorHandler as (
+            msg: string,
+            err?: Error,
+          ) => Promise<void>
+        )("Mentor tools error", new Error("tool error"));
       }
 
       expect(consoleErrorSpy).toHaveBeenCalled();
       consoleErrorSpy.mockRestore();
     });
 
-    it('should handle error without error object', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it("should handle error without error object", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       let capturedMentorToolsErrorHandler:
         | ((message: string, error?: Error) => Promise<void>)
         | null = null;
 
-      const { useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useMentorTools } = await import("@iblai/iblai-js/web-utils");
       (useMentorTools as any).mockImplementation((options: any) => {
         capturedMentorToolsErrorHandler = options.errorHandler;
         return {
@@ -9129,9 +9517,12 @@ describe('Chat', () => {
 
       if (capturedMentorToolsErrorHandler) {
         // Call without error object
-        await (capturedMentorToolsErrorHandler as (msg: string, err?: Error) => Promise<void>)(
-          'Mentor tools error without details',
-        );
+        await (
+          capturedMentorToolsErrorHandler as (
+            msg: string,
+            err?: Error,
+          ) => Promise<void>
+        )("Mentor tools error without details");
       }
 
       // console.error should NOT be called when there's no error object
@@ -9140,28 +9531,28 @@ describe('Chat', () => {
     });
   });
 
-  describe('onStartNewChat callback', () => {
-    it('should dispatch updateSessionIds and save to cache when called', async () => {
+  describe("onStartNewChat callback", () => {
+    it("should dispatch updateSessionIds and save to cache when called", async () => {
       let capturedOnStartNewChat: ((sessionId: string) => void) | null = null;
       const mockSaveCachedSessionId = vi.fn();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedOnStartNewChat = options.onStartNewChat;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -9169,7 +9560,7 @@ describe('Chat', () => {
         };
       });
 
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
       (useLocalStorage as any).mockReturnValue([{}, mockSaveCachedSessionId]);
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
@@ -9178,7 +9569,9 @@ describe('Chat', () => {
 
       // Call the callback
       if (capturedOnStartNewChat) {
-        (capturedOnStartNewChat as (sessionId: string) => void)('new-session-456');
+        (capturedOnStartNewChat as (sessionId: string) => void)(
+          "new-session-456",
+        );
       }
 
       // Verify saveCachedSessionId was called with the new session
@@ -9186,27 +9579,27 @@ describe('Chat', () => {
     });
   });
 
-  describe('onOfflineWithoutLocalLLM callback', () => {
-    it('should be passed to useAdvancedChat', async () => {
+  describe("onOfflineWithoutLocalLLM callback", () => {
+    it("should be passed to useAdvancedChat", async () => {
       let capturedOnOfflineCallback: (() => void) | null = null;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedOnOfflineCallback = options.onOfflineWithoutLocalLLM;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -9221,27 +9614,27 @@ describe('Chat', () => {
     });
   });
 
-  describe('isOffline prop to useAdvancedChat', () => {
-    it('should pass isOffline as true when service worker reports offline in Tauri', async () => {
+  describe("isOffline prop to useAdvancedChat", () => {
+    it("should pass isOffline as true when service worker reports offline in Tauri", async () => {
       let capturedIsOffline: boolean | undefined = undefined;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedIsOffline = options.isOffline;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -9249,7 +9642,9 @@ describe('Chat', () => {
         };
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: false },
       });
@@ -9262,120 +9657,126 @@ describe('Chat', () => {
     });
   });
 
-  describe('loading indicator visibility', () => {
-    it('should render component when streaming without content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator visibility", () => {
+    it("should render component when streaming without content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Component should render when isStreaming is true
       expect(container).toBeInTheDocument();
     });
 
-    it('should render when last message has artifact versions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render when last message has artifact versions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
-          { role: 'user', content: 'Hello', id: 1 },
+          { role: "user", content: "Hello", id: 1 },
           {
-            role: 'assistant',
-            content: '',
+            role: "assistant",
+            content: "",
             id: 2,
-            artifactVersions: [{ id: 1, content: 'code' }],
+            artifactVersions: [{ id: 1, content: "code" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Component should render - loading indicator is suppressed when last message has artifactVersions
       expect(container).toBeInTheDocument();
     });
 
-    it('should render component when isPending is true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render component when isPending is true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Component should render when isPending is true
       expect(container).toBeInTheDocument();
     });
   });
 
-  describe('eventBus handlers', () => {
-    it('should register newChat event handler on mount', async () => {
-      const eventBusMock = await import('@/lib/eventBus');
+  describe("eventBus handlers", () => {
+    it("should register newChat event handler on mount", async () => {
+      const eventBusMock = await import("@/lib/eventBus");
       vi.mocked(eventBusMock.default.on).mockClear();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9386,29 +9787,32 @@ describe('Chat', () => {
 
       // Verify eventBus.on was called for newChat
       await waitFor(() => {
-        expect(eventBusMock.default.on).toHaveBeenCalledWith('newChat', expect.any(Function));
+        expect(eventBusMock.default.on).toHaveBeenCalledWith(
+          "newChat",
+          expect.any(Function),
+        );
       });
     });
 
-    it('should register stopChatGenerating event handler on mount', async () => {
-      const eventBusMock = await import('@/lib/eventBus');
+    it("should register stopChatGenerating event handler on mount", async () => {
+      const eventBusMock = await import("@/lib/eventBus");
       vi.mocked(eventBusMock.default.on).mockClear();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9420,33 +9824,33 @@ describe('Chat', () => {
       // Verify eventBus.on was called for stopChatGenerating
       await waitFor(() => {
         expect(eventBusMock.default.on).toHaveBeenCalledWith(
-          'stopChatGenerating',
+          "stopChatGenerating",
           expect.any(Function),
         );
       });
     });
 
-    it('should call startNewChat when newChat handler is triggered', async () => {
-      const eventBusMock = await import('@/lib/eventBus');
+    it("should call startNewChat when newChat handler is triggered", async () => {
+      const eventBusMock = await import("@/lib/eventBus");
       const mockOn = vi.mocked(eventBusMock.default.on);
       mockOn.mockClear();
       const mockStartNewChat = vi.fn();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: mockStartNewChat,
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9457,11 +9861,11 @@ describe('Chat', () => {
 
       // Get the newChat handler that was registered
       await waitFor(() => {
-        expect(mockOn).toHaveBeenCalledWith('newChat', expect.any(Function));
+        expect(mockOn).toHaveBeenCalledWith("newChat", expect.any(Function));
       });
 
       const newChatHandler = (mockOn.mock.calls as [string, () => void][]).find(
-        (call) => call[0] === 'newChat',
+        (call) => call[0] === "newChat",
       )?.[1];
 
       // Call the handler manually
@@ -9472,27 +9876,27 @@ describe('Chat', () => {
       expect(mockStartNewChat).toHaveBeenCalled();
     });
 
-    it('should call stopGenerating when stopChatGenerating handler is triggered', async () => {
-      const eventBusMock = await import('@/lib/eventBus');
+    it("should call stopGenerating when stopChatGenerating handler is triggered", async () => {
+      const eventBusMock = await import("@/lib/eventBus");
       const mockOn = vi.mocked(eventBusMock.default.on);
       mockOn.mockClear();
       const mockStopGenerating = vi.fn();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: mockStopGenerating,
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9503,11 +9907,14 @@ describe('Chat', () => {
 
       // Get the stopChatGenerating handler that was registered
       await waitFor(() => {
-        expect(mockOn).toHaveBeenCalledWith('stopChatGenerating', expect.any(Function));
+        expect(mockOn).toHaveBeenCalledWith(
+          "stopChatGenerating",
+          expect.any(Function),
+        );
       });
 
       const stopHandler = (mockOn.mock.calls as [string, () => void][]).find(
-        (call) => call[0] === 'stopChatGenerating',
+        (call) => call[0] === "stopChatGenerating",
       )?.[1];
 
       // Call the handler manually
@@ -9519,23 +9926,23 @@ describe('Chat', () => {
     });
   });
 
-  describe('window resize handler for isMdUp', () => {
-    it('should update isMdUp state on window resize', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("window resize handler for isMdUp", () => {
+    it("should update isMdUp state on window resize", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9543,42 +9950,53 @@ describe('Chat', () => {
       });
 
       // Start with desktop width
-      Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+      Object.defineProperty(window, "innerWidth", {
+        value: 1024,
+        writable: true,
+      });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Resize to mobile
-      Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
-      fireEvent(window, new Event('resize'));
+      Object.defineProperty(window, "innerWidth", {
+        value: 500,
+        writable: true,
+      });
+      fireEvent(window, new Event("resize"));
 
       // The component should still render
       expect(container).toBeInTheDocument();
 
       // Resize back to desktop
-      Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
-      fireEvent(window, new Event('resize'));
+      Object.defineProperty(window, "innerWidth", {
+        value: 1024,
+        writable: true,
+      });
+      fireEvent(window, new Event("resize"));
 
       expect(container).toBeInTheDocument();
     });
   });
 
-  describe('mentorAccessibilityMessage updates', () => {
-    it('should set accessibility message when streaming starts', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("mentorAccessibilityMessage updates", () => {
+    it("should set accessibility message when streaming starts", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9589,33 +10007,33 @@ describe('Chat', () => {
 
       // The accessibility message should indicate streaming
       await waitFor(() => {
-        const srOnlyElements = screen.getAllByRole('status');
+        const srOnlyElements = screen.getAllByRole("status");
         const accessibilityStatus = srOnlyElements.find((el) =>
-          el.textContent?.includes('generating a response'),
+          el.textContent?.includes("generating a response"),
         );
         expect(accessibilityStatus).toBeInTheDocument();
       });
     });
 
-    it('should set accessibility message with assistant response when streaming ends', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should set accessibility message with assistant response when streaming ends", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
-          { role: 'user', content: 'Hello', id: 1 },
-          { role: 'assistant', content: 'Hi there, how can I help?', id: 2 },
+          { role: "user", content: "Hello", id: 1 },
+          { role: "assistant", content: "Hi there, how can I help?", id: 2 },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9626,31 +10044,35 @@ describe('Chat', () => {
 
       // The accessibility message should contain the assistant's response
       await waitFor(() => {
-        const srOnlyElements = screen.getAllByRole('status');
-        const accessibilityStatus = srOnlyElements.find((el) => el.textContent?.includes('says:'));
+        const srOnlyElements = screen.getAllByRole("status");
+        const accessibilityStatus = srOnlyElements.find((el) =>
+          el.textContent?.includes("says:"),
+        );
         expect(accessibilityStatus).toBeInTheDocument();
       });
     });
   });
 
-  describe('handleCloseCanvas', () => {
-    it('should provide handleCloseCanvas callback to component', async () => {
+  describe("handleCloseCanvas", () => {
+    it("should provide handleCloseCanvas callback to component", async () => {
       // This test verifies the component renders with canvas capabilities
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9672,35 +10094,37 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="advanced" isPreviewMode={false} />,
+      );
 
       // The component should render correctly with canvas capabilities
       expect(container).toBeInTheDocument();
     });
   });
 
-  describe('newChat event with showingSharedChat', () => {
-    it('should register newChat handler that calls startNewChat', async () => {
-      const eventBusMock = await import('@/lib/eventBus');
+  describe("newChat event with showingSharedChat", () => {
+    it("should register newChat handler that calls startNewChat", async () => {
+      const eventBusMock = await import("@/lib/eventBus");
       const mockOn = vi.mocked(eventBusMock.default.on);
       mockOn.mockClear();
       const mockStartNewChat = vi.fn();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: mockStartNewChat,
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9711,12 +10135,12 @@ describe('Chat', () => {
 
       // Verify the handler was registered
       await waitFor(() => {
-        expect(mockOn).toHaveBeenCalledWith('newChat', expect.any(Function));
+        expect(mockOn).toHaveBeenCalledWith("newChat", expect.any(Function));
       });
 
       // Get and invoke the handler
       const handler = (mockOn.mock.calls as [string, () => void][]).find(
-        (call) => call[0] === 'newChat',
+        (call) => call[0] === "newChat",
       )?.[1];
       if (handler) {
         handler();
@@ -9726,146 +10150,166 @@ describe('Chat', () => {
     });
   });
 
-  describe('Tauri offline mode detection', () => {
-    it('should handle offline server origin (localhost:3456)', async () => {
+  describe("Tauri offline mode detection", () => {
+    it("should handle offline server origin (localhost:3456)", async () => {
       // Store original location
       const originalLocation = window.location;
 
       // Mock location to be offline server
-      Object.defineProperty(window, 'location', {
-        value: { ...originalLocation, origin: 'http://localhost:3456' },
+      Object.defineProperty(window, "location", {
+        value: { ...originalLocation, origin: "http://localhost:3456" },
         writable: true,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
       // Restore original location
-      Object.defineProperty(window, 'location', {
+      Object.defineProperty(window, "location", {
         value: originalLocation,
         writable: true,
       });
     });
 
-    it('should handle navigator offline state', async () => {
+    it("should handle navigator offline state", async () => {
       // Mock navigator.onLine to be false
-      const originalOnLine = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      const originalOnLine = Object.getOwnPropertyDescriptor(
+        Navigator.prototype,
+        "onLine",
+      );
+      Object.defineProperty(navigator, "onLine", {
+        value: false,
+        configurable: true,
+      });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
       // Restore original
       if (originalOnLine) {
-        Object.defineProperty(navigator, 'onLine', originalOnLine);
+        Object.defineProperty(navigator, "onLine", originalOnLine);
       }
     });
   });
 
-  describe('window resize handler cleanup', () => {
-    it('should add and remove resize listener', async () => {
-      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
-      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+  describe("window resize handler cleanup", () => {
+    it("should add and remove resize listener", async () => {
+      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { unmount } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { unmount } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Check that resize listener was added
-      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function),
+      );
 
       // Unmount and check cleanup
       unmount();
 
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function),
+      );
 
       addEventListenerSpy.mockRestore();
       removeEventListenerSpy.mockRestore();
     });
   });
 
-  describe('canvas event listeners cleanup', () => {
-    it('should add canvas event listeners', async () => {
-      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+  describe("canvas event listeners cleanup", () => {
+    it("should add canvas event listeners", async () => {
+      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
 
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -9892,10 +10336,10 @@ describe('Chat', () => {
       // Check that canvas-related listeners were added
       const canvasEventCalls = addEventListenerSpy.mock.calls.filter(
         (call) =>
-          call[0] === 'canvas-active' ||
-          call[0] === 'canvas-inactive' ||
-          call[0] === 'artifact-update' ||
-          call[0] === 'artifact-title-updated',
+          call[0] === "canvas-active" ||
+          call[0] === "canvas-inactive" ||
+          call[0] === "artifact-update" ||
+          call[0] === "artifact-title-updated",
       );
 
       expect(canvasEventCalls.length).toBeGreaterThan(0);
@@ -9904,102 +10348,115 @@ describe('Chat', () => {
     });
   });
 
-  describe('chat with streaming content', () => {
-    it('should handle currentStreamingMessage with content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("chat with streaming content", () => {
+    it("should handle currentStreamingMessage with content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
-        currentStreamingMessage: { role: 'assistant', content: 'Streaming response...' },
+        activeTab: "chat",
+        currentStreamingMessage: {
+          role: "assistant",
+          content: "Streaming response...",
+        },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Component should render with streaming content
       expect(container).toBeInTheDocument();
     });
   });
 
-  describe('isAdvancedMode behavior', () => {
-    it('should render builder header in advanced mode', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("isAdvancedMode behavior", () => {
+    it("should render builder header in advanced mode", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'builder',
+        activeTab: "builder",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="advanced" isPreviewMode={false} />,
+      );
 
       // Should render with builder header
       expect(container).toBeInTheDocument();
-      expect(screen.getByTestId('advanced-chat-header')).toBeInTheDocument();
+      expect(screen.getByTestId("advanced-chat-header")).toBeInTheDocument();
     });
   });
 
-  describe('mentorSettings behavior', () => {
-    it('should handle preview mode with visiting tenant', async () => {
-      const { useVisitingTenant } = await import('@/hooks/use-user');
-      (useVisitingTenant as any).mockReturnValue({ visitingTenant: 'other-tenant' });
+  describe("mentorSettings behavior", () => {
+    it("should handle preview mode with visiting tenant", async () => {
+      const { useVisitingTenant } = await import("@/hooks/use-user");
+      (useVisitingTenant as any).mockReturnValue({
+        visitingTenant: "other-tenant",
+      });
 
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PUBLIC',
+          mentorVisibility: "PUBLIC",
         },
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
@@ -10008,29 +10465,213 @@ describe('Chat', () => {
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
     });
   });
 
-  describe('artifact streaming events', () => {
-    it('should handle artifact-stream-start event', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("custom-app query parameter disables preview mode", () => {
+    it("should not activate preview mode when custom-app=true, even with visiting tenant and non-anonymous mentor", async () => {
+      const { useSearchParams } = await import("next/navigation");
+      (useSearchParams as any).mockReturnValue(
+        new URLSearchParams("custom-app=true"),
+      );
+
+      const { useVisitingTenant } = await import("@/hooks/use-user");
+      (useVisitingTenant as any).mockReturnValue({
+        visitingTenant: { key: "other-tenant" },
+      });
+
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      (useMentorSettings as any).mockReturnValue({
+        data: {
+          allowAnonymous: false,
+          mentorVisibility: "PRIVATE",
+        },
+      });
+
+      const { isLoggedIn } = await import("@/lib/utils");
+      (isLoggedIn as any).mockReturnValue(true);
+
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
+        startNewChat: vi.fn(),
+        enableSafetyDisclaimer: false,
+        isPending: false,
+        isLoadingChats: false,
+      });
+
+      renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+
+      // useAdvancedChat should have been called with isPreviewMode: false
+      // because custom-app=true disables the visiting-tenant preview guard
+      expect(useAdvancedChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPreviewMode: false,
+        }),
+      );
+
+      // Reset mocks
+      (useSearchParams as any).mockReturnValue(new URLSearchParams());
+      (useVisitingTenant as any).mockReturnValue({ visitingTenant: null });
+      (isLoggedIn as any).mockReturnValue(true);
+    });
+
+    it("should activate preview mode when custom-app is NOT set, with visiting tenant and non-anonymous mentor", async () => {
+      const { useSearchParams } = await import("next/navigation");
+      (useSearchParams as any).mockReturnValue(new URLSearchParams());
+
+      const { useVisitingTenant } = await import("@/hooks/use-user");
+      (useVisitingTenant as any).mockReturnValue({
+        visitingTenant: { key: "other-tenant" },
+      });
+
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      (useMentorSettings as any).mockReturnValue({
+        data: {
+          allowAnonymous: false,
+          mentorVisibility: "PRIVATE",
+        },
+      });
+
+      const { isLoggedIn } = await import("@/lib/utils");
+      (isLoggedIn as any).mockReturnValue(true);
+
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      (useAdvancedChat as any).mockReturnValue({
+        changeTab: vi.fn(),
+        activeTab: "chat",
+        currentStreamingMessage: null,
+        enabledGuidedPrompts: [],
+        isStreaming: false,
+        mentorName: "Test Mentor",
+        messages: [],
+        profileImage: "/avatar.png",
+        sendMessage: vi.fn(),
+        setMessage: vi.fn(),
+        stopGenerating: vi.fn(),
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
+        startNewChat: vi.fn(),
+        enableSafetyDisclaimer: false,
+        isPending: false,
+        isLoadingChats: false,
+      });
+
+      renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+
+      // useAdvancedChat should have been called with isPreviewMode: true
+      // because visitingTenant + isLoggedIn + !allowAnonymous + no token = preview mode
+      expect(useAdvancedChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPreviewMode: true,
+        }),
+      );
+
+      // Reset mocks
+      (useSearchParams as any).mockReturnValue(new URLSearchParams());
+      (useVisitingTenant as any).mockReturnValue({ visitingTenant: null });
+      (isLoggedIn as any).mockReturnValue(true);
+    });
+
+    it("should not activate preview mode when custom-app=true with embed mode", async () => {
+      const { useSearchParams } = await import("next/navigation");
+      (useSearchParams as any).mockReturnValue(
+        new URLSearchParams("custom-app=true&embed=true"),
+      );
+
+      const { useVisitingTenant } = await import("@/hooks/use-user");
+      (useVisitingTenant as any).mockReturnValue({
+        visitingTenant: { key: "enterprise-tenant" },
+      });
+
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      (useMentorSettings as any).mockReturnValue({
+        data: {
+          allowAnonymous: false,
+          mentorVisibility: "VIEWABLE_BY_TENANT_ADMINS",
+        },
+      });
+
+      const { isLoggedIn } = await import("@/lib/utils");
+      (isLoggedIn as any).mockReturnValue(true);
+
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      (useAdvancedChat as any).mockReturnValue({
+        changeTab: vi.fn(),
+        activeTab: "chat",
+        currentStreamingMessage: null,
+        enabledGuidedPrompts: [],
+        isStreaming: false,
+        mentorName: "Test Mentor",
+        messages: [],
+        profileImage: "/avatar.png",
+        sendMessage: vi.fn(),
+        setMessage: vi.fn(),
+        stopGenerating: vi.fn(),
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
+        startNewChat: vi.fn(),
+        enableSafetyDisclaimer: false,
+        isPending: false,
+        isLoadingChats: false,
+      });
+
+      renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+
+      // custom-app=true should still bypass preview even with embed=true
+      expect(useAdvancedChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPreviewMode: false,
+        }),
+      );
+
+      // Reset mocks
+      (useSearchParams as any).mockReturnValue(new URLSearchParams());
+      (useVisitingTenant as any).mockReturnValue({ visitingTenant: null });
+      (isLoggedIn as any).mockReturnValue(true);
+    });
+  });
+
+  describe("artifact streaming events", () => {
+    it("should handle artifact-stream-start event", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      (useAdvancedChat as any).mockReturnValue({
+        changeTab: vi.fn(),
+        activeTab: "chat",
+        currentStreamingMessage: null,
+        enabledGuidedPrompts: [],
+        isStreaming: false,
+        mentorName: "Test Mentor",
+        messages: [],
+        profileImage: "/avatar.png",
+        sendMessage: vi.fn(),
+        setMessage: vi.fn(),
+        stopGenerating: vi.fn(),
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10056,31 +10697,33 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-start event
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
-          detail: { id: 1, sessionId: 'session-123' },
+        new CustomEvent("artifact-stream-start", {
+          detail: { id: 1, sessionId: "session-123" },
         }),
       );
 
       // Component should handle the event
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
 
-    it('should handle artifact-stream-end event', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-end event", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10106,53 +10749,57 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-end event
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
-          detail: { id: 1, sessionId: 'session-123' },
+        new CustomEvent("artifact-stream-end", {
+          detail: { id: 1, sessionId: "session-123" },
         }),
       );
 
       // Component should handle the event
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('user agreement handling', () => {
-    it('should handle enableSafetyDisclaimer when true', async () => {
+  describe("user agreement handling", () => {
+    it("should handle enableSafetyDisclaimer when true", async () => {
       const mockHandleDisclaimerAgree = vi.fn().mockResolvedValue(undefined);
 
-      const { useUserAgreement } = await import('@/hooks/use-user-agreement');
+      const { useUserAgreement } = await import("@/hooks/use-user-agreement");
       (useUserAgreement as any).mockReturnValue({
         showDisclaimerModal: false,
         isAgreeing: false,
-        userAgreement: { content: 'Test agreement' },
+        userAgreement: { content: "Test agreement" },
         hasUserAgreement: true,
         handleDisclaimerAgree: mockHandleDisclaimerAgree,
-        checkAgreementAndExecute: vi.fn((content: string, fn: (c: string) => void) => fn(content)),
+        checkAgreementAndExecute: vi.fn(
+          (content: string, fn: (c: string) => void) => fn(content),
+        ),
         executePendingSubmit: vi.fn(),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: true,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
@@ -10163,39 +10810,46 @@ describe('Chat', () => {
         userAgreement: null,
         hasUserAgreement: false,
         handleDisclaimerAgree: vi.fn(),
-        checkAgreementAndExecute: vi.fn((content: string, fn: (c: string) => void) => fn(content)),
+        checkAgreementAndExecute: vi.fn(
+          (content: string, fn: (c: string) => void) => fn(content),
+        ),
         executePendingSubmit: vi.fn(),
       });
     });
   });
 
-  describe('cached session ID handling', () => {
-    it('should use cached session ID when available', async () => {
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
-      (useLocalStorage as any).mockReturnValue([{ 'mentor-123': 'cached-session-456' }, vi.fn()]);
+  describe("cached session ID handling", () => {
+    it("should use cached session ID when available", async () => {
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
+      (useLocalStorage as any).mockReturnValue([
+        { "mentor-123": "cached-session-456" },
+        vi.fn(),
+      ]);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
@@ -10204,38 +10858,40 @@ describe('Chat', () => {
     });
   });
 
-  describe('mentorId from query param', () => {
-    it('should handle mentorId from search params', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("mentorId from query param", () => {
+    it("should handle mentorId from search params", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
         get: vi.fn((param: string) => {
-          if (param === 'mentor') return 'query-mentor-id';
+          if (param === "mentor") return "query-mentor-id";
           return null;
         }),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
@@ -10246,23 +10902,25 @@ describe('Chat', () => {
     });
   });
 
-  describe('artifact stream with isUpdate', () => {
-    it('should handle artifact stream start with isUpdate true', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream with isUpdate", () => {
+    it("should handle artifact stream start with isUpdate true", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10288,30 +10946,32 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-start with isUpdate=true
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
-          detail: { id: 1, sessionId: 'session-123', isUpdate: true },
+        new CustomEvent("artifact-stream-start", {
+          detail: { id: 1, sessionId: "session-123", isUpdate: true },
         }),
       );
 
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
 
-    it('should handle artifact stream end with isUpdate true', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact stream end with isUpdate true", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10337,37 +10997,39 @@ describe('Chat', () => {
 
       // Dispatch artifact-stream-end with isUpdate=true
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             id: 1,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: true,
-            content: 'Updated content',
+            content: "Updated content",
           },
         }),
       );
 
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('artifact stream with artifactId', () => {
-    it('should handle artifact stream start with new artifact (no isUpdate)', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream with artifactId", () => {
+    it("should handle artifact stream start with new artifact (no isUpdate)", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10390,111 +11052,118 @@ describe('Chat', () => {
       });
 
       // Set desktop width for canvas to show
-      Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+      Object.defineProperty(window, "innerWidth", {
+        value: 1024,
+        writable: true,
+      });
 
       renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start with artifactId (new artifact)
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 123,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
-            title: 'New Artifact',
+            title: "New Artifact",
           },
         }),
       );
 
       // Wait for canvas to potentially open
       await waitFor(() => {
-        expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+        expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
       });
     });
   });
 
-  describe('requireUserToJoinTenantOnChat', () => {
-    it('should show join prompt when user is not member of tenant', async () => {
+  describe("requireUserToJoinTenantOnChat", () => {
+    it("should show join prompt when user is not member of tenant", async () => {
       const mockUserTenants = vi.fn(() => ({
-        userTenants: [{ key: 'other-tenant' }],
+        userTenants: [{ key: "other-tenant" }],
       }));
-      const { useUserTenants } = await import('@/hooks/use-user');
+      const { useUserTenants } = await import("@/hooks/use-user");
       (useUserTenants as any).mockReturnValue(mockUserTenants());
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
       // Reset mock
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'test-tenant' }],
+        userTenants: [{ key: "test-tenant" }],
       });
     });
   });
 
-  describe('messages reset handling', () => {
-    it('should reset scroll state when messages are cleared', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("messages reset handling", () => {
+    it("should reset scroll state when messages are cleared", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       // First render with messages
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
-        messages: [{ role: 'user', content: 'Hello', id: 1 }],
-        profileImage: '/avatar.png',
+        mentorName: "Test Mentor",
+        messages: [{ role: "user", content: "Hello", id: 1 }],
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Rerender with no messages
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10508,30 +11177,30 @@ describe('Chat', () => {
       );
 
       // Component should handle the state change
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('embedMode handling', () => {
-    it('should show chat input in embed mode even without messages', async () => {
-      const { useEmbedMode } = await import('@/hooks/use-embed-mode');
+  describe("embedMode handling", () => {
+    it("should show chat input in embed mode even without messages", async () => {
+      const { useEmbedMode } = await import("@/hooks/use-embed-mode");
       (useEmbedMode as any).mockReturnValue(true);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10541,36 +11210,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Chat input should be shown in embed mode
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
 
       // Reset mock
       (useEmbedMode as any).mockReturnValue(false);
     });
   });
 
-  describe('guided prompts visibility', () => {
-    it('should show guided prompts when enabled', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("guided prompts visibility", () => {
+    it("should show guided prompts when enabled", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [
-          { id: '1', text: 'Prompt 1' },
-          { id: '2', text: 'Prompt 2' },
+          { id: "1", text: "Prompt 1" },
+          { id: "2", text: "Prompt 2" },
         ],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
-          { role: 'user', content: 'Hello', id: 1 },
-          { role: 'assistant', content: 'Hi', id: 2 },
+          { role: "user", content: "Hello", id: 1 },
+          { role: "assistant", content: "Hi", id: 2 },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10580,41 +11249,43 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Guided prompts component should be rendered
-      expect(screen.getByTestId('guided-prompts')).toBeInTheDocument();
+      expect(screen.getByTestId("guided-prompts")).toBeInTheDocument();
     });
   });
 
-  describe('Tauri app detection', () => {
-    it('should detect Tauri app when __TAURI__ is in window', async () => {
+  describe("Tauri app detection", () => {
+    it("should detect Tauri app when __TAURI__ is in window", async () => {
       // Add __TAURI__ to window to simulate Tauri app
-      Object.defineProperty(window, '__TAURI__', {
+      Object.defineProperty(window, "__TAURI__", {
         value: {},
         writable: true,
         configurable: true,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
@@ -10622,128 +11293,143 @@ describe('Chat', () => {
       delete (window as unknown as Record<string, unknown>).__TAURI__;
     });
 
-    it('should handle Tauri offline mode flag', async () => {
+    it("should handle Tauri offline mode flag", async () => {
       // Set up Tauri offline mode
-      Object.defineProperty(window, '__TAURI__', {
+      Object.defineProperty(window, "__TAURI__", {
         value: {},
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(window, '__TAURI_OFFLINE_MODE__', {
+      Object.defineProperty(window, "__TAURI_OFFLINE_MODE__", {
         value: true,
         writable: true,
         configurable: true,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: false },
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
-      delete (window as unknown as Record<string, unknown>).__TAURI_OFFLINE_MODE__;
+      delete (window as unknown as Record<string, unknown>)
+        .__TAURI_OFFLINE_MODE__;
     });
 
-    it('should handle Tauri offline mode via localStorage', async () => {
+    it("should handle Tauri offline mode via localStorage", async () => {
       // Set up Tauri with localStorage offline mode
-      Object.defineProperty(window, '__TAURI__', {
+      Object.defineProperty(window, "__TAURI__", {
         value: {},
         writable: true,
         configurable: true,
       });
-      localStorage.setItem('tauri_offline_mode', 'true');
+      localStorage.setItem("tauri_offline_mode", "true");
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       expect(container).toBeInTheDocument();
 
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
-      localStorage.removeItem('tauri_offline_mode');
+      localStorage.removeItem("tauri_offline_mode");
     });
   });
 
-  describe('error handler with Tauri offline suppression', () => {
-    it('should suppress errors when in Tauri app and offline', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  describe("error handler with Tauri offline suppression", () => {
+    it("should suppress errors when in Tauri app and offline", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       // Set up Tauri environment
-      Object.defineProperty(window, '__TAURI__', {
+      Object.defineProperty(window, "__TAURI__", {
         value: {},
         writable: true,
         configurable: true,
       });
 
       // Mock navigator.onLine to be false
-      const originalOnLine = Object.getOwnPropertyDescriptor(Navigator.prototype, 'onLine');
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      const originalOnLine = Object.getOwnPropertyDescriptor(
+        Navigator.prototype,
+        "onLine",
+      );
+      Object.defineProperty(navigator, "onLine", {
+        value: false,
+        configurable: true,
+      });
 
-      let capturedErrorHandler: ((message: string, error?: Error) => Promise<void>) | null = null;
+      let capturedErrorHandler:
+        | ((message: string, error?: Error) => Promise<void>)
+        | null = null;
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockImplementation((options: any) => {
         capturedErrorHandler = options.errorHandler;
         return {
           changeTab: vi.fn(),
-          activeTab: 'chat',
+          activeTab: "chat",
           currentStreamingMessage: null,
           enabledGuidedPrompts: [],
           isStreaming: false,
-          mentorName: 'Test Mentor',
+          mentorName: "Test Mentor",
           messages: [],
-          profileImage: '/avatar.png',
+          profileImage: "/avatar.png",
           sendMessage: vi.fn(),
           setMessage: vi.fn(),
           stopGenerating: vi.fn(),
-          uniqueMentorId: 'unique-mentor-123',
-          sessionId: 'session-123',
+          uniqueMentorId: "unique-mentor-123",
+          sessionId: "session-123",
           startNewChat: vi.fn(),
           enableSafetyDisclaimer: false,
           isPending: false,
@@ -10751,7 +11437,9 @@ describe('Chat', () => {
         };
       });
 
-      const { useServiceWorker } = await import('@/components/service-worker-provider');
+      const { useServiceWorker } = await import(
+        "@/components/service-worker-provider"
+      );
       (useServiceWorker as any).mockReturnValue({
         status: { isOnline: false },
       });
@@ -10762,14 +11450,14 @@ describe('Chat', () => {
 
       // Call the error handler
       if (capturedErrorHandler) {
-        await (capturedErrorHandler as (msg: string, err?: Error) => Promise<void>)(
-          'Test error in offline Tauri',
-        );
+        await (
+          capturedErrorHandler as (msg: string, err?: Error) => Promise<void>
+        )("Test error in offline Tauri");
       }
 
       // Verify console.log was called with suppression message
       expect(consoleSpy).toHaveBeenCalledWith(
-        '[offline] Error suppressed in Tauri offline mode:',
+        "[offline] Error suppressed in Tauri offline mode:",
         expect.anything(),
         expect.anything(),
       );
@@ -10777,29 +11465,31 @@ describe('Chat', () => {
       // Clean up
       delete (window as unknown as Record<string, unknown>).__TAURI__;
       if (originalOnLine) {
-        Object.defineProperty(navigator, 'onLine', originalOnLine);
+        Object.defineProperty(navigator, "onLine", originalOnLine);
       }
       consoleSpy.mockRestore();
     });
   });
 
-  describe('canvas with file extensions', () => {
-    it('should handle artifact with code file extension', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas with file extensions", () => {
+    it("should handle artifact with code file extension", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10825,58 +11515,62 @@ describe('Chat', () => {
 
       // Dispatch artifact with Python file extension
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 123,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
-            title: 'code.py',
-            fileExtension: 'py',
+            title: "code.py",
+            fileExtension: "py",
           },
         }),
       );
 
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
   });
 
-  describe('requireUserToJoinTenantOnChat', () => {
-    it('should show join tenant message when logged in user is not in tenant and allowAnonymous is false', async () => {
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("requireUserToJoinTenantOnChat", () => {
+    it("should show join tenant message when logged in user is not in tenant and allowAnonymous is false", async () => {
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       // User is logged in
       (isLoggedIn as any).mockReturnValue(true);
 
       // User is NOT in the tenant
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'other-tenant' }], // Different tenant key
+        userTenants: [{ key: "other-tenant" }], // Different tenant key
       });
 
       // Anonymous is not allowed
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10886,7 +11580,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Submit a message
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         // Should add user message and AI message about joining tenant
@@ -10894,45 +11588,49 @@ describe('Chat', () => {
       });
     });
 
-    it('should show join tenant message with platform name when available', async () => {
-      const { useAdvancedChat, chatActions, useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+    it("should show join tenant message with platform name when available", async () => {
+      const { useAdvancedChat, chatActions, useTenantMetadata } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(true);
 
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'other-tenant' }],
+        userTenants: [{ key: "other-tenant" }],
       });
 
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       // Set platform name
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'My Custom Platform',
+        platformName: "My Custom Platform",
         metadata: { chat_area_size: 800 },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10941,7 +11639,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalled();
@@ -10949,11 +11647,15 @@ describe('Chat', () => {
     });
   });
 
-  describe('handleSubmit with anonymous user', () => {
-    it('should show login prompt when user is not logged in and anonymous is not allowed', async () => {
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("handleSubmit with anonymous user", () => {
+    it("should show login prompt when user is not logged in and anonymous is not allowed", async () => {
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       // User is NOT logged in
       (isLoggedIn as any).mockReturnValue(false);
@@ -10962,24 +11664,24 @@ describe('Chat', () => {
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -10988,7 +11690,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         // Should show login prompt messages
@@ -10996,11 +11698,13 @@ describe('Chat', () => {
       });
     });
 
-    it('should allow submission when user is logged in and in tenant', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+    it("should allow submission when user is logged in and in tenant", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       const mockSendMessage = vi.fn();
 
@@ -11008,30 +11712,30 @@ describe('Chat', () => {
 
       // User IS in the tenant
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'test-tenant' }],
+        userTenants: [{ key: "test-tenant" }],
       });
 
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11040,18 +11744,20 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
       });
     });
 
-    it('should allow submission when allowAnonymous is true even if user not in tenant', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+    it("should allow submission when allowAnonymous is true even if user not in tenant", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       const mockSendMessage = vi.fn();
 
@@ -11059,31 +11765,31 @@ describe('Chat', () => {
 
       // User is NOT in the tenant
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'other-tenant' }],
+        userTenants: [{ key: "other-tenant" }],
       });
 
       // But anonymous is allowed
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: true,
-          mentorVisibility: 'PUBLIC',
+          mentorVisibility: "PUBLIC",
         },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11092,7 +11798,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -11100,47 +11806,49 @@ describe('Chat', () => {
     });
   });
 
-  describe('handleDisclaimerAgreeWithPendingSubmit', () => {
-    it('should call handleDisclaimerAgree and executePendingSubmit when disclaimer is agreed', async () => {
+  describe("handleDisclaimerAgreeWithPendingSubmit", () => {
+    it("should call handleDisclaimerAgree and executePendingSubmit when disclaimer is agreed", async () => {
       const mockHandleDisclaimerAgree = vi.fn().mockResolvedValue(undefined);
       const mockExecutePendingSubmit = vi.fn();
       const mockSendMessage = vi.fn();
 
-      const { useUserAgreement } = await import('@/hooks/use-user-agreement');
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useUserAgreement } = await import("@/hooks/use-user-agreement");
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useUserAgreement as any).mockReturnValue({
         showDisclaimerModal: true,
         isAgreeing: false,
-        userAgreement: { content: 'Test disclaimer content' },
+        userAgreement: { content: "Test disclaimer content" },
         hasUserAgreement: true,
         handleDisclaimerAgree: mockHandleDisclaimerAgree,
-        checkAgreementAndExecute: vi.fn((content: string, fn: (c: string) => void) => fn(content)),
+        checkAgreementAndExecute: vi.fn(
+          (content: string, fn: (c: string) => void) => fn(content),
+        ),
         executePendingSubmit: mockExecutePendingSubmit,
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11151,11 +11859,11 @@ describe('Chat', () => {
 
       // Wait for the disclaimer modal to appear
       await waitFor(() => {
-        expect(screen.getByTestId('disclaimer-modal')).toBeInTheDocument();
+        expect(screen.getByTestId("disclaimer-modal")).toBeInTheDocument();
       });
 
       // Click the agree button
-      fireEvent.click(screen.getByTestId('agree-btn'));
+      fireEvent.click(screen.getByTestId("agree-btn"));
 
       await waitFor(() => {
         expect(mockHandleDisclaimerAgree).toHaveBeenCalled();
@@ -11163,39 +11871,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('onReply callback in canvas split view', () => {
-    it('should set replying message and focus textarea when reply is clicked in canvas view', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply callback in canvas split view", () => {
+    it("should set replying message and focus textarea when reply is clicked in canvas view", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11220,103 +11930,114 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // First open a canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Now try to click reply (in canvas split view)
-      const replyBtn = screen.queryByTestId('reply-btn');
+      const replyBtn = screen.queryByTestId("reply-btn");
       if (replyBtn) {
         fireEvent.click(replyBtn);
       }
     });
   });
 
-  describe('scroll to bottom button in non-canvas view', () => {
-    it('should show scroll to bottom button when scrolled up', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll to bottom button in non-canvas view", () => {
+    it("should show scroll to bottom button when scrolled up", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the chat container and simulate scroll
-      const scrollContainer = container.querySelector('.overflow-y-auto');
+      const scrollContainer = container.querySelector(".overflow-y-auto");
 
       if (scrollContainer) {
         // Mock scroll properties
-        Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, writable: true });
-        Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000, writable: true });
-        Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, writable: true });
+        Object.defineProperty(scrollContainer, "scrollTop", {
+          value: 0,
+          writable: true,
+        });
+        Object.defineProperty(scrollContainer, "scrollHeight", {
+          value: 1000,
+          writable: true,
+        });
+        Object.defineProperty(scrollContainer, "clientHeight", {
+          value: 400,
+          writable: true,
+        });
 
         // Fire scroll event
         fireEvent.scroll(scrollContainer);
       }
     });
 
-    it('should call scrollToBottom when button is clicked', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should call scrollToBottom when button is clicked", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11326,46 +12047,50 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Try to find the scroll button (it only shows when scrolled up)
-      const scrollBtn = screen.queryByRole('button', { name: /scroll to bottom/i });
+      const scrollBtn = screen.queryByRole("button", {
+        name: /scroll to bottom/i,
+      });
       if (scrollBtn) {
         fireEvent.click(scrollBtn);
       }
     });
   });
 
-  describe('normal chat layout ChatMessages onReply', () => {
-    it('should handle reply callback in normal chat layout', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("normal chat layout ChatMessages onReply", () => {
+    it("should handle reply callback in normal chat layout", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11390,7 +12115,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click reply button in the chat messages (normal layout)
-      const replyBtn = screen.getByTestId('reply-btn');
+      const replyBtn = screen.getByTestId("reply-btn");
       fireEvent.click(replyBtn);
 
       // Should set replying message
@@ -11398,39 +12123,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas resize functionality', () => {
-    it('should handle mouse resize interactions in canvas split view', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas resize functionality", () => {
+    it("should handle mouse resize interactions in canvas split view", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11455,14 +12182,14 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Find the resize handle (it has cursor-col-resize class)
-      const resizeHandle = document.querySelector('.cursor-col-resize');
+      const resizeHandle = document.querySelector(".cursor-col-resize");
       if (resizeHandle) {
         // Start resizing
         fireEvent.mouseDown(resizeHandle, { clientX: 500 });
@@ -11475,31 +12202,33 @@ describe('Chat', () => {
       }
     });
 
-    it('should handle resize with parent element', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should handle resize with parent element", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11524,32 +12253,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('artifact stream end with matching streamingArtifactId', () => {
-    it('should clear streaming artifact ID when stream ends', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream end with matching streamingArtifactId", () => {
+    it("should clear streaming artifact ID when stream ends", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11575,26 +12306,26 @@ describe('Chat', () => {
 
       // First trigger artifact-stream-start
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 456,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
-            title: 'Test Artifact',
-            fileExtension: 'txt',
+            title: "Test Artifact",
+            fileExtension: "txt",
           },
         }),
       );
 
       // Then trigger artifact-stream-end with the same artifactId
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 456,
-            title: 'Test Artifact',
-            content: 'Final content',
-            fileExtension: 'txt',
-            sessionId: 'session-123',
+            title: "Test Artifact",
+            content: "Final content",
+            fileExtension: "txt",
+            sessionId: "session-123",
             isUpdate: false,
             isPartial: false,
             versionNumber: 1,
@@ -11606,66 +12337,79 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll button interaction', () => {
-    it('should show scroll to bottom button when user scrolls up in chat with messages', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll button interaction", () => {
+    it("should show scroll to bottom button when user scrolls up in chat with messages", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '3',
-            role: 'user',
-            content: 'How are you?',
+            id: "3",
+            role: "user",
+            content: "How are you?",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
-      const scrollContainer = container.querySelector('.overflow-y-auto');
+      const scrollContainer = container.querySelector(".overflow-y-auto");
 
       if (scrollContainer) {
         // Mock being scrolled up (not at bottom)
-        Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, configurable: true });
-        Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
-        Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+        Object.defineProperty(scrollContainer, "scrollTop", {
+          value: 0,
+          configurable: true,
+        });
+        Object.defineProperty(scrollContainer, "scrollHeight", {
+          value: 2000,
+          configurable: true,
+        });
+        Object.defineProperty(scrollContainer, "clientHeight", {
+          value: 400,
+          configurable: true,
+        });
 
         fireEvent.scroll(scrollContainer);
 
         await waitFor(() => {
-          const scrollBtn = screen.queryByRole('button', { name: /scroll to bottom/i });
+          const scrollBtn = screen.queryByRole("button", {
+            name: /scroll to bottom/i,
+          });
           if (scrollBtn) {
             fireEvent.click(scrollBtn);
           }
@@ -11674,39 +12418,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('onReply in canvas view with promptTextareaRef', () => {
-    it('should attempt to focus prompt textarea when reply is clicked', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply in canvas view with promptTextareaRef", () => {
+    it("should attempt to focus prompt textarea when reply is clicked", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11731,14 +12477,14 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Find and click reply button in the canvas split view
-      const replyBtns = screen.queryAllByTestId('reply-btn');
+      const replyBtns = screen.queryAllByTestId("reply-btn");
       if (replyBtns.length > 0) {
         // Click the reply button - this should trigger setReplyingToMessage and attempt to focus
         fireEvent.click(replyBtns[0]);
@@ -11746,36 +12492,39 @@ describe('Chat', () => {
     });
   });
 
-  describe('chat with messages starting with assistant', () => {
-    it('should filter out first assistant message in welcome display logic', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
-      const { useLocalStorage } = await import('@/hooks/use-local-storage');
+  describe("chat with messages starting with assistant", () => {
+    it("should filter out first assistant message in welcome display logic", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      const { useLocalStorage } = await import("@/hooks/use-local-storage");
 
       // Mock cached session to make isNewSession.current = false
-      (useLocalStorage as any).mockReturnValue([{ 'mentor-123': 'cached-session-id' }, vi.fn()]);
+      (useLocalStorage as any).mockReturnValue([
+        { "mentor-123": "cached-session-id" },
+        vi.fn(),
+      ]);
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'assistant',
-            content: 'Welcome! How can I help?',
+            id: "1",
+            role: "assistant",
+            content: "Welcome! How can I help?",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11786,81 +12535,85 @@ describe('Chat', () => {
 
       // Should still show welcome chat because only message is from assistant
       // and isNewSession.current is false (due to cached session)
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('scroll to bottom button click handler', () => {
-    it('should execute scroll button onClick handler with stopPropagation', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll to bottom button click handler", () => {
+    it("should execute scroll button onClick handler with stopPropagation", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there',
+            id: "2",
+            role: "assistant",
+            content: "Hi there",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '3',
-            role: 'user',
-            content: 'How are you?',
+            id: "3",
+            role: "user",
+            content: "How are you?",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the scrollable container
-      const scrollContainer = container.querySelector('.flex-1.overflow-y-auto');
+      const scrollContainer = container.querySelector(
+        ".flex-1.overflow-y-auto",
+      );
       expect(scrollContainer).toBeInTheDocument();
 
       if (scrollContainer) {
         const mockScrollTo = vi.fn();
         // Set up scroll properties to simulate scrolled up state
-        Object.defineProperty(scrollContainer, 'scrollTop', {
+        Object.defineProperty(scrollContainer, "scrollTop", {
           value: 0,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(scrollContainer, 'scrollHeight', {
+        Object.defineProperty(scrollContainer, "scrollHeight", {
           value: 2000,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(scrollContainer, 'clientHeight', {
+        Object.defineProperty(scrollContainer, "clientHeight", {
           value: 500,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(scrollContainer, 'scrollTo', {
+        Object.defineProperty(scrollContainer, "scrollTo", {
           value: mockScrollTo,
           writable: true,
           configurable: true,
@@ -11875,7 +12628,9 @@ describe('Chat', () => {
       // Wait for state update and button to appear
       await waitFor(
         () => {
-          const scrollButton = screen.queryByRole('button', { name: /scroll to bottom/i });
+          const scrollButton = screen.queryByRole("button", {
+            name: /scroll to bottom/i,
+          });
           if (scrollButton) {
             // Click the button which should call event.stopPropagation and scrollToBottom
             fireEvent.click(scrollButton);
@@ -11888,39 +12643,39 @@ describe('Chat', () => {
     });
   });
 
-  describe('onReply callback execution in different contexts', () => {
-    it('should execute onReply callback without error when promptTextareaRef is null', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply callback execution in different contexts", () => {
+    it("should execute onReply callback without error when promptTextareaRef is null", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there',
+            id: "2",
+            role: "assistant",
+            content: "Hi there",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -11931,98 +12686,102 @@ describe('Chat', () => {
 
       // Click the reply button - this should execute the onReply callback
       // which calls setReplyingToMessage and conditionally calls focus()
-      const replyButton = screen.getByTestId('reply-btn');
+      const replyButton = screen.getByTestId("reply-btn");
 
       // Should not throw when clicking reply (ref.current is null)
       expect(() => fireEvent.click(replyButton)).not.toThrow();
     });
   });
 
-  describe('normal chat view conditional rendering', () => {
-    it('should render ChatMessages in normal chat layout when canvas is closed', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("normal chat view conditional rendering", () => {
+    it("should render ChatMessages in normal chat layout when canvas is closed", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Verify normal chat layout is rendered
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
 
       // Find the chat container with messages
-      const chatContainer = container.querySelector('.flex-1.overflow-y-auto');
+      const chatContainer = container.querySelector(".flex-1.overflow-y-auto");
       expect(chatContainer).toBeInTheDocument();
 
       // Verify accessibility region exists
-      const accessibilityRegion = container.querySelector('[aria-live="polite"]');
+      const accessibilityRegion = container.querySelector(
+        '[aria-live="polite"]',
+      );
       expect(accessibilityRegion).toBeInTheDocument();
     });
 
-    it('should render guided prompts in normal view when not showing shared chat', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should render guided prompts in normal view when not showing shared chat", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
-        enabledGuidedPrompts: ['prompt1', 'prompt2'],
+        enabledGuidedPrompts: ["prompt1", "prompt2"],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12031,36 +12790,36 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('guided-prompts')).toBeInTheDocument();
+      expect(screen.getByTestId("guided-prompts")).toBeInTheDocument();
     });
   });
 
-  describe('loading message visibility in normal chat', () => {
-    it('should show loading message when streaming and no streaming content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading message visibility in normal chat", () => {
+    it("should show loading message when streaming and no streaming content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12069,34 +12828,34 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should hide loading message when streaming message has content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide loading message when streaming message has content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
-        currentStreamingMessage: { content: 'Streaming text...' },
+        activeTab: "chat",
+        currentStreamingMessage: { content: "Streaming text..." },
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12105,42 +12864,42 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
 
-    it('should hide loading message when last message has artifact versions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide loading message when last message has artifact versions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Here is an artifact',
+            id: "2",
+            role: "assistant",
+            content: "Here is an artifact",
             timestamp: new Date().toISOString(),
             visible: true,
             artifactVersions: [{ id: 1, version: 1 }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12150,43 +12909,45 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should be hidden because last message has artifactVersions
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('artifact-title-updated event', () => {
-    it('should update canvas state title when artifact-title-updated event is received for matching artifact', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-title-updated event", () => {
+    it("should update canvas state title when artifact-title-updated event is received for matching artifact", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12212,27 +12973,27 @@ describe('Chat', () => {
 
       // Open canvas with a specific artifact
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 789,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
-            title: 'Original Title',
-            fileExtension: 'txt',
+            title: "Original Title",
+            fileExtension: "txt",
           },
         }),
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch title update event
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 789,
-            title: 'Updated Title',
+            title: "Updated Title",
           },
         }),
       );
@@ -12241,31 +13002,33 @@ describe('Chat', () => {
       // We verify by checking no errors are thrown
     });
 
-    it('should update currentCanvasArtifact when artifact-title-updated event matches', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should update currentCanvasArtifact when artifact-title-updated event matches", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12291,21 +13054,21 @@ describe('Chat', () => {
 
       // Dispatch canvas-active event to set currentCanvasArtifact
       window.dispatchEvent(
-        new CustomEvent('canvas-active', {
+        new CustomEvent("canvas-active", {
           detail: {
             artifactId: 999,
-            title: 'Active Artifact',
-            file_extension: 'txt',
+            title: "Active Artifact",
+            file_extension: "txt",
           },
         }),
       );
 
       // Update the title for the same artifact
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 999,
-            title: 'New Active Title',
+            title: "New Active Title",
           },
         }),
       );
@@ -12313,23 +13076,23 @@ describe('Chat', () => {
       // Verify no errors and state is updated internally
     });
 
-    it('should ignore artifact-title-updated event with missing artifactId or title', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should ignore artifact-title-updated event with missing artifactId or title", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12340,16 +13103,16 @@ describe('Chat', () => {
 
       // Dispatch with missing artifactId
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
-            title: 'Some Title',
+            title: "Some Title",
           },
         }),
       );
 
       // Dispatch with missing title
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 123,
           },
@@ -12360,24 +13123,26 @@ describe('Chat', () => {
     });
   });
 
-  describe('artifact stream end clears streaming artifact ID', () => {
-    it('should clear streamingArtifactId when artifact-stream-end matches the streaming artifact', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact stream end clears streaming artifact ID", () => {
+    it("should clear streamingArtifactId when artifact-stream-end matches the streaming artifact", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true, // Initially streaming
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -12403,30 +13168,30 @@ describe('Chat', () => {
 
       // Start artifact stream - this sets streamingArtifactId
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 555,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
-            title: 'Streaming Artifact',
-            fileExtension: 'py',
+            title: "Streaming Artifact",
+            fileExtension: "py",
           },
         }),
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // End artifact stream with the same ID
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 555,
-            title: 'Streaming Artifact',
+            title: "Streaming Artifact",
             content: 'print("hello")',
-            fileExtension: 'py',
-            sessionId: 'session-123',
+            fileExtension: "py",
+            sessionId: "session-123",
             isUpdate: false,
             isPartial: false,
             versionNumber: 1,
@@ -12439,39 +13204,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('onReply in canvas split view with messages', () => {
-    it('should handle onReply callback in canvas split view with existing messages', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply in canvas split view with messages", () => {
+    it("should handle onReply callback in canvas split view with existing messages", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12496,16 +13263,16 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to switch to split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Find the reply button in the canvas split view (line 1430-1435)
       // This tests the onReply callback which calls setReplyingToMessage
       // and conditionally calls promptTextareaRef.current.focus()
-      const replyButtons = screen.queryAllByTestId('reply-btn');
+      const replyButtons = screen.queryAllByTestId("reply-btn");
 
       // There may be multiple reply buttons - one in the canvas split view area
       if (replyButtons.length > 0) {
@@ -12516,39 +13283,39 @@ describe('Chat', () => {
     });
   });
 
-  describe('normal chat view onReply callback', () => {
-    it('should trigger onReply in normal chat layout at lines 1596-1601', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("normal chat view onReply callback", () => {
+    it("should trigger onReply in normal chat layout at lines 1596-1601", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12559,7 +13326,7 @@ describe('Chat', () => {
 
       // This is the normal chat layout (canvas not open)
       // The onReply callback is at lines 1596-1601
-      const replyButton = screen.getByTestId('reply-btn');
+      const replyButton = screen.getByTestId("reply-btn");
       fireEvent.click(replyButton);
 
       // Should execute the callback which sets replyingToMessage
@@ -12567,24 +13334,26 @@ describe('Chat', () => {
     });
   });
 
-  describe('streaming artifact ID clearing on stream end', () => {
-    it('should clear streamingArtifactId when artifact-stream-end matches the streaming artifact', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("streaming artifact ID clearing on stream end", () => {
+    it("should clear streamingArtifactId when artifact-stream-end matches the streaming artifact", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -12606,19 +13375,21 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       const artifactId = 12345;
 
       // First, dispatch artifact-stream-start to set streamingArtifactId
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-start', {
+          new CustomEvent("artifact-stream-start", {
             detail: {
               artifactId,
-              title: 'Test Artifact',
-              fileExtension: 'txt',
-              sessionId: 'session-123',
+              title: "Test Artifact",
+              fileExtension: "txt",
+              sessionId: "session-123",
               isUpdate: false,
             },
           }),
@@ -12629,13 +13400,13 @@ describe('Chat', () => {
       // This should trigger the setStreamingArtifactId(undefined) call
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-end', {
+          new CustomEvent("artifact-stream-end", {
             detail: {
               artifactId,
-              title: 'Test Artifact',
-              content: 'Final content',
-              fileExtension: 'txt',
-              sessionId: 'session-123',
+              title: "Test Artifact",
+              content: "Final content",
+              fileExtension: "txt",
+              sessionId: "session-123",
               isUpdate: false,
               versionNumber: 1,
             },
@@ -12647,77 +13418,79 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll handler and button functionality', () => {
-    it('should handle scroll event and show button when scrolled up', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll handler and button functionality", () => {
+    it("should handle scroll event and show button when scrolled up", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there',
+            id: "2",
+            role: "assistant",
+            content: "Hi there",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '3',
-            role: 'user',
-            content: 'Question',
+            id: "3",
+            role: "user",
+            content: "Question",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '4',
-            role: 'assistant',
-            content: 'Answer',
+            id: "4",
+            role: "assistant",
+            content: "Answer",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the chat container with onScroll handler
-      const chatContainer = container.querySelector('.flex-1.overflow-y-auto');
+      const chatContainer = container.querySelector(".flex-1.overflow-y-auto");
 
       if (chatContainer) {
         // Define scroll properties that indicate user is scrolled up
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 100,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollHeight', {
+        Object.defineProperty(chatContainer, "scrollHeight", {
           value: 2000,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(chatContainer, 'clientHeight', {
+        Object.defineProperty(chatContainer, "clientHeight", {
           value: 500,
           writable: true,
           configurable: true,
@@ -12735,70 +13508,72 @@ describe('Chat', () => {
       });
     });
 
-    it('should execute button click handler when scroll button is clicked', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should execute button click handler when scroll button is clicked", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Get the chat container
-      const chatContainer = container.querySelector('.flex-1.overflow-y-auto');
+      const chatContainer = container.querySelector(".flex-1.overflow-y-auto");
 
       if (chatContainer) {
         // Create a mock scrollTo function
         const mockScrollTo = vi.fn();
 
         // Set scroll properties
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 50,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollHeight', {
+        Object.defineProperty(chatContainer, "scrollHeight", {
           value: 3000,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(chatContainer, 'clientHeight', {
+        Object.defineProperty(chatContainer, "clientHeight", {
           value: 400,
           writable: true,
           configurable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollTo', {
+        Object.defineProperty(chatContainer, "scrollTo", {
           value: mockScrollTo,
           writable: true,
           configurable: true,
@@ -12812,7 +13587,9 @@ describe('Chat', () => {
         // Wait and check for scroll button
         await waitFor(
           () => {
-            const scrollButton = screen.queryByRole('button', { name: /scroll to bottom/i });
+            const scrollButton = screen.queryByRole("button", {
+              name: /scroll to bottom/i,
+            });
             if (scrollButton) {
               // Click the button - this should call stopPropagation and scrollToBottom
               fireEvent.click(scrollButton);
@@ -12826,40 +13603,42 @@ describe('Chat', () => {
     });
   });
 
-  describe('session change handling', () => {
-    it('should close canvas when sessionId changes while canvas is open', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("session change handling", () => {
+    it("should close canvas when sessionId changes while canvas is open", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       const mockUpdateSessionTools = vi.fn().mockResolvedValue(undefined);
 
-      let sessionId = 'session-1';
+      let sessionId = "session-1";
       const getMockAdvancedChat = () => ({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
+        uniqueMentorId: "unique-mentor-123",
         sessionId,
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
@@ -12884,17 +13663,19 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Change session ID
-      sessionId = 'session-2';
+      sessionId = "session-2";
       (useAdvancedChat as any).mockImplementation(() => getMockAdvancedChat());
 
       // Re-render with new sessionId
@@ -12908,39 +13689,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll restoration in canvas view', () => {
-    it('should restore scroll position when canvas is opened with scroll state', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll restoration in canvas view", () => {
+    it("should restore scroll position when canvas is opened with scroll state", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -12962,10 +13745,12 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Get chat container and mock scrollTo method
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
         (chatContainer as HTMLElement).scrollTo = vi.fn();
       }
@@ -12977,38 +13762,40 @@ describe('Chat', () => {
 
       // Open canvas - the component will try to reset scroll positions
       // We've mocked the scrollTo methods so this should work
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle scroll bounds when target exceeds maxScroll', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should handle scroll bounds when target exceeds maxScroll", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13030,10 +13817,12 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Get chat container and mock scrollTo method
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
         (chatContainer as HTMLElement).scrollTo = vi.fn();
       }
@@ -13044,43 +13833,45 @@ describe('Chat', () => {
       window.scrollTo = vi.fn();
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('session change with artifacts enabled', () => {
-    it('should disable canvas tool when session changes and artifacts are enabled', async () => {
+  describe("session change with artifacts enabled", () => {
+    it("should disable canvas tool when session changes and artifacts are enabled", async () => {
       const mockUpdateSessionTools = vi.fn().mockResolvedValue(undefined);
 
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Create a mock that returns changing sessionId
-      let currentSessionId = 'session-1';
+      let currentSessionId = "session-1";
       const mockAdvancedChatFn = vi.fn(() => ({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
+        uniqueMentorId: "unique-mentor-123",
         sessionId: currentSessionId,
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
@@ -13105,10 +13896,12 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Change sessionId and trigger re-render
-      currentSessionId = 'session-2';
+      currentSessionId = "session-2";
 
       // Re-render with updated session
       rerender(
@@ -13127,40 +13920,46 @@ describe('Chat', () => {
 
       // Wait for effect to run
       await waitFor(() => {
-        expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+        expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
       });
     });
   });
 
-  describe('updateSessionTools error handling', () => {
-    it('should handle error when updateSessionTools fails on session change', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const mockUpdateSessionTools = vi.fn().mockRejectedValue(new Error('Failed to update tools'));
+  describe("updateSessionTools error handling", () => {
+    it("should handle error when updateSessionTools fails on session change", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const mockUpdateSessionTools = vi
+        .fn()
+        .mockRejectedValue(new Error("Failed to update tools"));
 
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
-      let currentSessionId = 'session-1';
+      let currentSessionId = "session-1";
       const mockAdvancedChatFn = vi.fn(() => ({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
+        uniqueMentorId: "unique-mentor-123",
         sessionId: currentSessionId,
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
@@ -13185,10 +13984,12 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Change sessionId
-      currentSessionId = 'session-2';
+      currentSessionId = "session-2";
 
       // Re-render with updated session
       rerender(
@@ -13213,7 +14014,7 @@ describe('Chat', () => {
       // The error should be caught and logged (line 910)
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith(
-          '[Chat] Failed to disable canvas on session change:',
+          "[Chat] Failed to disable canvas on session change:",
           expect.any(Error),
         );
       });
@@ -13222,39 +14023,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll restoration inner branches', () => {
-    it('should call scrollTo with targetChat when within bounds', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll restoration inner branches", () => {
+    it("should call scrollTo with targetChat when within bounds", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13276,30 +14079,32 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find the chat container
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       const mockScrollTo = vi.fn();
 
       if (chatContainer) {
         // Set scroll position in valid range: targetChat (150) <= maxScroll (600)
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 150,
           configurable: true,
           writable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollHeight', {
+        Object.defineProperty(chatContainer, "scrollHeight", {
           value: 1000,
           configurable: true,
           writable: true,
         });
-        Object.defineProperty(chatContainer, 'clientHeight', {
+        Object.defineProperty(chatContainer, "clientHeight", {
           value: 400,
           configurable: true,
           writable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollTo', {
+        Object.defineProperty(chatContainer, "scrollTo", {
           value: mockScrollTo,
           configurable: true,
           writable: true,
@@ -13309,44 +14114,54 @@ describe('Chat', () => {
       // Make parent scrollTop writable
       let el: Element | null = chatContainer?.parentElement ?? null;
       while (el && el !== document.documentElement) {
-        Object.defineProperty(el, 'scrollTop', { value: 0, configurable: true, writable: true });
-        Object.defineProperty(el, 'scrollLeft', { value: 0, configurable: true, writable: true });
+        Object.defineProperty(el, "scrollTop", {
+          value: 0,
+          configurable: true,
+          writable: true,
+        });
+        Object.defineProperty(el, "scrollLeft", {
+          value: 0,
+          configurable: true,
+          writable: true,
+        });
         el = el.parentElement;
       }
 
       // Open canvas - this triggers the scroll restoration logic
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle body scroll reset when body has non-zero scroll', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should handle body scroll reset when body has non-zero scroll", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13369,42 +14184,44 @@ describe('Chat', () => {
       });
 
       // Set body scroll to non-zero
-      Object.defineProperty(document.body, 'scrollTop', {
+      Object.defineProperty(document.body, "scrollTop", {
         value: 100,
         configurable: true,
         writable: true,
       });
-      Object.defineProperty(document.body, 'scrollLeft', {
+      Object.defineProperty(document.body, "scrollLeft", {
         value: 50,
         configurable: true,
         writable: true,
       });
-      Object.defineProperty(document.documentElement, 'scrollTop', {
+      Object.defineProperty(document.documentElement, "scrollTop", {
         value: 100,
         configurable: true,
         writable: true,
       });
-      Object.defineProperty(document.documentElement, 'scrollLeft', {
+      Object.defineProperty(document.documentElement, "scrollLeft", {
         value: 50,
         configurable: true,
         writable: true,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
-      const chatContainer = container.querySelector('.overflow-y-auto');
+      const chatContainer = container.querySelector(".overflow-y-auto");
       if (chatContainer) {
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 150,
           configurable: true,
           writable: true,
         });
-        Object.defineProperty(chatContainer, 'scrollHeight', {
+        Object.defineProperty(chatContainer, "scrollHeight", {
           value: 1000,
           configurable: true,
           writable: true,
         });
-        Object.defineProperty(chatContainer, 'clientHeight', {
+        Object.defineProperty(chatContainer, "clientHeight", {
           value: 400,
           configurable: true,
           writable: true,
@@ -13415,53 +14232,63 @@ describe('Chat', () => {
       // Make parent scrollTop writable with non-zero values
       let el: Element | null = chatContainer?.parentElement ?? null;
       while (el && el !== document.documentElement) {
-        Object.defineProperty(el, 'scrollTop', { value: 50, configurable: true, writable: true });
-        Object.defineProperty(el, 'scrollLeft', { value: 25, configurable: true, writable: true });
+        Object.defineProperty(el, "scrollTop", {
+          value: 50,
+          configurable: true,
+          writable: true,
+        });
+        Object.defineProperty(el, "scrollLeft", {
+          value: 25,
+          configurable: true,
+          writable: true,
+        });
         el = el.parentElement;
       }
 
       // Open canvas - this triggers the scroll reset logic (lines 736-745)
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('onReply with promptTextareaRef focus', () => {
-    it('should attempt to call focus on promptTextareaRef in canvas split view', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply with promptTextareaRef focus", () => {
+    it("should attempt to call focus on promptTextareaRef in canvas split view", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13486,14 +14313,14 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // First open the canvas to enter split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Now click reply in the canvas split view (tests line 1433)
-      const replyButtons = screen.queryAllByTestId('reply-btn');
+      const replyButtons = screen.queryAllByTestId("reply-btn");
       if (replyButtons.length > 0) {
         fireEvent.click(replyButtons[0]);
       }
@@ -13502,38 +14329,44 @@ describe('Chat', () => {
     });
   });
 
-  describe('updateSessionTools error handling', () => {
-    it('should handle updateSessionTools rejection when session changes with artifacts enabled', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const mockRejectedUpdateSessionTools = vi.fn().mockRejectedValue(new Error('Update failed'));
+  describe("updateSessionTools error handling", () => {
+    it("should handle updateSessionTools rejection when session changes with artifacts enabled", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const mockRejectedUpdateSessionTools = vi
+        .fn()
+        .mockRejectedValue(new Error("Update failed"));
 
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // We need to simulate a session change scenario
       // First render with session-1, then session changes to session-2
-      let sessionIdRef = 'session-1';
+      let sessionIdRef = "session-1";
 
       (useAdvancedChat as any).mockImplementation(() => ({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
+        uniqueMentorId: "unique-mentor-123",
         sessionId: sessionIdRef,
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
@@ -13556,10 +14389,12 @@ describe('Chat', () => {
         artifactsEnabled: true,
       });
 
-      const { rerender } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { rerender } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Change session ID
-      sessionIdRef = 'session-2';
+      sessionIdRef = "session-2";
 
       // Force re-render with new session
       rerender(
@@ -13589,7 +14424,7 @@ describe('Chat', () => {
 
       // Verify console.error was called with the error
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[Chat] Failed to disable canvas on session change:',
+        "[Chat] Failed to disable canvas on session change:",
         expect.any(Error),
       );
 
@@ -13597,39 +14432,41 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll restoration branch coverage', () => {
-    it('should handle scroll restoration when maxScroll is greater than 0 and targetChat is within bounds', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll restoration branch coverage", () => {
+    it("should handle scroll restoration when maxScroll is greater than 0 and targetChat is within bounds", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi',
+            id: "2",
+            role: "assistant",
+            content: "Hi",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13656,50 +14493,54 @@ describe('Chat', () => {
       document.documentElement.scrollTo = vi.fn();
       window.scrollTo = vi.fn();
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Get the chat container and mock scroll properties
-      const chatContainer = container.querySelector('.flex-1.overflow-y-auto');
+      const chatContainer = container.querySelector(".flex-1.overflow-y-auto");
       if (chatContainer) {
         (chatContainer as HTMLElement).scrollTo = vi.fn();
       }
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('canvas sendMessage callback', () => {
-    it('should call sendMessage with activeTab when canvas sends message', async () => {
+  describe("canvas sendMessage callback", () => {
+    it("should call sendMessage with activeTab when canvas sends message", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13729,52 +14570,54 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Click send from canvas mock
-      fireEvent.click(screen.getByTestId('canvas-send-btn'));
+      fireEvent.click(screen.getByTestId("canvas-send-btn"));
 
       // Verify sendMessage was called with activeTab
-      expect(mockSendMessage).toHaveBeenCalledWith('chat', 'test message', {});
+      expect(mockSendMessage).toHaveBeenCalledWith("chat", "test message", {});
     });
   });
 
-  describe('chatAreaMaxWidth calculation', () => {
-    it('should use tenant metadata chat_area_size when within valid bounds', async () => {
-      const { useTenantMetadata, useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("chatAreaMaxWidth calculation", () => {
+    it("should use tenant metadata chat_area_size when within valid bounds", async () => {
+      const { useTenantMetadata, useAdvancedChat } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Set metadata to a value that is WITHIN valid bounds (600 <= 700 <= 1200)
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 700 },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13784,32 +14627,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Look for the div with maxWidth style set to 700px
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should use sizeValue (MIN boundary) when exactly at MIN', async () => {
-      const { useTenantMetadata, useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should use sizeValue (MIN boundary) when exactly at MIN", async () => {
+      const { useTenantMetadata, useAdvancedChat } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Test with value exactly at MIN boundary - should return sizeValue, not DEFAULT
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 600 },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13818,32 +14663,34 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should use sizeValue (MAX boundary) when exactly at MAX', async () => {
-      const { useTenantMetadata, useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should use sizeValue (MAX boundary) when exactly at MAX", async () => {
+      const { useTenantMetadata, useAdvancedChat } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Test with value exactly at MAX boundary - should return sizeValue
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 1200 },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13852,32 +14699,34 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
 
-    it('should use sizeValue within valid mid-range', async () => {
-      const { useTenantMetadata, useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should use sizeValue within valid mid-range", async () => {
+      const { useTenantMetadata, useAdvancedChat } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Test with a value in the middle of valid range (e.g., 900)
       (useTenantMetadata as any).mockReturnValue({
-        platformName: 'Test Platform',
+        platformName: "Test Platform",
         metadata: { chat_area_size: 900 },
       });
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13886,35 +14735,35 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('resolveCanvasType function', () => {
-    it('should resolve to code type when toolType is code', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("resolveCanvasType function", () => {
+    it("should resolve to code type when toolType is code", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13924,38 +14773,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click the code canvas button with toolType: 'code'
-      fireEvent.click(screen.getByTestId('open-code-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-code-canvas-btn"));
 
       // Canvas should open
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should resolve to code type based on file extension', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should resolve to code type based on file extension", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -13965,38 +14814,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click the JS file canvas button with fileExtension: 'js'
-      fireEvent.click(screen.getByTestId('open-file-ext-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-file-ext-canvas-btn"));
 
       // Canvas should open with code type
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should resolve to document type for non-code extensions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should resolve to document type for non-code extensions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14006,38 +14855,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click the regular canvas button (non-code type)
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       // Canvas should open with document type
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle artifact-stream-start event with code file extension', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-stream-start event with code file extension", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14047,12 +14896,12 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Dispatch artifact-stream-start with py extension (code file)
-      const event = new CustomEvent('artifact-stream-start', {
+      const event = new CustomEvent("artifact-stream-start", {
         detail: {
           artifactId: 111,
-          title: 'Python File',
-          fileExtension: 'py',
-          sessionId: 'session-123',
+          title: "Python File",
+          fileExtension: "py",
+          sessionId: "session-123",
           isUpdate: false,
         },
       });
@@ -14060,36 +14909,36 @@ describe('Chat', () => {
 
       // Canvas should open
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('resize interaction and user-select prevention', () => {
-    it('should trigger mouse move and mouse up during resize', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("resize interaction and user-select prevention", () => {
+    it("should trigger mouse move and mouse up during resize", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14099,40 +14948,42 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to show split view with resize handle
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // The resize handle has onMouseDown handler to start resizing
       // This tests the resize start functionality - the cleanup function is tested when unmounting
     });
 
-    it('should clean up user-select style when resize ends', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+    it("should clean up user-select style when resize ends", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14157,17 +15008,19 @@ describe('Chat', () => {
       // Store original userSelect value
       const originalUserSelect = document.body.style.userSelect;
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Open canvas to show split view with resize handle
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Find the resize handle (has cursor-col-resize class)
-      const resizeHandle = container.querySelector('.cursor-col-resize');
+      const resizeHandle = container.querySelector(".cursor-col-resize");
       expect(resizeHandle).toBeInTheDocument();
 
       // Start resizing by clicking on the resize handle
@@ -14178,7 +15031,7 @@ describe('Chat', () => {
       });
 
       // Verify userSelect is set to 'none' during resize
-      expect(document.body.style.userSelect).toBe('none');
+      expect(document.body.style.userSelect).toBe("none");
 
       // End resizing by triggering mouseup on window
       // This triggers handleMouseUp which sets isResizing = false
@@ -14193,38 +15046,38 @@ describe('Chat', () => {
     });
   });
 
-  describe('scroll restoration in canvas view', () => {
-    it('should handle scroll position restoration when canvas opens', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll restoration in canvas view", () => {
+    it("should handle scroll position restoration when canvas opens", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi there!',
+            id: "2",
+            role: "assistant",
+            content: "Hi there!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14232,46 +15085,49 @@ describe('Chat', () => {
       });
 
       // Mock window scroll position
-      Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
-      Object.defineProperty(window, 'pageYOffset', { value: 200, writable: true });
+      Object.defineProperty(window, "scrollY", { value: 200, writable: true });
+      Object.defineProperty(window, "pageYOffset", {
+        value: 200,
+        writable: true,
+      });
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // The scroll should be reset when canvas opens
       expect(window.scrollTo).toHaveBeenCalled();
     });
 
-    it('should handle scroll with scrollTop greater than maxScroll', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle scroll with scrollTop greater than maxScroll", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14281,49 +15137,49 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Layout effect should handle scroll position
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('onReply focus handling with textarea ref', () => {
-    it('should attempt to focus promptTextareaRef in canvas split view onReply', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("onReply focus handling with textarea ref", () => {
+    it("should attempt to focus promptTextareaRef in canvas split view onReply", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14333,50 +15189,50 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first to test the canvas split view path
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Click reply button - this tests the onReply callback which tries to focus promptTextareaRef
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
       // The component should handle the reply action without errors
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should trigger onReply in normal chat view with focus attempt', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should trigger onReply in normal chat view with focus attempt", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14386,38 +15242,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click reply button in normal view - tests the normal chat layout onReply path
-      fireEvent.click(screen.getByTestId('reply-btn'));
+      fireEvent.click(screen.getByTestId("reply-btn"));
 
       // The component should handle the reply action
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('scroll reset with scrollable parents', () => {
-    it('should reset scroll on parent elements when canvas opens', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("scroll reset with scrollable parents", () => {
+    it("should reset scroll on parent elements when canvas opens", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14425,12 +15281,12 @@ describe('Chat', () => {
       });
 
       // Set up scroll state on document.body - this will be checked by the while loop
-      Object.defineProperty(document.body, 'scrollTop', {
+      Object.defineProperty(document.body, "scrollTop", {
         value: 100,
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(document.body, 'scrollLeft', {
+      Object.defineProperty(document.body, "scrollLeft", {
         value: 50,
         writable: true,
         configurable: true,
@@ -14439,65 +15295,75 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas - this triggers the useLayoutEffect that resets scroll
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Scroll should be reset
       expect(window.scrollTo).toHaveBeenCalled();
 
       // Clean up
-      Object.defineProperty(document.body, 'scrollTop', {
+      Object.defineProperty(document.body, "scrollTop", {
         value: 0,
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(document.body, 'scrollLeft', {
+      Object.defineProperty(document.body, "scrollLeft", {
         value: 0,
         writable: true,
         configurable: true,
       });
     });
 
-    it('should restore scroll position within valid bounds when canvas opens', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should restore scroll position within valid bounds when canvas opens", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: Array.from({ length: 20 }, (_, i) => ({
           id: String(i + 1),
-          role: i % 2 === 0 ? 'user' : 'assistant',
-          content: `Message ${i + 1}: `.padEnd(500, 'Lorem ipsum '),
+          role: i % 2 === 0 ? "user" : "assistant",
+          content: `Message ${i + 1}: `.padEnd(500, "Lorem ipsum "),
           timestamp: new Date().toISOString(),
           visible: true,
         })),
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find chat container and mock its scroll properties
-      const chatContainer = container.querySelector('[data-testid="chat-container"]');
+      const chatContainer = container.querySelector(
+        '[data-testid="chat-container"]',
+      );
       if (chatContainer) {
         // Mock scrollable content
-        Object.defineProperty(chatContainer, 'scrollHeight', { value: 2000, configurable: true });
-        Object.defineProperty(chatContainer, 'clientHeight', { value: 500, configurable: true });
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollHeight", {
+          value: 2000,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "clientHeight", {
+          value: 500,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 300,
           writable: true,
           configurable: true,
@@ -14506,10 +15372,10 @@ describe('Chat', () => {
       }
 
       // Open canvas to trigger scroll restoration
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Wait for RAF callbacks to execute
@@ -14518,47 +15384,57 @@ describe('Chat', () => {
       });
 
       // Messages should be visible
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should handle scroll restoration when saved position exceeds maxScroll', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle scroll restoration when saved position exceeds maxScroll", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: Array.from({ length: 10 }, (_, i) => ({
           id: String(i + 1),
-          role: i % 2 === 0 ? 'user' : 'assistant',
+          role: i % 2 === 0 ? "user" : "assistant",
           content: `Message ${i + 1}`,
           timestamp: new Date().toISOString(),
           visible: true,
         })),
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
         isLoadingChats: false,
       });
 
-      const { container } = renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
+      const { container } = renderWithRedux(
+        <Chat mode="default" isPreviewMode={false} />,
+      );
 
       // Find chat container and set up a scenario where saved scroll exceeds max
-      const chatContainer = container.querySelector('[data-testid="chat-container"]');
+      const chatContainer = container.querySelector(
+        '[data-testid="chat-container"]',
+      );
       if (chatContainer) {
         // Mock scrollable content where maxScroll is smaller than saved position
-        Object.defineProperty(chatContainer, 'scrollHeight', { value: 600, configurable: true });
-        Object.defineProperty(chatContainer, 'clientHeight', { value: 500, configurable: true });
+        Object.defineProperty(chatContainer, "scrollHeight", {
+          value: 600,
+          configurable: true,
+        });
+        Object.defineProperty(chatContainer, "clientHeight", {
+          value: 500,
+          configurable: true,
+        });
         // maxScroll = 600 - 500 = 100, but saved scroll position might be higher
-        Object.defineProperty(chatContainer, 'scrollTop', {
+        Object.defineProperty(chatContainer, "scrollTop", {
           value: 500,
           writable: true,
           configurable: true,
@@ -14567,10 +15443,10 @@ describe('Chat', () => {
       }
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Wait for RAF callbacks to execute
@@ -14578,37 +15454,37 @@ describe('Chat', () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('handleHighlightMessage timeout', () => {
-    it('should handle highlight message with auto-clear after timeout', async () => {
+  describe("handleHighlightMessage timeout", () => {
+    it("should handle highlight message with auto-clear after timeout", async () => {
       vi.useFakeTimers();
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14618,13 +15494,13 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click highlight button
-      fireEvent.click(screen.getByTestId('highlight-btn'));
+      fireEvent.click(screen.getByTestId("highlight-btn"));
 
       // Advance timer past the highlight duration (2000ms)
       vi.advanceTimersByTime(2500);
 
       // Messages should still be visible after highlight clears
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
 
       vi.useRealTimers();
     });
@@ -14634,49 +15510,49 @@ describe('Chat', () => {
   // NEW BRANCH COVERAGE TESTS
   // ============================================================
 
-  describe('Strategy 1: default props coverage', () => {
-    it('should render with no props (default mode, isPreviewMode, hasBorder, isInCanvasView)', () => {
+  describe("Strategy 1: default props coverage", () => {
+    it("should render with no props (default mode, isPreviewMode, hasBorder, isInCanvasView)", () => {
       // @ts-expect-error testing default parameter branches - isPreviewMode has default value in implementation
       renderWithRedux(<Chat />);
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('Strategy 2: username is null', () => {
-    it('should render when useUsername returns null, falling back to ANONYMOUS_USERNAME', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+  describe("Strategy 2: username is null", () => {
+    it("should render when useUsername returns null, falling back to ANONYMOUS_USERNAME", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14686,29 +15562,29 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component should render with null username falling back to ANONYMOUS_USERNAME
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
 
-    it('should pass null username fallbacks when submitting a message', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+    it("should pass null username fallbacks when submitting a message", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14716,40 +15592,40 @@ describe('Chat', () => {
       });
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
       });
     });
 
-    it('should handle null username in canvas open path via artifact-stream-start', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+    it("should handle null username in canvas open path via artifact-stream-start", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14760,12 +15636,12 @@ describe('Chat', () => {
 
       // Fire artifact-stream-start with null username to cover userId: username ?? undefined
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: 5000,
-            title: 'Test Artifact',
-            fileExtension: 'txt',
-            sessionId: 'session-123',
+            title: "Test Artifact",
+            fileExtension: "txt",
+            sessionId: "session-123",
             isUpdate: false,
           },
         }),
@@ -14773,37 +15649,37 @@ describe('Chat', () => {
 
       // Verify canvas opened (no error)
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
 
-    it('should handle null username in artifact-stream-end fallback canvas open path', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+    it("should handle null username in artifact-stream-end fallback canvas open path", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14814,13 +15690,13 @@ describe('Chat', () => {
 
       // Fire artifact-stream-end when canvas is not open (fallback path)
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 6000,
-            title: 'End Artifact',
-            content: 'final content',
-            fileExtension: 'py',
-            sessionId: 'session-123',
+            title: "End Artifact",
+            content: "final content",
+            fileExtension: "py",
+            sessionId: "session-123",
             isUpdate: false,
             isPartial: false,
             versionNumber: 1,
@@ -14829,31 +15705,33 @@ describe('Chat', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('Strategy 3: getMentorId returns null', () => {
-    it('should fall back to mentorIdParam when getMentorId returns null', async () => {
-      const { useNavigate } = await import('@/hooks/user-navigate');
-      vi.mocked(useNavigate).mockReturnValue({ getMentorId: vi.fn(() => null) } as any);
+  describe("Strategy 3: getMentorId returns null", () => {
+    it("should fall back to mentorIdParam when getMentorId returns null", async () => {
+      const { useNavigate } = await import("@/hooks/user-navigate");
+      vi.mocked(useNavigate).mockReturnValue({
+        getMentorId: vi.fn(() => null),
+      } as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14861,27 +15739,27 @@ describe('Chat', () => {
       });
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('Strategy 4: attachedFiles fallback', () => {
-    it('should handle attachedFiles being undefined in store', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("Strategy 4: attachedFiles fallback", () => {
+    it("should handle attachedFiles being undefined in store", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14891,32 +15769,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />, {
         files: { attachedFiles: undefined },
       });
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('Strategy 5: screen-share chat-action', () => {
-    it('should show screen share confirmation when chat-action=screen-share in search params', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("Strategy 5: screen-share chat-action", () => {
+    it("should show screen share confirmation when chat-action=screen-share in search params", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((key: string) => (key === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((key: string) =>
+          key === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14926,36 +15806,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
     });
   });
 
-  describe('Strategy 7: canvas artifact events with partial fields', () => {
-    it('should update canvas state with partial fields on artifact-update (fallback to prev values)', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("Strategy 7: canvas artifact events with partial fields", () => {
+    it("should update canvas state with partial fields on artifact-update (fallback to prev values)", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -14965,52 +15845,52 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // First open a canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Now dispatch artifact-update with matching artifactId but MISSING title/content/fileExtension
       // This covers the || prev.title, || prev.content, || prev.fileExtension fallback branches
       window.dispatchEvent(
-        new CustomEvent('artifact-update', {
+        new CustomEvent("artifact-update", {
           detail: {
             artifactId: 123, // Matches the canvas artifactId
-            title: '', // Empty - should fall back to prev.title
-            content: '', // Empty - should fall back to prev.content
-            fileExtension: '', // Empty - should fall back to prev.fileExtension
+            title: "", // Empty - should fall back to prev.title
+            content: "", // Empty - should fall back to prev.content
+            fileExtension: "", // Empty - should fall back to prev.fileExtension
           },
         }),
       );
 
       // Component should still render fine
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
 
-    it('should handle artifact-title-updated with mismatched artifactId (no currentCanvasArtifact match)', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should handle artifact-title-updated with mismatched artifactId (no currentCanvasArtifact match)", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15020,49 +15900,49 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas with artifactId 123
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Fire artifact-title-updated with different artifactId (no match to canvasState or currentCanvasArtifact)
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 99999, // Mismatched
-            title: 'Ignored Title',
+            title: "Ignored Title",
           },
         }),
       );
 
       // Should not throw, canvas still open
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
 
-    it('should open canvas via artifact-stream-end fallback when canvas is not open and with partial fields', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should open canvas via artifact-stream-end fallback when canvas is not open and with partial fields", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15073,13 +15953,13 @@ describe('Chat', () => {
 
       // Fire artifact-stream-end without canvas being open, with partial fields
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 7777,
-            title: '', // Empty - triggers || 'Untitled Artifact'
-            content: '', // Empty - triggers || ''
-            fileExtension: '', // Empty - triggers CODE_FILE_EXTENSIONS check
-            sessionId: 'session-123',
+            title: "", // Empty - triggers || 'Untitled Artifact'
+            content: "", // Empty - triggers || ''
+            fileExtension: "", // Empty - triggers CODE_FILE_EXTENSIONS check
+            sessionId: "session-123",
             isUpdate: false,
             isPartial: false,
             versionNumber: 1,
@@ -15088,44 +15968,44 @@ describe('Chat', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('Strategy 8: executeSubmit with empty content and no files', () => {
-    it('should return early when content is empty and no files attached', async () => {
+  describe("Strategy 8: executeSubmit with empty content and no files", () => {
+    it("should return early when content is empty and no files attached", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15146,7 +16026,7 @@ describe('Chat', () => {
       // We'll need a custom approach - fire the submit programmatically via the mocked component.
       // Since the mock sends 'Test message', sendMessage should be called (the branch doesn't trigger).
       // This test verifies the non-empty content path works, which means it takes the else branch.
-      fireEvent.click(screen.getByTestId('submit-btn'));
+      fireEvent.click(screen.getByTestId("submit-btn"));
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -15154,23 +16034,27 @@ describe('Chat', () => {
     });
   });
 
-  describe('Strategy 9: handleSubmit not logged in with null platformName', () => {
-    it('should show join tenant message with tenantKey.toUpperCase() when platformName is null', async () => {
-      const { useAdvancedChat, chatActions, useTenantMetadata } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("Strategy 9: handleSubmit not logged in with null platformName", () => {
+    it("should show join tenant message with tenantKey.toUpperCase() when platformName is null", async () => {
+      const { useAdvancedChat, chatActions, useTenantMetadata } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(true);
 
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'other-tenant' }],
+        userTenants: [{ key: "other-tenant" }],
       });
 
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
@@ -15182,18 +16066,18 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15202,42 +16086,46 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalledTimes(2);
       });
     });
 
-    it('should show login prompt and not call executeSubmit when not logged in, not anonymous, no token', async () => {
-      const { useAdvancedChat, chatActions } = await import('@iblai/iblai-js/web-utils');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+    it("should show login prompt and not call executeSubmit when not logged in, not anonymous, no token", async () => {
+      const { useAdvancedChat, chatActions } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(false);
 
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       const mockSendMessage = vi.fn();
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15246,7 +16134,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalledTimes(2);
@@ -15256,30 +16144,32 @@ describe('Chat', () => {
     });
   });
 
-  describe('Strategy 10: dialog onOpenChange with window.opener', () => {
-    it('should call window.close when voice call dialog closes via onOpenChange and window.opener is set', async () => {
+  describe("Strategy 10: dialog onOpenChange with window.opener", () => {
+    it("should call window.close when voice call dialog closes via onOpenChange and window.opener is set", async () => {
       (window as any).opener = {};
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'voice-call' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "voice-call" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15289,38 +16179,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Voice Call')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Voice Call")).toBeInTheDocument();
       });
 
       // Click dialog backdrop to trigger onOpenChange(false)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should call window.close when screen share dialog closes via onOpenChange and window.opener is set', async () => {
+    it("should call window.close when screen share dialog closes via onOpenChange and window.opener is set", async () => {
       (window as any).opener = {};
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15330,33 +16222,33 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Click dialog backdrop to trigger onOpenChange(false)
-      fireEvent.click(screen.getByTestId('dialog'));
+      fireEvent.click(screen.getByTestId("dialog"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should call window.close on LiveKitChat onClose when window.opener exists', async () => {
+    it("should call window.close on LiveKitChat onClose when window.opener exists", async () => {
       (window as any).opener = {};
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15366,36 +16258,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open phone call modal by clicking phone call button on welcome chat
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
 
       // Close the LiveKitChat - should call window.close since window.opener is set
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       expect(window.close).toHaveBeenCalled();
     });
 
-    it('should call window.close on LiveKitScreenSharing onClose when window.opener exists', async () => {
+    it("should call window.close on LiveKitScreenSharing onClose when window.opener exists", async () => {
       (window as any).opener = {};
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15405,23 +16297,27 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal by clicking screen sharing button on welcome chat
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
 
       // Close the LiveKitScreenSharing - should call window.close since window.opener is set
-      fireEvent.click(screen.getByText('Close'));
+      fireEvent.click(screen.getByText("Close"));
 
       expect(window.close).toHaveBeenCalled();
     });
   });
 
-  describe('Strategy 12: artifactsEnabled on session change', () => {
-    it('should call updateSessionTools when session changes and artifactsEnabled is true', async () => {
+  describe("Strategy 12: artifactsEnabled on session change", () => {
+    it("should call updateSessionTools when session changes and artifactsEnabled is true", async () => {
       const mockUpdateSessionTools = vi.fn().mockResolvedValue(undefined);
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useMentorTools as any).mockReturnValue({
         enableWebBrowsing: true,
@@ -15441,18 +16337,18 @@ describe('Chat', () => {
       // First render with session-123
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15468,18 +16364,18 @@ describe('Chat', () => {
       // Now change session to session-456
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-456', // Changed session
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-456", // Changed session
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15498,31 +16394,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('Strategy 13: artifact-title-updated with null currentCanvasArtifact prev', () => {
-    it('should return prev (null) when setCurrentCanvasArtifact is called with null prev', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("Strategy 13: artifact-title-updated with null currentCanvasArtifact prev", () => {
+    it("should return prev (null) when setCurrentCanvasArtifact is called with null prev", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15535,51 +16431,51 @@ describe('Chat', () => {
       // Fire artifact-title-updated - the setCurrentCanvasArtifact callback should get prev=null
       // and return null (the `prev ? {...prev, title} : prev` branch)
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 123,
-            title: 'New Title',
+            title: "New Title",
           },
         }),
       );
 
       // Should not throw, component still renders
-      expect(screen.getByTestId('chat-messages')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-messages")).toBeInTheDocument();
     });
   });
 
-  describe('Strategy 11: canvas width ternary for mobile', () => {
-    it('should use 100% width when window width is below 768px (isMdUp = false)', async () => {
+  describe("Strategy 11: canvas width ternary for mobile", () => {
+    it("should use 100% width when window width is below 768px (isMdUp = false)", async () => {
       // Set window width below 768
-      Object.defineProperty(window, 'innerWidth', {
+      Object.defineProperty(window, "innerWidth", {
         value: 500,
         writable: true,
         configurable: true,
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15589,17 +16485,17 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Fire resize event to set isMdUp = false
-      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event("resize"));
 
       // Open canvas to trigger the width ternary
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Reset window width
-      Object.defineProperty(window, 'innerWidth', {
+      Object.defineProperty(window, "innerWidth", {
         value: 1024,
         writable: true,
         configurable: true,
@@ -15607,26 +16503,26 @@ describe('Chat', () => {
     });
   });
 
-  describe('Strategy 6: support_email null fallback', () => {
-    it('should use config.supportEmail() when metadata.support_email is missing', async () => {
-      const { useTenantContext } = await import('@iblai/iblai-js/web-utils');
+  describe("Strategy 6: support_email null fallback", () => {
+    it("should use config.supportEmail() when metadata.support_email is missing", async () => {
+      const { useTenantContext } = await import("@iblai/iblai-js/web-utils");
       (useTenantContext as any).mockReturnValue({ metadata: {} });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15637,7 +16533,7 @@ describe('Chat', () => {
 
       // The errorHandler is set up internally and uses metadata?.support_email || config.supportEmail()
       // Just rendering with empty metadata covers the || fallback in the closure.
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
@@ -15645,39 +16541,39 @@ describe('Chat', () => {
   // ADDITIONAL BRANCH COVERAGE TESTS (Round 2)
   // ============================================================
 
-  describe('submit with canvas open and artifact payload', () => {
-    it('should include artifact reference in message when canvas is open', async () => {
+  describe("submit with canvas open and artifact payload", () => {
+    it("should include artifact reference in message when canvas is open", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15687,54 +16583,54 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas first
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Submit a message while canvas is open - covers artifact payload branches
       // (lines 1166 effectiveTitle || 'Untitled Artifact', 1167 effectiveFileExtension || 'txt',
       //  1172 currentCanvasArtifact ? 'canvas-active-event' : 'canvasState')
       // In canvas split view, there are multiple submit buttons (desktop + mobile)
-      fireEvent.click(screen.getAllByTestId('submit-btn')[0]);
+      fireEvent.click(screen.getAllByTestId("submit-btn")[0]);
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
       });
     });
 
-    it('should submit with canvas open but no currentCanvasArtifact (using canvasState source)', async () => {
+    it("should submit with canvas open but no currentCanvasArtifact (using canvasState source)", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15744,16 +16640,16 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch canvas-inactive to clear currentCanvasArtifact
-      window.dispatchEvent(new CustomEvent('canvas-inactive'));
+      window.dispatchEvent(new CustomEvent("canvas-inactive"));
 
       // Submit - now currentCanvasArtifact is null, so it uses canvasState as source
-      fireEvent.click(screen.getAllByTestId('submit-btn')[0]);
+      fireEvent.click(screen.getAllByTestId("submit-btn")[0]);
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -15761,26 +16657,26 @@ describe('Chat', () => {
     });
   });
 
-  describe('null username in LiveKitChat and LiveKitScreenSharing', () => {
-    it('should pass empty string when username is null for LiveKitChat', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+  describe("null username in LiveKitChat and LiveKitScreenSharing", () => {
+    it("should pass empty string when username is null for LiveKitChat", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15790,32 +16686,32 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open phone call modal
-      fireEvent.click(screen.getByTestId('phone-call-btn'));
+      fireEvent.click(screen.getByTestId("phone-call-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-chat')).toBeInTheDocument();
+        expect(screen.getByTestId("live-kit-chat")).toBeInTheDocument();
       });
     });
 
-    it('should pass empty string when username is null for LiveKitScreenSharing', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+    it("should pass empty string when username is null for LiveKitScreenSharing", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15825,34 +16721,36 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open screen sharing modal
-      fireEvent.click(screen.getByTestId('screen-sharing-btn'));
+      fireEvent.click(screen.getByTestId("screen-sharing-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('live-kit-screen-sharing')).toBeInTheDocument();
+        expect(
+          screen.getByTestId("live-kit-screen-sharing"),
+        ).toBeInTheDocument();
       });
     });
   });
 
-  describe('advanced mode with null username', () => {
-    it('should render advanced mode with null username fallback', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+  describe("advanced mode with null username", () => {
+    it("should render advanced mode with null username fallback", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15862,35 +16760,37 @@ describe('Chat', () => {
       // Render in advanced mode to cover username ?? '' on line 1351
       renderWithRedux(<Chat mode="advanced" isPreviewMode={false} />);
 
-      expect(screen.getByTestId('advanced-chat-header')).toBeInTheDocument();
-      expect(screen.getByTestId('advanced-chat-builder')).toBeInTheDocument();
+      expect(screen.getByTestId("advanced-chat-header")).toBeInTheDocument();
+      expect(screen.getByTestId("advanced-chat-builder")).toBeInTheDocument();
     });
   });
 
-  describe('screen share cancel button with window.opener', () => {
-    it('should call window.close on screen share cancel button when window.opener exists', async () => {
+  describe("screen share cancel button with window.opener", () => {
+    it("should call window.close on screen share cancel button when window.opener exists", async () => {
       (window as any).opener = {};
 
-      const { useSearchParams } = await import('next/navigation');
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((param: string) => (param === 'chat-action' ? 'screen-share' : null)),
+        get: vi.fn((param: string) =>
+          param === "chat-action" ? "screen-share" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15900,41 +16800,41 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Confirm Screen Sharing')).toBeInTheDocument();
+        expect(screen.getByText("Confirm Screen Sharing")).toBeInTheDocument();
       });
 
       // Click Cancel button (not dialog backdrop)
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(screen.getByText("Cancel"));
 
       expect(window.close).toHaveBeenCalled();
     });
   });
 
-  describe('loading indicator in canvas view with isPending', () => {
-    it('should show loading indicator in canvas split view when isPending is true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator in canvas view with isPending", () => {
+    it("should show loading indicator in canvas split view when isPending is true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true, // isPending is true
@@ -15944,48 +16844,48 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to enter split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Loading message should be visible in the canvas split view
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should hide loading indicator when last message has artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide loading indicator when last message has artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
-            artifactVersions: [{ id: 1, content: 'artifact content' }],
+            artifactVersions: [{ id: 1, content: "artifact content" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -15995,34 +16895,38 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to enter split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Loading message should NOT be visible because last message has artifactVersions
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('requireUserToJoinTenantOnChat with null support_email', () => {
-    it('should use config.supportEmail() when metadata.support_email is null in join tenant message', async () => {
-      const { useAdvancedChat, chatActions, useTenantContext } = await import('@iblai/iblai-js/web-utils');
-      const { useUserTenants } = await import('@/hooks/use-user');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("requireUserToJoinTenantOnChat with null support_email", () => {
+    it("should use config.supportEmail() when metadata.support_email is null in join tenant message", async () => {
+      const { useAdvancedChat, chatActions, useTenantContext } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
+      const { useUserTenants } = await import("@/hooks/use-user");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(true);
 
       (useUserTenants as any).mockReturnValue({
-        userTenants: [{ key: 'other-tenant' }],
+        userTenants: [{ key: "other-tenant" }],
       });
 
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
@@ -16031,18 +16935,18 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16051,7 +16955,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         expect(chatActions.addUserMessage).toHaveBeenCalledTimes(2);
@@ -16059,11 +16963,13 @@ describe('Chat', () => {
     });
   });
 
-  describe('handleSubmit when not logged in but allowAnonymous is true', () => {
-    it('should not show login prompt when allowAnonymous is true and user is not logged in', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("handleSubmit when not logged in but allowAnonymous is true", () => {
+    it("should not show login prompt when allowAnonymous is true and user is not logged in", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(false);
 
@@ -16071,25 +16977,25 @@ describe('Chat', () => {
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: true,
-          mentorVisibility: 'PUBLIC',
+          mentorVisibility: "PUBLIC",
         },
       });
 
       const mockSendMessage = vi.fn();
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16098,7 +17004,7 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       // Should proceed to executeSubmit (not show login prompt)
       await waitFor(() => {
@@ -16107,31 +17013,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas open without artifactId', () => {
-    it('should open canvas without setting currentCanvasArtifact when artifactId is undefined', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas open without artifactId", () => {
+    it("should open canvas without setting currentCanvasArtifact when artifactId is undefined", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16149,47 +17055,47 @@ describe('Chat', () => {
       // The existing mock for open-canvas-btn always includes artifactId: 123
       // We can fire artifact-stream-start without an artifactId to cover the !artifactId path
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-start', {
+        new CustomEvent("artifact-stream-start", {
           detail: {
             artifactId: undefined, // No artifactId
-            title: 'Test',
-            fileExtension: 'txt',
-            sessionId: 'session-123',
+            title: "Test",
+            fileExtension: "txt",
+            sessionId: "session-123",
             isUpdate: false,
           },
         }),
       );
 
       // Should not open canvas
-      expect(screen.queryByTestId('canvas-view')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("canvas-view")).not.toBeInTheDocument();
     });
   });
 
-  describe('canvas key fallback when artifactId is undefined', () => {
-    it('should use canvas string as key when canvasState.artifactId is undefined', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas key fallback when artifactId is undefined", () => {
+    it("should use canvas string as key when canvasState.artifactId is undefined", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16199,10 +17105,10 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas via the mock button (this sets artifactId: 123)
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // The canvas key is `${canvasState.artifactId ?? 'canvas'}-${canvasRefreshTrigger}`
@@ -16211,42 +17117,42 @@ describe('Chat', () => {
     });
   });
 
-  describe('null username in chat input form and guided prompts', () => {
-    it('should pass empty string for username in ChatInputForm when username is null', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+  describe("null username in chat input form and guided prompts", () => {
+    it("should pass empty string for username in ChatInputForm when username is null", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16258,36 +17164,36 @@ describe('Chat', () => {
       // The ChatInputForm and GuidedSuggestedPrompts should receive username ?? '' = ''
       // This covers lines 1304 (guidedPrompts username ?? ''), 1514 (ChatInputForm in canvas),
       // 1717 (ChatInputForm in normal view)
-      expect(screen.getByTestId('chat-input-form')).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-form")).toBeInTheDocument();
     });
 
-    it('should pass empty string for username in canvas split view ChatInputForm when username is null', async () => {
-      const { useUsername } = await import('@/hooks/use-user');
+    it("should pass empty string for username in canvas split view ChatInputForm when username is null", async () => {
+      const { useUsername } = await import("@/hooks/use-user");
       vi.mocked(useUsername).mockReturnValue(null as any);
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16297,10 +17203,10 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to enter split view
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // The canvas split view ChatInputForm should also receive username ?? '' = ''
@@ -16308,31 +17214,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('loading indicator in normal view', () => {
-    it('should show loading indicator in normal view when isStreaming is true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator in normal view", () => {
+    it("should show loading indicator in normal view when isStreaming is true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true, // Streaming
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16342,41 +17248,41 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Loading message should be visible in normal view
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should hide loading indicator in normal view when last message has artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should hide loading indicator in normal view when last message has artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Response',
+            id: "2",
+            role: "assistant",
+            content: "Response",
             timestamp: new Date().toISOString(),
             visible: true,
-            artifactVersions: [{ id: 1, content: 'v1' }],
+            artifactVersions: [{ id: 1, content: "v1" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16387,35 +17293,35 @@ describe('Chat', () => {
 
       // Loading message should NOT be visible because last message has artifactVersions
       // This covers Branch 148[2,3] and 149[0,1] in the normal view (lines 1643-1650)
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
   });
 
-  describe('artifact-update with matching artifact and all fields present', () => {
-    it('should update canvas state when all fields are provided (covering non-fallback branches)', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-update with matching artifact and all fields present", () => {
+    it("should update canvas state when all fields are provided (covering non-fallback branches)", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16425,56 +17331,56 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas with artifactId 123
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch artifact-update with matching artifactId AND all fields populated
       // This covers the non-fallback side of || prev.title, || prev.content, || prev.fileExtension
       window.dispatchEvent(
-        new CustomEvent('artifact-update', {
+        new CustomEvent("artifact-update", {
           detail: {
             artifactId: 123,
-            title: 'New Title',
-            content: 'New content',
-            fileExtension: 'py',
-            org: 'org-1',
-            userId: 'user-1',
-            metadata: { key: 'value' },
+            title: "New Title",
+            content: "New content",
+            fileExtension: "py",
+            org: "org-1",
+            userId: "user-1",
+            metadata: { key: "value" },
           },
         }),
       );
 
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('artifact-title-updated matching canvasState but not currentCanvasArtifact', () => {
-    it('should update canvasState title but not currentCanvasArtifact when only canvasState matches', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-title-updated matching canvasState but not currentCanvasArtifact", () => {
+    it("should update canvasState title but not currentCanvasArtifact when only canvasState matches", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16484,54 +17390,54 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas with artifactId 123
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Clear currentCanvasArtifact via canvas-inactive
-      window.dispatchEvent(new CustomEvent('canvas-inactive'));
+      window.dispatchEvent(new CustomEvent("canvas-inactive"));
 
       // Now fire artifact-title-updated matching canvasState artifactId (123)
       // but currentCanvasArtifact is null, so the second condition path covers the null check
       window.dispatchEvent(
-        new CustomEvent('artifact-title-updated', {
+        new CustomEvent("artifact-title-updated", {
           detail: {
             artifactId: 123,
-            title: 'Updated Title For Canvas State',
+            title: "Updated Title For Canvas State",
           },
         }),
       );
 
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('handleOpenCanvas with payload.content undefined', () => {
-    it('should use empty string when payload.content is undefined', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("handleOpenCanvas with payload.content undefined", () => {
+    it("should use empty string when payload.content is undefined", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16543,13 +17449,13 @@ describe('Chat', () => {
       // Use artifact-stream-start which calls handleOpenCanvas with content=''
       // But also test artifact-stream-end with content undefined
       window.dispatchEvent(
-        new CustomEvent('artifact-stream-end', {
+        new CustomEvent("artifact-stream-end", {
           detail: {
             artifactId: 8888,
-            title: 'No Content',
+            title: "No Content",
             content: undefined, // undefined - should use || '' fallback
             fileExtension: undefined,
-            sessionId: 'session-123',
+            sessionId: "session-123",
             isUpdate: false,
             isPartial: false,
             versionNumber: 1,
@@ -16558,7 +17464,7 @@ describe('Chat', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
@@ -16567,28 +17473,30 @@ describe('Chat', () => {
   // ADDITIONAL BRANCH COVERAGE TESTS (Round 3)
   // ============================================================
 
-  describe('chatAction with unknown value', () => {
-    it('should not open any dialog when chatAction is an unknown value', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("chatAction with unknown value", () => {
+    it("should not open any dialog when chatAction is an unknown value", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
-        get: vi.fn((key: string) => (key === 'chat-action' ? 'unknown-action' : null)),
+        get: vi.fn((key: string) =>
+          key === "chat-action" ? "unknown-action" : null,
+        ),
       });
 
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16598,44 +17506,46 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Neither voice call nor screen share dialog should appear
-      expect(screen.queryByText('Confirm Voice Call')).not.toBeInTheDocument();
-      expect(screen.queryByText('Confirm Screen Sharing')).not.toBeInTheDocument();
+      expect(screen.queryByText("Confirm Voice Call")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Confirm Screen Sharing"),
+      ).not.toBeInTheDocument();
     });
   });
 
-  describe('submit with canvas open and empty title/extension (artifact payload fallbacks)', () => {
-    it('should fallback to Untitled Artifact and txt when effectiveTitle and effectiveFileExtension are empty', async () => {
+  describe("submit with canvas open and empty title/extension (artifact payload fallbacks)", () => {
+    it("should fallback to Untitled Artifact and txt when effectiveTitle and effectiveFileExtension are empty", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16648,13 +17558,13 @@ describe('Chat', () => {
       // This sets canvasState.title = 'Untitled Artifact' and fileExtension = undefined
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-end', {
+          new CustomEvent("artifact-stream-end", {
             detail: {
               artifactId: 9999,
-              title: '',
-              content: 'some content',
-              fileExtension: '',
-              sessionId: 'session-123',
+              title: "",
+              content: "some content",
+              fileExtension: "",
+              sessionId: "session-123",
               isUpdate: false,
               isPartial: false,
               versionNumber: 1,
@@ -16664,35 +17574,37 @@ describe('Chat', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Clear currentCanvasArtifact so effectiveTitle/FileExtension come from canvasState
       await act(async () => {
-        window.dispatchEvent(new CustomEvent('canvas-inactive'));
+        window.dispatchEvent(new CustomEvent("canvas-inactive"));
       });
 
       // Submit with canvas open - effectiveTitle will be '' (from canvasState after empty title)
       // and effectiveFileExtension will be '' - triggering the || fallbacks on lines 1166, 1167
-      fireEvent.click(screen.getAllByTestId('submit-btn')[0]);
+      fireEvent.click(screen.getAllByTestId("submit-btn")[0]);
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
         // Check that artifact payload was sent with fallback values
         const callArgs = mockSendMessage.mock.calls[0];
         if (callArgs[2]?.artifact) {
-          expect(callArgs[2].artifact.title).toBe('Untitled Artifact');
-          expect(callArgs[2].artifact.file_extension).toBe('txt');
+          expect(callArgs[2].artifact.title).toBe("Untitled Artifact");
+          expect(callArgs[2].artifact.file_extension).toBe("txt");
         }
       });
     });
   });
 
-  describe('not logged in with tokenEnabled true (alternative path)', () => {
-    it('should not show login prompt when not logged in but token and tokenEnabled are set', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
-      const { useMentorSettings } = await import('@/hooks/use-mentors/use-mentor-settings');
-      const { isLoggedIn } = await import('@/lib/utils');
+  describe("not logged in with tokenEnabled true (alternative path)", () => {
+    it("should not show login prompt when not logged in but token and tokenEnabled are set", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
+      const { useMentorSettings } = await import(
+        "@/hooks/use-mentors/use-mentor-settings"
+      );
+      const { isLoggedIn } = await import("@/lib/utils");
 
       (isLoggedIn as any).mockReturnValue(false);
 
@@ -16700,25 +17612,25 @@ describe('Chat', () => {
       (useMentorSettings as any).mockReturnValue({
         data: {
           allowAnonymous: false,
-          mentorVisibility: 'PRIVATE',
+          mentorVisibility: "PRIVATE",
         },
       });
 
       const mockSendMessage = vi.fn();
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16740,43 +17652,43 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // This test verifies the else path is taken (no login prompt shown)
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('loading indicator with artifactVersions in both views', () => {
-    it('should hide loading in canvas view when last message has non-empty artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator with artifactVersions in both views", () => {
+    it("should hide loading in canvas view when last message has non-empty artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: '',
+            id: "2",
+            role: "assistant",
+            content: "",
             timestamp: new Date().toISOString(),
             visible: true,
-            artifactVersions: [{ id: 1, content: 'v1' }],
+            artifactVersions: [{ id: 1, content: "v1" }],
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16786,49 +17698,49 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas to test the canvas split view loading indicator
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Loading message should NOT be visible because last message has artifactVersions
       // This covers Branch 148[2,3] (lines 1492-1494) and Branch 149[0,1] (line 1495)
-      expect(screen.queryByTestId('loading-message')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("loading-message")).not.toBeInTheDocument();
     });
 
-    it('should show loading in canvas view when isPending and last message has empty artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading in canvas view when isPending and last message has empty artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Response',
+            id: "2",
+            role: "assistant",
+            content: "Response",
             timestamp: new Date().toISOString(),
             visible: true,
             artifactVersions: [], // Empty array
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true, // isPending is true
@@ -16838,48 +17750,48 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Open canvas
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Loading should be visible because artifactVersions is empty (length is 0)
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should show loading in normal view when isPending and no artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading in normal view when isPending and no artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Response',
+            id: "2",
+            role: "assistant",
+            content: "Response",
             timestamp: new Date().toISOString(),
             visible: true,
             // no artifactVersions property
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -16890,35 +17802,35 @@ describe('Chat', () => {
 
       // Loading should be visible in normal view
       // This covers Branch 161[1] (line 1649) - artifactVersions being undefined
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
   });
 
-  describe('artifact-update with act wrappers for better coverage', () => {
-    it('should update canvas state with empty fields via artifact-update using act', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-update with act wrappers for better coverage", () => {
+    it("should update canvas state with empty fields via artifact-update using act", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16929,18 +17841,18 @@ describe('Chat', () => {
 
       // Open canvas
       await act(async () => {
-        fireEvent.click(screen.getByTestId('open-canvas-btn'));
+        fireEvent.click(screen.getByTestId("open-canvas-btn"));
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch artifact-update with matching artifactId but null/empty fields
       // Use act to ensure React processes all state updates
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-update', {
+          new CustomEvent("artifact-update", {
             detail: {
               artifactId: 123,
               title: null, // null triggers || prev.title (Branch 71[1])
@@ -16955,35 +17867,35 @@ describe('Chat', () => {
       });
 
       // The handler should have updated canvasState using prev values
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('artifact-title-updated with canvasState match and currentCanvasArtifact match', () => {
-    it('should update both canvasState and currentCanvasArtifact when both match', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-title-updated with canvasState match and currentCanvasArtifact match", () => {
+    it("should update both canvasState and currentCanvasArtifact when both match", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -16994,11 +17906,11 @@ describe('Chat', () => {
 
       // Open canvas with artifactId 123 - this also sets currentCanvasArtifact
       await act(async () => {
-        fireEvent.click(screen.getByTestId('open-canvas-btn'));
+        fireEvent.click(screen.getByTestId("open-canvas-btn"));
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Now fire artifact-title-updated with matching artifactId
@@ -17006,47 +17918,49 @@ describe('Chat', () => {
       // This covers Branch 77[1] (line 994) and Branch 84[0] (line 1001 - prev is truthy)
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-title-updated', {
+          new CustomEvent("artifact-title-updated", {
             detail: {
               artifactId: 123,
-              title: 'Brand New Title',
+              title: "Brand New Title",
             },
           }),
         );
       });
 
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('onStartNewChat with null mentorId', () => {
-    it('should not save cached sessionId when mentorId is null', async () => {
-      const { useNavigate } = await import('@/hooks/user-navigate');
-      vi.mocked(useNavigate).mockReturnValue({ getMentorId: vi.fn(() => null) } as any);
+  describe("onStartNewChat with null mentorId", () => {
+    it("should not save cached sessionId when mentorId is null", async () => {
+      const { useNavigate } = await import("@/hooks/user-navigate");
+      vi.mocked(useNavigate).mockReturnValue({
+        getMentorId: vi.fn(() => null),
+      } as any);
 
       // Also set mentorIdParam to undefined by adjusting useParams
-      const { useParams } = await import('next/navigation');
+      const { useParams } = await import("next/navigation");
       (useParams as any).mockReturnValue({
-        tenantKey: 'test-tenant',
+        tenantKey: "test-tenant",
         mentorId: undefined, // No mentorId param either
       });
 
       const mockStartNewChat = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: mockStartNewChat,
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17064,31 +17978,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('artifact-stream-end with canvas already open (isUpdate=true path)', () => {
-    it('should not reopen canvas when artifact-stream-end has isUpdate=true', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-stream-end with canvas already open (isUpdate=true path)", () => {
+    it("should not reopen canvas when artifact-stream-end has isUpdate=true", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17099,23 +18013,23 @@ describe('Chat', () => {
 
       // Open canvas
       await act(async () => {
-        fireEvent.click(screen.getByTestId('open-canvas-btn'));
+        fireEvent.click(screen.getByTestId("open-canvas-btn"));
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Dispatch artifact-stream-end with isUpdate=true and same artifactId
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-end', {
+          new CustomEvent("artifact-stream-end", {
             detail: {
               artifactId: 123,
-              title: 'Updated',
-              content: 'Updated content',
-              fileExtension: 'txt',
-              sessionId: 'session-123',
+              title: "Updated",
+              content: "Updated content",
+              fileExtension: "txt",
+              sessionId: "session-123",
               isUpdate: true, // This is an update, not a new artifact
               isPartial: false,
               versionNumber: 2,
@@ -17125,35 +18039,35 @@ describe('Chat', () => {
       });
 
       // Canvas should still be open
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('canvas key with undefined artifactId', () => {
-    it('should use canvas fallback in key when canvasState has no artifactId', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas key with undefined artifactId", () => {
+    it("should use canvas fallback in key when canvasState has no artifactId", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17165,12 +18079,12 @@ describe('Chat', () => {
       // Use artifact-stream-start with artifactId to open canvas
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-start', {
+          new CustomEvent("artifact-stream-start", {
             detail: {
               artifactId: 100,
-              title: 'Test',
-              fileExtension: 'txt',
-              sessionId: 'session-123',
+              title: "Test",
+              fileExtension: "txt",
+              sessionId: "session-123",
               isUpdate: false,
             },
           }),
@@ -17178,7 +18092,7 @@ describe('Chat', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
@@ -17187,10 +18101,12 @@ describe('Chat', () => {
   // ADDITIONAL BRANCH COVERAGE TESTS (Round 4)
   // ============================================================
 
-  describe('session change with artifactsEnabled false', () => {
-    it('should not call updateSessionTools when session changes and artifactsEnabled is false', async () => {
+  describe("session change with artifactsEnabled false", () => {
+    it("should not call updateSessionTools when session changes and artifactsEnabled is false", async () => {
       const mockUpdateSessionTools = vi.fn().mockResolvedValue(undefined);
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useMentorTools as any).mockReturnValue({
         enableWebBrowsing: true,
@@ -17209,18 +18125,18 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17236,18 +18152,18 @@ describe('Chat', () => {
       // Change session
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-789', // Changed session
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-789", // Changed session
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17266,31 +18182,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('artifact-title-updated when canvasState does not match but currentCanvasArtifact does', () => {
-    it('should update currentCanvasArtifact but not canvasState when only currentCanvasArtifact matches', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-title-updated when canvasState does not match but currentCanvasArtifact does", () => {
+    it("should update currentCanvasArtifact but not canvasState when only currentCanvasArtifact matches", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17301,21 +18217,21 @@ describe('Chat', () => {
 
       // Open canvas with artifactId 123
       await act(async () => {
-        fireEvent.click(screen.getByTestId('open-canvas-btn'));
+        fireEvent.click(screen.getByTestId("open-canvas-btn"));
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Set currentCanvasArtifact to a DIFFERENT artifactId via canvas-active event
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('canvas-active', {
+          new CustomEvent("canvas-active", {
             detail: {
               artifactId: 555,
-              title: 'Different Artifact',
-              file_extension: 'py',
+              title: "Different Artifact",
+              file_extension: "py",
             },
           }),
         );
@@ -17327,44 +18243,44 @@ describe('Chat', () => {
       // This covers Branch 77[1] (line 994 - canvasState match false)
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-title-updated', {
+          new CustomEvent("artifact-title-updated", {
             detail: {
               artifactId: 555,
-              title: 'Updated Via Canvas Active',
+              title: "Updated Via Canvas Active",
             },
           }),
         );
       });
 
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('loading indicator artifactVersions edge cases', () => {
-    it('should show loading when last message is user role (not assistant) even when isPending', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator artifactVersions edge cases", () => {
+    it("should show loading when last message is user role (not assistant) even when isPending", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true, // isPending
@@ -17375,41 +18291,41 @@ describe('Chat', () => {
 
       // Loading message should be visible since last message is user (not assistant with artifactVersions)
       // This covers Branch 149[1] and 161[1] - messages[last].role !== 'assistant'
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should show loading when assistant message has undefined artifactVersions', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading when assistant message has undefined artifactVersions", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Thinking...',
+            id: "2",
+            role: "assistant",
+            content: "Thinking...",
             timestamp: new Date().toISOString(),
             visible: true,
             // artifactVersions is undefined
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17421,41 +18337,41 @@ describe('Chat', () => {
       // Loading message should be visible - artifactVersions is undefined
       // The condition checks: messages[last]?.artifactVersions (undefined = falsy)
       // So it short-circuits and the loading shows
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should show loading in canvas view when assistant message has null artifactVersions and isPending', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading in canvas view when assistant message has null artifactVersions and isPending", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: '',
+            id: "2",
+            role: "assistant",
+            content: "",
             timestamp: new Date().toISOString(),
             visible: true,
             artifactVersions: null, // null
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: true,
@@ -17466,37 +18382,37 @@ describe('Chat', () => {
 
       // Open canvas to test the canvas-view loading path
       await act(async () => {
-        fireEvent.click(screen.getByTestId('open-canvas-btn'));
+        fireEvent.click(screen.getByTestId("open-canvas-btn"));
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Loading should be visible since artifactVersions is null (falsy)
       // This covers the branches at lines 1492-1495 in the canvas split view
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
   });
 
-  describe('executeSubmit returns early in previewMode', () => {
-    it('should not call sendMessage when isPreviewMode is true', async () => {
+  describe("executeSubmit returns early in previewMode", () => {
+    it("should not call sendMessage when isPreviewMode is true", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17505,31 +18421,31 @@ describe('Chat', () => {
 
       renderWithRedux(<Chat mode="default" isPreviewMode={true} />);
 
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       // sendMessage should NOT be called since isPreviewMode is true (returns early at line 1126)
       expect(mockSendMessage).not.toHaveBeenCalled();
     });
   });
 
-  describe('submit with attached files and empty content', () => {
-    it('should proceed to submit when content has text and files are attached', async () => {
+  describe("submit with attached files and empty content", () => {
+    it("should proceed to submit when content has text and files are attached", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17541,21 +18457,21 @@ describe('Chat', () => {
         files: {
           attachedFiles: [
             {
-              id: 'file-1',
-              fileName: 'test.txt',
-              fileType: 'text/plain',
+              id: "file-1",
+              fileName: "test.txt",
+              fileType: "text/plain",
               fileSize: 100,
-              uploadStatus: 'success',
-              fileKey: 'key-1',
-              fileId: 'id-1',
-              fileUrl: 'https://example.com/test.txt',
+              uploadStatus: "success",
+              fileKey: "key-1",
+              fileId: "id-1",
+              fileUrl: "https://example.com/test.txt",
             },
           ],
         },
       });
 
       // Submit with 'Hello!' from welcome-submit (non-empty content)
-      fireEvent.click(screen.getByTestId('welcome-submit'));
+      fireEvent.click(screen.getByTestId("welcome-submit"));
 
       await waitFor(() => {
         // sendMessage should be called with file references
@@ -17564,39 +18480,39 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas submit with effectiveTitle empty', () => {
-    it('should use Untitled Artifact fallback when submitting with canvas that has empty title', async () => {
+  describe("canvas submit with effectiveTitle empty", () => {
+    it("should use Untitled Artifact fallback when submitting with canvas that has empty title", async () => {
       const mockSendMessage = vi.fn();
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: 'Hi!',
+            id: "2",
+            role: "assistant",
+            content: "Hi!",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17608,13 +18524,13 @@ describe('Chat', () => {
       // Open canvas via artifact-stream-end with empty title
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-end', {
+          new CustomEvent("artifact-stream-end", {
             detail: {
               artifactId: 11111,
-              title: '',
-              content: 'code',
-              fileExtension: '',
-              sessionId: 'session-123',
+              title: "",
+              content: "code",
+              fileExtension: "",
+              sessionId: "session-123",
               isUpdate: false,
               isPartial: false,
               versionNumber: 1,
@@ -17624,18 +18540,18 @@ describe('Chat', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Now clear the currentCanvasArtifact to use canvasState values
       await act(async () => {
-        window.dispatchEvent(new CustomEvent('canvas-inactive'));
+        window.dispatchEvent(new CustomEvent("canvas-inactive"));
       });
 
       // Submit while canvas is open - effectiveTitle should fallback to 'Untitled Artifact'
       // effectiveFileExtension should fallback to 'txt'
       // source should be 'canvasState' (not 'canvas-active-event')
-      fireEvent.click(screen.getAllByTestId('submit-btn')[0]);
+      fireEvent.click(screen.getAllByTestId("submit-btn")[0]);
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -17643,31 +18559,31 @@ describe('Chat', () => {
     });
   });
 
-  describe('canvas open without artifactId (Branch 46, 44)', () => {
-    it('should open canvas without setting currentCanvasArtifact when no artifactId and null content', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("canvas open without artifactId (Branch 46, 44)", () => {
+    it("should open canvas without setting currentCanvasArtifact when no artifactId and null content", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17677,40 +18593,40 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Click the new button that opens canvas without artifactId and with null content
-      fireEvent.click(screen.getByTestId('open-canvas-no-artifact-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-no-artifact-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
     });
   });
 
-  describe('empty content submission guard (Branch 103, 104)', () => {
-    it('should return early when content is empty and no files attached', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("empty content submission guard (Branch 103, 104)", () => {
+    it("should return early when content is empty and no files attached", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       const mockSendMessage = vi.fn();
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17720,7 +18636,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Submit empty content via the new submit-empty-btn
-      fireEvent.click(screen.getByTestId('submit-empty-btn'));
+      fireEvent.click(screen.getByTestId("submit-empty-btn"));
 
       // sendMessage should NOT be called because executeSubmit guards against empty content
       await waitFor(() => {
@@ -17729,9 +18645,11 @@ describe('Chat', () => {
     });
   });
 
-  describe('artifact-title-updated past guard (Branch 77)', () => {
-    it('should pass through title update guard when artifactId and title are both present', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("artifact-title-updated past guard (Branch 77)", () => {
+    it("should pass through title update guard when artifactId and title are both present", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       (useMentorTools as any).mockReturnValue({
         enableWebBrowsing: true,
@@ -17750,26 +18668,26 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17779,32 +18697,34 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // First open canvas with a specific artifactId
-      fireEvent.click(screen.getByTestId('open-canvas-btn'));
+      fireEvent.click(screen.getByTestId("open-canvas-btn"));
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Now dispatch title update with matching artifactId (123 from the mock)
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-title-updated', {
+          new CustomEvent("artifact-title-updated", {
             detail: {
               artifactId: 123,
-              title: 'Updated Title',
+              title: "Updated Title",
             },
           }),
         );
       });
 
       // Should update without error - covers the branch past the guard
-      expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+      expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
     });
   });
 
-  describe('executeSubmit with canvas open but empty title (Branch 112)', () => {
-    it('should use Untitled Artifact fallback when effectiveTitle is empty', async () => {
-      const { useAdvancedChat, useMentorTools } = await import('@iblai/iblai-js/web-utils');
+  describe("executeSubmit with canvas open but empty title (Branch 112)", () => {
+    it("should use Untitled Artifact fallback when effectiveTitle is empty", async () => {
+      const { useAdvancedChat, useMentorTools } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
       const mockSendMessage = vi.fn();
 
       (useMentorTools as any).mockReturnValue({
@@ -17824,26 +18744,26 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: mockSendMessage,
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17855,12 +18775,12 @@ describe('Chat', () => {
       // Open canvas with empty title via stream-start event
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('artifact-stream-start', {
+          new CustomEvent("artifact-stream-start", {
             detail: {
               artifactId: 999,
-              title: '', // empty title
-              fileExtension: '',
-              sessionId: 'session-123',
+              title: "", // empty title
+              fileExtension: "",
+              sessionId: "session-123",
               isUpdate: false,
             },
           }),
@@ -17868,24 +18788,24 @@ describe('Chat', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('canvas-view')).toBeInTheDocument();
+        expect(screen.getByTestId("canvas-view")).toBeInTheDocument();
       });
 
       // Set the canvas-active event so currentCanvasArtifact has empty title
       await act(async () => {
         window.dispatchEvent(
-          new CustomEvent('canvas-active', {
+          new CustomEvent("canvas-active", {
             detail: {
               artifactId: 999,
-              title: '',
-              file_extension: '',
+              title: "",
+              file_extension: "",
             },
           }),
         );
       });
 
       // Submit message while canvas is open - effectiveTitle should fallback to 'Untitled Artifact'
-      fireEvent.click(screen.getAllByTestId('submit-btn')[0]);
+      fireEvent.click(screen.getAllByTestId("submit-btn")[0]);
 
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalled();
@@ -17893,39 +18813,39 @@ describe('Chat', () => {
     });
   });
 
-  describe('loading indicator with artifact versions undefined length (Branch 149, 161)', () => {
-    it('should show loading indicator when last assistant message has artifactVersions as empty array', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+  describe("loading indicator with artifact versions undefined length (Branch 149, 161)", () => {
+    it("should show loading indicator when last assistant message has artifactVersions as empty array", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: '',
+            id: "2",
+            role: "assistant",
+            content: "",
             timestamp: new Date().toISOString(),
             visible: true,
             artifactVersions: [], // empty array: length is 0, not undefined
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17935,41 +18855,41 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // With empty artifactVersions array, the loading message SHOULD show because (0 > 0) is false
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
 
-    it('should show loading indicator when last message has no artifactVersions property', async () => {
-      const { useAdvancedChat } = await import('@iblai/iblai-js/web-utils');
+    it("should show loading indicator when last message has no artifactVersions property", async () => {
+      const { useAdvancedChat } = await import("@iblai/iblai-js/web-utils");
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: true,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [
           {
-            id: '1',
-            role: 'user',
-            content: 'Hello',
+            id: "1",
+            role: "user",
+            content: "Hello",
             timestamp: new Date().toISOString(),
             visible: true,
           },
           {
-            id: '2',
-            role: 'assistant',
-            content: '',
+            id: "2",
+            role: "assistant",
+            content: "",
             timestamp: new Date().toISOString(),
             visible: true,
             // no artifactVersions property - undefined?.length ?? 0 = 0
           },
         ],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -17980,13 +18900,15 @@ describe('Chat', () => {
 
       // The loading message should appear since artifactVersions is undefined
       // covers ?. operator returning undefined and ?? 0 fallback
-      expect(screen.getByTestId('loading-message')).toBeInTheDocument();
+      expect(screen.getByTestId("loading-message")).toBeInTheDocument();
     });
   });
 
-  describe('support_email fallback in errorHandler (Branch 15, 20)', () => {
-    it('should use config.supportEmail() fallback when metadata has no support_email', async () => {
-      const { useAdvancedChat, useTenantContext } = await import('@iblai/iblai-js/web-utils');
+  describe("support_email fallback in errorHandler (Branch 15, 20)", () => {
+    it("should use config.supportEmail() fallback when metadata has no support_email", async () => {
+      const { useAdvancedChat, useTenantContext } = await import(
+        "@iblai/iblai-js/web-utils"
+      );
 
       // Set up metadata without support_email
       (useTenantContext as any).mockReturnValue({
@@ -17995,18 +18917,18 @@ describe('Chat', () => {
 
       (useAdvancedChat as any).mockReturnValue({
         changeTab: vi.fn(),
-        activeTab: 'chat',
+        activeTab: "chat",
         currentStreamingMessage: null,
         enabledGuidedPrompts: [],
         isStreaming: false,
-        mentorName: 'Test Mentor',
+        mentorName: "Test Mentor",
         messages: [],
-        profileImage: '/avatar.png',
+        profileImage: "/avatar.png",
         sendMessage: vi.fn(),
         setMessage: vi.fn(),
         stopGenerating: vi.fn(),
-        uniqueMentorId: 'unique-mentor-123',
-        sessionId: 'session-123',
+        uniqueMentorId: "unique-mentor-123",
+        sessionId: "session-123",
         startNewChat: vi.fn(),
         enableSafetyDisclaimer: false,
         isPending: false,
@@ -18015,16 +18937,16 @@ describe('Chat', () => {
 
       // Render should succeed with fallback email
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 
-  describe('compact mode', () => {
-    it('should render in compact mode when compact=true search param is set', async () => {
-      const { useSearchParams } = await import('next/navigation');
+  describe("compact mode", () => {
+    it("should render in compact mode when compact=true search param is set", async () => {
+      const { useSearchParams } = await import("next/navigation");
       (useSearchParams as any).mockReturnValue({
         get: vi.fn((param: string) => {
-          if (param === 'compact') return 'true';
+          if (param === "compact") return "true";
           return null;
         }),
       });
@@ -18032,7 +18954,7 @@ describe('Chat', () => {
       renderWithRedux(<Chat mode="default" isPreviewMode={false} />);
 
       // Component should render without errors in compact mode
-      expect(screen.getByTestId('welcome-chat')).toBeInTheDocument();
+      expect(screen.getByTestId("welcome-chat")).toBeInTheDocument();
     });
   });
 });

--- a/components/chat/index.tsx
+++ b/components/chat/index.tsx
@@ -262,6 +262,7 @@ export function Chat({
   })();
   const mentorId = getMentorId() ?? mentorIdParam;
   const searchParams = useSearchParams();
+  const isCustomApp = searchParams.get("custom-app") === "true";
   const isCompactMode = searchParams.get("compact") === "true";
   const isEmbeddedMode = useEmbedMode();
   const { visitingTenant } = useVisitingTenant();
@@ -383,7 +384,8 @@ export function Chat({
     sendMessageToParentWebsite,
     isPreviewMode:
       isPreviewMode ||
-      (!!visitingTenant &&
+      (!isCustomApp &&
+        !!visitingTenant &&
         isLoggedIn() &&
         !mentorSettings.allowAnonymous &&
         !searchParams.get("token")),


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
Disable preview mode for custom app (having `custom-app=true` in query param). This enables external app devs to chat with mentors