### PR TITLE
fix: force reinstall tauri-cli to avoid stale cache

### DIFF
--- a/.github/workflows/build-windows-msix.yml
+++ b/.github/workflows/build-windows-msix.yml
@@ -82,7 +82,7 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile binstall.zip
           Expand-Archive -Path binstall.zip -DestinationPath "$env:USERPROFILE\.cargo\bin" -Force
           Remove-Item binstall.zip
-          cargo binstall tauri-cli --no-confirm
+          cargo binstall tauri-cli --no-confirm --force
 
       - name: Build Tauri app (${{ matrix.rust_target }})
         run: cargo tauri build --target ${{ matrix.rust_target }}


### PR DESCRIPTION
## Summary
- `cargo binstall tauri-cli` was skipping install because the Rust cache restores `.crates.toml`/`.crates2.json` metadata, making it think tauri-cli is already installed — but the actual binary isn't in the cache
- Adding `--force` ensures the binary is always installed regardless of cached metadata

## Root cause
From the [failed run logs](https://github.com/iblai/mentorai/actions/runs/23859661749/job/69562558779):
```
INFO resolve: tauri-cli v2.10.1 is already installed, use --force to override
...
error: no such command: `tauri`
```

## Test plan
- [ ] Re-run the "Build Windows Packages" workflow and verify both x64 and arm64 jobs pass the "Build Tauri app" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)