### PR TITLE
Feat/1209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,30 @@
 
 ### Bug Fixes
 
-* add check for Schedule Retrain button enabled state in dataset management journey ([bb3b1e2](https://github.com/iblai/mentorai/commit/bb3b1e2dd8e37d4ddc2244c8bc7b25d75b15dcd5))
-* **chore:** comment out a use effect that determines the save current tenant flow and not in the tenant provider ([f2d3d2d](https://github.com/iblai/mentorai/commit/f2d3d2de96d83de1569185ee9be63e63f15cca07))
-* increase download event timeout in HistoryTab to improve export reliability ([eaee906](https://github.com/iblai/mentorai/commit/eaee90625c48052307325882be991ba8a85b1118))
-* increase download event timeout in mentor history tab to enhance export reliability ([6ad3606](https://github.com/iblai/mentorai/commit/6ad360652d2796796f29c75a87277e612db3e4d8))
-* update deleteMentor method to use alertdialog for confirmation ([cc5ffa0](https://github.com/iblai/mentorai/commit/cc5ffa0b75109cfd4abacef89932d1cea2328147))
-* update sidebar navigation to conditionally set rbacResource based on mentorId ([cd9fd16](https://github.com/iblai/mentorai/commit/cd9fd167f8e4ade215a37408bec9aef46ac9c8f5))
+- add check for Schedule Retrain button enabled state in dataset management journey ([bb3b1e2](https://github.com/iblai/mentorai/commit/bb3b1e2dd8e37d4ddc2244c8bc7b25d75b15dcd5))
+- **chore:** comment out a use effect that determines the save current tenant flow and not in the tenant provider ([f2d3d2d](https://github.com/iblai/mentorai/commit/f2d3d2de96d83de1569185ee9be63e63f15cca07))
+- increase download event timeout in HistoryTab to improve export reliability ([eaee906](https://github.com/iblai/mentorai/commit/eaee90625c48052307325882be991ba8a85b1118))
+- increase download event timeout in mentor history tab to enhance export reliability ([6ad3606](https://github.com/iblai/mentorai/commit/6ad360652d2796796f29c75a87277e612db3e4d8))
+- update deleteMentor method to use alertdialog for confirmation ([cc5ffa0](https://github.com/iblai/mentorai/commit/cc5ffa0b75109cfd4abacef89932d1cea2328147))
+- update sidebar navigation to conditionally set rbacResource based on mentorId ([cd9fd16](https://github.com/iblai/mentorai/commit/cd9fd167f8e4ade215a37408bec9aef46ac9c8f5))
 
 ### Refactors
 
-* streamline nav-bar and edit-mentor-modal components to utilize mentor segments ([efc2402](https://github.com/iblai/mentorai/commit/efc2402ba4cda8c328e3f815072dd7acc09fc380))
-* update memory management components to use new mentor memory API ([0a93e4f](https://github.com/iblai/mentorai/commit/0a93e4f9429031b31bd260dd1e0f6df31aae2997))
+- streamline nav-bar and edit-mentor-modal components to utilize mentor segments ([efc2402](https://github.com/iblai/mentorai/commit/efc2402ba4cda8c328e3f815072dd7acc09fc380))
+- update memory management components to use new mentor memory API ([0a93e4f](https://github.com/iblai/mentorai/commit/0a93e4f9429031b31bd260dd1e0f6df31aae2997))
 
 ## [0.44.7](https://github.com/iblai/mentorai/compare/v0.44.6...v0.44.7) (2026-04-07)
 
 ### Bug Fixes
 
-* close billing modal tab on upgrade button click ([4333887](https://github.com/iblai/mentorai/commit/43338879939e130afd972470d501d3eb82e01ce4))
-* close billing modal tab on upgrade button click > test coverage ([de21e58](https://github.com/iblai/mentorai/commit/de21e5803afba839536ff0ed2dccd6afe7268806))
+- close billing modal tab on upgrade button click ([4333887](https://github.com/iblai/mentorai/commit/43338879939e130afd972470d501d3eb82e01ce4))
+- close billing modal tab on upgrade button click > test coverage ([de21e58](https://github.com/iblai/mentorai/commit/de21e5803afba839536ff0ed2dccd6afe7268806))
 
 ## [0.44.6](https://github.com/iblai/mentorai/compare/v0.44.5...v0.44.6) (2026-04-06)
 
 ### Bug Fixes
 
-* memoize middleware map to stabilize AuthProvider cookie sync interval ([3eb1e86](https://github.com/iblai/mentorai/commit/3eb1e8604aafa33058ad45b0976e02e4be662919))
+- memoize middleware map to stabilize AuthProvider cookie sync interval ([3eb1e86](https://github.com/iblai/mentorai/commit/3eb1e8604aafa33058ad45b0976e02e4be662919))
 
 ## [0.44.5](https://github.com/iblai/mentorai/compare/v0.44.4...v0.44.5) (2026-04-06)
 

--- a/__tests__/a11y-test-utils.ts
+++ b/__tests__/a11y-test-utils.ts
@@ -3,7 +3,7 @@ import { test, expect } from 'vitest';
 import { axe, AxeCore } from 'vitest-axe';
 import { render } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
-import { mentorApiSlice } from '@iblai/iblai-js/data-layer';
+import { mentorApiSlice, memoryApiSlice } from '@iblai/iblai-js/data-layer';
 import { modalReducer } from '@/features/navigation/slice';
 
 export function createTestStore() {
@@ -11,11 +11,14 @@ export function createTestStore() {
     reducer: {
       modals: modalReducer,
       [mentorApiSlice.reducerPath]: mentorApiSlice.reducer,
+      [memoryApiSlice.reducerPath]: memoryApiSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         serializableCheck: false,
-      }).concat(mentorApiSlice.middleware),
+      })
+        .concat(mentorApiSlice.middleware)
+        .concat(memoryApiSlice.middleware),
     preloadedState: {
       modals: {
         modalStack: [],

--- a/app/platform/[tenantKey]/[mentorId]/_components/nav-bar/__tests__/index.test.tsx
+++ b/app/platform/[tenantKey]/[mentorId]/_components/nav-bar/__tests__/index.test.tsx
@@ -180,7 +180,7 @@ vi.mock('@iblai/iblai-js/data-layer', async (importOriginal) => {
       isLoading: false,
       isSuccess: true,
     }),
-    useGetMemsearchConfigQuery: () => ({
+    useGetMemsearchStatusQuery: () => ({
       data: { enable_memsearch: false },
       isLoading: false,
       isSuccess: true,

--- a/components/chat-input-form.tsx
+++ b/components/chat-input-form.tsx
@@ -378,6 +378,10 @@ export function ChatInputForm({
                   embedMode={embedMode}
                   promptsIsEnabled={promptsIsEnabled}
                   studyMode={studyMode}
+                  memoryEnabled={mentorSettings.data.memoryEnabled}
+                  isAnonymousMentor={!!mentorSettings.data.allowAnonymous}
+                  tenantKey={tenantKey}
+                  username={username}
                 />
               )}
 

--- a/components/chat-input-form/__tests__/inside-buttons.test.tsx
+++ b/components/chat-input-form/__tests__/inside-buttons.test.tsx
@@ -109,39 +109,42 @@ describe('InsideButtons', () => {
       expect(screen.getByText('Deep Research')).toBeInTheDocument();
     });
 
-    it('should render MemoryButton when the filtered list includes Memory', () => {
-      const originalFilter = Array.prototype.filter;
-      let bypassed = false;
-      const filterSpy = vi
-        .spyOn(Array.prototype, 'filter')
-        .mockImplementation(function (
-          this: any[],
-          ...args: Parameters<typeof Array.prototype.filter>
-        ) {
-          if (!bypassed) {
-            bypassed = true;
-            return this;
-          }
-          return originalFilter.apply(
-            this,
-            args as [
-              predicate: (value: any, index: number, array: any[]) => unknown,
-              thisArg?: any,
-            ],
-          );
-        });
-
+    it('should render MemoryButton when memoryEnabled is true', () => {
       render(
         <InsideButtons
           {...defaultProps}
-          artifactsEnabled={true}
-          deepResearch={true}
+          memoryEnabled={true}
           containerWidth={1000}
         />,
       );
 
       expect(screen.getByTestId('memory-button')).toBeInTheDocument();
-      filterSpy.mockRestore();
+    });
+
+    it('should not render MemoryButton for an anonymous mentor', () => {
+      render(
+        <InsideButtons
+          {...defaultProps}
+          memoryEnabled={true}
+          isAnonymousMentor={true}
+          containerWidth={1000}
+        />,
+      );
+
+      expect(screen.queryByTestId('memory-button')).not.toBeInTheDocument();
+    });
+
+    it('should not render MemoryButton in embed mode', () => {
+      render(
+        <InsideButtons
+          {...defaultProps}
+          memoryEnabled={true}
+          embedMode={true}
+          containerWidth={1000}
+        />,
+      );
+
+      expect(screen.queryByTestId('memory-button')).not.toBeInTheDocument();
     });
   });
 

--- a/components/chat-input-form/__tests__/memory-button.test.tsx
+++ b/components/chat-input-form/__tests__/memory-button.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from '@testing-library/react';
+
+import { MemoryButton } from '../memory-button';
+
+// Mock the nested MemoryMenu so these tests focus on the button's
+// open/close behaviour and prop forwarding, not the menu internals.
+vi.mock('../memory-menu', () => ({
+  MemoryMenu: ({ onClose, tenantKey, username }: any) => (
+    <div data-testid="memory-menu">
+      <span data-testid="memory-menu-tenant">{tenantKey ?? ''}</span>
+      <span data-testid="memory-menu-username">{username ?? ''}</span>
+      <button data-testid="memory-menu-close" onClick={onClose}>
+        close-from-menu
+      </button>
+    </div>
+  ),
+}));
+
+// Radix Popover renders its content into a portal; these stubs keep
+// everything in the test root and expose open state on the trigger.
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ open, onOpenChange, children }: any) => (
+    <div data-testid="popover" data-state={open ? 'open' : 'closed'}>
+      {React.Children.map(children, (child: any) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, {
+              __open: open,
+              __onOpenChange: onOpenChange,
+            } as any)
+          : child,
+      )}
+    </div>
+  ),
+  PopoverTrigger: ({ children, __onOpenChange }: any) => {
+    const child = React.Children.only(children);
+    return React.cloneElement(child, {
+      onClick: () => __onOpenChange?.(true),
+    });
+  },
+  PopoverContent: ({ children, __open }: any) =>
+    __open ? <div data-testid="popover-content">{children}</div> : null,
+}));
+
+describe('MemoryButton', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Memory label and is closed by default', () => {
+    render(<MemoryButton />);
+
+    expect(screen.getByText('Memory')).toBeInTheDocument();
+    expect(screen.getByTestId('popover')).toHaveAttribute(
+      'data-state',
+      'closed',
+    );
+    expect(screen.queryByTestId('memory-menu')).not.toBeInTheDocument();
+  });
+
+  it('opens the popover with MemoryMenu when the trigger is clicked', () => {
+    render(<MemoryButton tenantKey="org-1" username="alice" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /memory/i }));
+
+    const menu = screen.getByTestId('memory-menu');
+    expect(menu).toBeInTheDocument();
+    expect(within(menu).getByTestId('memory-menu-tenant').textContent).toBe(
+      'org-1',
+    );
+    expect(within(menu).getByTestId('memory-menu-username').textContent).toBe(
+      'alice',
+    );
+    expect(screen.getByTestId('popover')).toHaveAttribute('data-state', 'open');
+  });
+
+  it('shows the inline close affordance once opened', () => {
+    render(<MemoryButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /memory/i }));
+
+    // The X icon inside the trigger is rendered only while the popover
+    // is open; it's still the same Button (name: Memory), but now
+    // contains an additional svg.
+    const trigger = screen.getByRole('button', { name: /memory/i });
+    const svgs = trigger.querySelectorAll('svg');
+    expect(svgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('closes via the MemoryMenu onClose callback', () => {
+    render(<MemoryButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /memory/i }));
+    expect(screen.getByTestId('popover')).toHaveAttribute('data-state', 'open');
+
+    fireEvent.click(screen.getByTestId('memory-menu-close'));
+    expect(screen.getByTestId('popover')).toHaveAttribute(
+      'data-state',
+      'closed',
+    );
+    expect(screen.queryByTestId('memory-menu')).not.toBeInTheDocument();
+  });
+
+  it('closes via the inline X icon onClick handler', () => {
+    render(<MemoryButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /memory/i }));
+    expect(screen.getByTestId('popover')).toHaveAttribute('data-state', 'open');
+
+    // The X icon rendered inside the trigger while open has its own
+    // onClick (stops propagation + closes). It's the second svg in
+    // the button's subtree.
+    const trigger = screen.getByRole('button', { name: /memory/i });
+    const xIcon = trigger.querySelectorAll('svg')[1]!;
+    fireEvent.click(xIcon);
+
+    expect(screen.getByTestId('popover')).toHaveAttribute(
+      'data-state',
+      'closed',
+    );
+  });
+
+  it('forwards undefined tenantKey and username to MemoryMenu when omitted', () => {
+    render(<MemoryButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /memory/i }));
+
+    expect(screen.getByTestId('memory-menu-tenant').textContent).toBe('');
+    expect(screen.getByTestId('memory-menu-username').textContent).toBe('');
+  });
+});

--- a/components/chat-input-form/__tests__/memory-menu.test.tsx
+++ b/components/chat-input-form/__tests__/memory-menu.test.tsx
@@ -60,15 +60,17 @@ vi.mock('next/navigation', () => ({
 }));
 
 // UI primitive stubs so we can drive the form without Radix portals.
-vi.mock('@/components/ui/button', () => ({
-  Button: React.forwardRef(
+vi.mock('@/components/ui/button', () => {
+  const Button = React.forwardRef(
     ({ children, onClick, disabled, ...rest }: any, ref: any) => (
       <button ref={ref} onClick={onClick} disabled={disabled} {...rest}>
         {children}
       </button>
     ),
-  ),
-}));
+  );
+  Button.displayName = 'Button';
+  return { Button };
+});
 
 vi.mock('@/components/ui/input', () => ({
   Input: (props: any) => <input {...props} />,

--- a/components/chat-input-form/__tests__/memory-menu.test.tsx
+++ b/components/chat-input-form/__tests__/memory-menu.test.tsx
@@ -1,0 +1,560 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+  within,
+} from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { MemoryMenu } from '../memory-menu';
+
+// ---- Data-layer hook mocks ----
+const mockGetMentorMemoriesQuery = vi.fn();
+const mockGetMemoryCategoriesAdminQuery = vi.fn();
+const mockDeleteMentorMemory = vi.fn();
+const mockUpdateMentorMemory = vi.fn();
+const mockCreateMentorMemory = vi.fn();
+
+vi.mock('@iblai/iblai-js/data-layer', () => ({
+  useGetMentorMemoriesQuery: (...args: unknown[]) =>
+    mockGetMentorMemoriesQuery(...args),
+  useGetMemoryCategoriesAdminQuery: (...args: unknown[]) =>
+    mockGetMemoryCategoriesAdminQuery(...args),
+  useDeleteMentorMemoryMutation: () => [
+    mockDeleteMentorMemory,
+    { isLoading: false },
+  ],
+  useUpdateMentorMemoryMutation: () => [
+    mockUpdateMentorMemory,
+    { isLoading: false },
+  ],
+  useCreateMentorMemoryMutation: () => [
+    mockCreateMentorMemory,
+    { isLoading: false },
+  ],
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockGetMentorId = vi.fn();
+vi.mock('@/hooks/user-navigate', () => ({
+  useNavigate: () => ({ getMentorId: mockGetMentorId }),
+}));
+
+const mockUserIsStudent = vi.fn();
+vi.mock('@/hooks/use-user', () => ({
+  useUserIsStudent: () => mockUserIsStudent(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ tenantKey: 'org-1', mentorId: 'mentor-from-params' }),
+}));
+
+// UI primitive stubs so we can drive the form without Radix portals.
+vi.mock('@/components/ui/button', () => ({
+  Button: React.forwardRef(
+    ({ children, onClick, disabled, ...rest }: any, ref: any) => (
+      <button ref={ref} onClick={onClick} disabled={disabled} {...rest}>
+        {children}
+      </button>
+    ),
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  // Replace Radix Select with a native <select>; SelectTrigger/SelectValue
+  // are null so they don't end up as invalid children of a <select>.
+  Select: ({ value, onValueChange, children }: any) => (
+    <select
+      data-testid="select-native"
+      value={value ?? ''}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      <option value="">--</option>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ children, value }: any) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+const makeUnwrap = (fn: any, resolved: any = {}) => {
+  fn.mockImplementation(() => ({
+    unwrap: () => Promise.resolve(resolved),
+  }));
+};
+
+const makeRejectingUnwrap = (fn: any, error: any) => {
+  fn.mockImplementation(() => ({
+    unwrap: () => Promise.reject(error),
+  }));
+};
+
+const baseResponse = [
+  {
+    category: { id: 1, name: 'General', slug: 'general' },
+    memories: [
+      {
+        id: 10,
+        content: 'Likes tea',
+        category: { id: 1, name: 'General', slug: 'general' },
+        username: 'alice',
+        created_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+      {
+        id: 11,
+        content: 'Loves hiking',
+        category: { id: 1, name: 'General', slug: 'general' },
+        username: 'alice',
+      },
+    ],
+  },
+  {
+    category: { id: 2, name: 'Work', slug: 'work' },
+    memories: [
+      {
+        id: 20,
+        content: 'Prefers async standups',
+        category: { id: 2, name: 'Work', slug: 'work' },
+        username: 'alice',
+        created_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+      {
+        id: 21,
+        content: 'Uses dark mode',
+        category: { id: 2, name: 'Work', slug: 'work' },
+      },
+      {
+        id: 22,
+        content: 'Remote team',
+        category: { id: 2, name: 'Work', slug: 'work' },
+      },
+    ],
+  },
+];
+
+const adminCategories = [
+  { id: 1, name: 'General', slug: 'general' },
+  { id: 2, name: 'Work', slug: 'work' },
+];
+
+const defaultProps = {
+  onClose: vi.fn(),
+  tenantKey: 'org-1',
+  username: 'alice',
+};
+
+describe('MemoryMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMentorId.mockReturnValue('mentor-1');
+    mockUserIsStudent.mockReturnValue(false);
+    mockGetMentorMemoriesQuery.mockReturnValue({
+      data: baseResponse,
+      isLoading: false,
+    });
+    mockGetMemoryCategoriesAdminQuery.mockReturnValue({
+      data: adminCategories,
+    });
+    makeUnwrap(mockDeleteMentorMemory);
+    makeUnwrap(mockUpdateMentorMemory);
+    makeUnwrap(mockCreateMentorMemory);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders header, search and memories flattened from the response', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    expect(screen.getByText('Your Memory')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Search memories...'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Likes tea')).toBeInTheDocument();
+    expect(screen.getByText('Prefers async standups')).toBeInTheDocument();
+  });
+
+  it('shows the student-specific subtitle when useUserIsStudent returns true', () => {
+    mockUserIsStudent.mockReturnValue(true);
+    render(<MemoryMenu {...defaultProps} />);
+
+    expect(
+      screen.getByText('Your saved memories for this mentor'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while memories are loading', () => {
+    mockGetMentorMemoriesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    render(<MemoryMenu {...defaultProps} />);
+
+    // Loader2 from lucide-react renders as an svg inside the scrolling area.
+    expect(screen.queryByText('No memories yet.')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no memories', () => {
+    mockGetMentorMemoriesQuery.mockReturnValue({ data: [], isLoading: false });
+    render(<MemoryMenu {...defaultProps} />);
+
+    expect(screen.getByText('No memories yet.')).toBeInTheDocument();
+  });
+
+  it('shows the search-empty state when the filter matches nothing', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search memories...'), {
+      target: { value: 'zzzzz' },
+    });
+    expect(
+      screen.getByText('No memories found matching your search.'),
+    ).toBeInTheDocument();
+  });
+
+  it('filters memories by content and by category name', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const search = screen.getByPlaceholderText('Search memories...');
+
+    fireEvent.change(search, { target: { value: 'hiking' } });
+    expect(screen.getByText('Loves hiking')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Prefers async standups'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: 'work' } });
+    expect(screen.getByText('Prefers async standups')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the header X button is clicked', () => {
+    const onClose = vi.fn();
+    render(<MemoryMenu {...defaultProps} onClose={onClose} />);
+
+    // The second icon button in the header is the close X.
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[1]!);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('opens the add-memory form and creates a new memory', async () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    // First header icon button is Plus (add)
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[0]!);
+
+    expect(screen.getByText('Add New Memory')).toBeInTheDocument();
+
+    const contentArea = screen.getByPlaceholderText('Memory content...');
+    fireEvent.change(contentArea, { target: { value: 'Prefers SSH' } });
+
+    // Pick a category
+    const select = screen.getAllByTestId('select-native')[0]!;
+    fireEvent.change(select, { target: { value: 'work' } });
+
+    // Click save (first Save button in the form)
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockCreateMentorMemory).toHaveBeenCalledWith({
+        org: 'org-1',
+        userId: 'alice',
+        mentorId: 'mentor-1',
+        data: { category_slug: 'work', content: 'Prefers SSH' },
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Memory created');
+  });
+
+  it('falls back to the general slug when no category picked', async () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[0]!);
+
+    fireEvent.change(screen.getByPlaceholderText('Memory content...'), {
+      target: { value: 'default cat test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockCreateMentorMemory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { category_slug: 'general', content: 'default cat test' },
+        }),
+      );
+    });
+  });
+
+  it('disables save when content is blank and cancels the add form', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[0]!);
+
+    const saveBtn = screen.getByRole('button', {
+      name: 'Save',
+    }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+    fireEvent.click(saveBtn);
+    expect(mockCreateMentorMemory).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Add New Memory')).not.toBeInTheDocument();
+  });
+
+  it('toasts an error when creation fails', async () => {
+    makeRejectingUnwrap(mockCreateMentorMemory, new Error('boom'));
+    render(<MemoryMenu {...defaultProps} />);
+
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[0]!);
+
+    fireEvent.change(screen.getByPlaceholderText('Memory content...'), {
+      target: { value: 'will fail' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to create memory');
+    });
+  });
+
+  it('edits a memory and saves it with a changed category', async () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    // Find the Edit3 icon button within this card — it's the first action button.
+    const actionButtons = within(memoryCard).getAllByRole('button');
+    fireEvent.click(actionButtons[0]!);
+
+    const editArea = screen.getByPlaceholderText('Memory content...');
+    fireEvent.change(editArea, { target: { value: 'Likes herbal tea' } });
+
+    // Change category to work
+    const select = screen.getAllByTestId('select-native')[0]!;
+    fireEvent.change(select, { target: { value: 'work' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdateMentorMemory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memoryId: 10,
+          data: expect.objectContaining({
+            content: 'Likes herbal tea',
+            category_slug: 'work',
+          }),
+        }),
+      );
+    });
+    expect(toast.success).toHaveBeenCalledWith('Memory updated');
+  });
+
+  it('omits category_slug when unchanged during an edit', async () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    const actionButtons = within(memoryCard).getAllByRole('button');
+    fireEvent.click(actionButtons[0]!);
+
+    const editArea = screen.getByPlaceholderText('Memory content...');
+    fireEvent.change(editArea, { target: { value: 'Likes strong tea' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const call = mockUpdateMentorMemory.mock.calls[0]![0];
+      expect(call.data.content).toBe('Likes strong tea');
+      expect(call.data.category_slug).toBeUndefined();
+    });
+  });
+
+  it('cancels an in-progress edit without mutating', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    fireEvent.click(within(memoryCard).getAllByRole('button')[0]!);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(mockUpdateMentorMemory).not.toHaveBeenCalled();
+    expect(screen.getByText('Likes tea')).toBeInTheDocument();
+  });
+
+  it('toasts an error when edit fails', async () => {
+    makeRejectingUnwrap(mockUpdateMentorMemory, new Error('nope'));
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    fireEvent.click(within(memoryCard).getAllByRole('button')[0]!);
+    fireEvent.change(screen.getByPlaceholderText('Memory content...'), {
+      target: { value: 'still tea' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to update memory');
+    });
+  });
+
+  it('deletes a memory and shows a success toast', async () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    const actionButtons = within(memoryCard).getAllByRole('button');
+    // Second action button is delete (Trash2)
+    fireEvent.click(actionButtons[1]!);
+
+    await waitFor(() => {
+      expect(mockDeleteMentorMemory).toHaveBeenCalledWith({
+        org: 'org-1',
+        userId: 'alice',
+        mentorId: 'mentor-1',
+        memoryId: 10,
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Memory deleted');
+  });
+
+  it('toasts an error when delete fails', async () => {
+    makeRejectingUnwrap(mockDeleteMentorMemory, new Error('nope'));
+    render(<MemoryMenu {...defaultProps} />);
+
+    const memoryCard = screen.getByText('Likes tea').closest('div')!
+      .parentElement!.parentElement!;
+    fireEvent.click(within(memoryCard).getAllByRole('button')[1]!);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to delete memory');
+    });
+  });
+
+  it('toggles the "View All Memories" button when the list exceeds 4', () => {
+    render(<MemoryMenu {...defaultProps} />);
+
+    const viewAllBtn = screen.getByRole('button', {
+      name: /view all memories \(5\)/i,
+    });
+    fireEvent.click(viewAllBtn);
+    expect(
+      screen.getByRole('button', { name: /show less/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('derives categories from the response when admin categories are empty', () => {
+    mockGetMemoryCategoriesAdminQuery.mockReturnValue({ data: [] });
+    render(<MemoryMenu {...defaultProps} />);
+
+    // Open add form and check the category select still renders
+    const headerButtons = screen
+      .getByText('Your Memory')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(headerButtons[0]!);
+    expect(screen.getByText('Add New Memory')).toBeInTheDocument();
+  });
+
+  it('skips mentor memory query when tenantKey is missing', () => {
+    render(<MemoryMenu onClose={vi.fn()} username="alice" />);
+
+    const call = mockGetMentorMemoriesQuery.mock.calls[0]![1];
+    expect(call.skip).toBe(true);
+  });
+
+  it('passes my_memory=true in params for students', () => {
+    mockUserIsStudent.mockReturnValue(true);
+    render(<MemoryMenu {...defaultProps} />);
+
+    const call = mockGetMentorMemoriesQuery.mock.calls[0]![0];
+    expect(call.params).toEqual({ my_memory: 'true' });
+  });
+
+  it('falls back to mentorId from params when useNavigate returns null', () => {
+    mockGetMentorId.mockReturnValue(null);
+    render(<MemoryMenu {...defaultProps} />);
+
+    const call = mockGetMentorMemoriesQuery.mock.calls[0]![0];
+    expect(call.mentorId).toBe('mentor-from-params');
+  });
+
+  it('falls back to the raw string when formatDistanceToNow throws on an invalid date', () => {
+    mockGetMentorMemoriesQuery.mockReturnValue({
+      data: [
+        {
+          category: { id: 5, name: 'Misc', slug: 'misc' },
+          memories: [
+            {
+              id: 51,
+              content: 'bad date memory',
+              category: { id: 5, name: 'Misc', slug: 'misc' },
+              created_at: 'not-a-real-date',
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    });
+    render(<MemoryMenu {...defaultProps} />);
+    expect(screen.getByText('bad date memory')).toBeInTheDocument();
+    // The catch branch returns the raw string, so it must appear somewhere.
+    expect(screen.getByText('not-a-real-date')).toBeInTheDocument();
+  });
+
+  it('renders a timestamp gracefully when created_at is missing or invalid', () => {
+    mockGetMentorMemoriesQuery.mockReturnValue({
+      data: [
+        {
+          category: { id: 99, name: 'Custom', slug: 'custom' },
+          memories: [
+            {
+              id: 99,
+              content: 'No date',
+              category: { id: 99, name: 'Custom', slug: 'custom' },
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    });
+    render(<MemoryMenu {...defaultProps} />);
+    expect(screen.getByText('No date')).toBeInTheDocument();
+  });
+});

--- a/components/chat-input-form/inside-buttons.tsx
+++ b/components/chat-input-form/inside-buttons.tsx
@@ -46,6 +46,8 @@ export const InsideButtons = ({
   tenantKey,
   username,
 }: InsideButtonsProps) => {
+  console.log('memory==> isAnonymousMentor', isAnonymousMentor);
+  console.log('memory==> memoryEnabled', memoryEnabled);
   const allInsideButtons = [
     {
       name: 'Canvas',

--- a/components/chat-input-form/inside-buttons.tsx
+++ b/components/chat-input-form/inside-buttons.tsx
@@ -24,6 +24,10 @@ interface InsideButtonsProps {
   onOpenPromptGallery?: () => void;
   embedMode?: boolean;
   promptsIsEnabled?: boolean;
+  memoryEnabled?: boolean;
+  isAnonymousMentor?: boolean;
+  tenantKey?: string;
+  username?: string;
 }
 
 export const InsideButtons = ({
@@ -37,6 +41,10 @@ export const InsideButtons = ({
   onOpenPromptGallery,
   embedMode = false,
   promptsIsEnabled = false,
+  memoryEnabled = false,
+  isAnonymousMentor = false,
+  tenantKey,
+  username,
 }: InsideButtonsProps) => {
   const allInsideButtons = [
     {
@@ -71,9 +79,8 @@ export const InsideButtons = ({
       name: 'Memory',
       icon: <Archive className="h-4 w-4" />,
       isActive: activeOptions.includes(TOOLS.MEMORY),
-      // Memory actions are disabled for now.
-      action: /* istanbul ignore next */ () => onOptionClick(TOOLS.MEMORY),
-      isEnabled: false,
+      action: () => onOptionClick(TOOLS.MEMORY),
+      isEnabled: memoryEnabled && !embedMode && !isAnonymousMentor,
     },
   ].filter((item) => item.isEnabled);
 
@@ -115,9 +122,14 @@ export const InsideButtons = ({
     <div className="relative flex items-center gap-1.5">
       {/* Responsive Inside Buttons */}
       {visibleInsideButtons.map((button) => {
-        // Memory buttons are disabled for now.
-        /* istanbul ignore next */ if (button.name === 'Memory') {
-          return <MemoryButton key={button.name} />;
+        if (button.name === 'Memory') {
+          return (
+            <MemoryButton
+              key={button.name}
+              tenantKey={tenantKey}
+              username={username}
+            />
+          );
         }
 
         return (

--- a/components/chat-input-form/memory-button.tsx
+++ b/components/chat-input-form/memory-button.tsx
@@ -1,7 +1,7 @@
+'use client';
+
 import { useState } from 'react';
-
 import { Archive, X } from 'lucide-react';
-
 import {
   Popover,
   PopoverContent,
@@ -10,48 +10,49 @@ import {
 import { Button } from '@/components/ui/button';
 import { MemoryMenu } from './memory-menu';
 
-export function MemoryButton() {
+interface MemoryButtonProps {
+  tenantKey?: string;
+  username?: string;
+}
+
+export function MemoryButton({ tenantKey, username }: MemoryButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
-      <Popover open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            type="button"
-            className={`flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm transition-all duration-200 ${
-              isOpen
-                ? 'border border-[#D0E0FF] bg-[#F5F8FF] text-[#38A1E5]'
-                : 'text-gray-600 hover:border hover:border-[#D0E0FF] hover:bg-[#F5F8FF]'
-            }`}
-            onClick={() => {
-              setIsOpen(true);
-            }}
-          >
-            <span className={isOpen ? 'text-[#38A1E5]' : 'text-gray-600'}>
-              <Archive />
-            </span>
-            Memory
-            {isOpen && (
-              <X
-                className="ml-1 h-3 w-3 cursor-pointer"
-                onClick={() => {
-                  setIsOpen(false);
-                }}
-              />
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-96 rounded-lg border border-gray-200 bg-white p-0 shadow-xl">
-          <MemoryMenu
-            onClose={() => setIsOpen(false)}
-            onSelectMemory={() => {}}
-            selectedMemories={[]}
-          />
-        </PopoverContent>
-      </Popover>
-    </>
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          type="button"
+          className={`flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm transition-all duration-200 ${
+            isOpen
+              ? 'border border-[#D0E0FF] bg-[#F5F8FF] text-[#38A1E5]'
+              : 'text-gray-600 hover:border hover:border-[#D0E0FF] hover:bg-[#F5F8FF]'
+          }`}
+        >
+          <span className={isOpen ? 'text-[#38A1E5]' : 'text-gray-600'}>
+            <Archive className="h-4 w-4" />
+          </span>
+          Memory
+          {isOpen && (
+            <X
+              className="ml-1 h-3 w-3 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsOpen(false);
+              }}
+            />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 rounded-lg border border-gray-200 bg-white p-0 shadow-xl">
+        <MemoryMenu
+          onClose={() => setIsOpen(false)}
+          tenantKey={tenantKey}
+          username={username}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/components/chat-input-form/memory-menu.tsx
+++ b/components/chat-input-form/memory-menu.tsx
@@ -1,166 +1,233 @@
 'use client';
 
 import type React from 'react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { useParams } from 'next/navigation';
+import { formatDistanceToNow } from 'date-fns';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { X, Search, Edit3, Trash2, Plus } from 'lucide-react';
-
-export interface MemoryItem {
-  id: string;
-  title: string;
-  content: string;
-  timestamp: string;
-  category: string;
-}
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { X, Search, Edit3, Trash2, Plus, Loader2 } from 'lucide-react';
+import {
+  useGetMentorMemoriesQuery,
+  useDeleteMentorMemoryMutation,
+  useUpdateMentorMemoryMutation,
+  useCreateMentorMemoryMutation,
+  useGetMemoryCategoriesAdminQuery,
+  type MentorMemory,
+  type MentorMemoryCategory,
+} from '@iblai/iblai-js/data-layer';
+import { useNavigate } from '@/hooks/user-navigate';
+import { useUserIsStudent } from '@/hooks/use-user';
+import { toast } from 'sonner';
+import { TenantKeyMentorIdParams } from '@/lib/types';
 
 interface MemoryMenuProps {
   onClose: () => void;
-  onSelectMemory: (memory: MemoryItem) => void;
-  selectedMemories: MemoryItem[];
+  tenantKey?: string;
+  username?: string;
 }
 
-// Memory Menu Component
+interface FlatMemory {
+  id: number;
+  content: string;
+  category: {
+    id: number;
+    name: string;
+    slug: string;
+  };
+  username?: string;
+  createdAt?: string;
+}
+
 export const MemoryMenu = ({
   onClose,
-  onSelectMemory,
-  selectedMemories,
+  tenantKey,
+  username,
 }: MemoryMenuProps) => {
+  const { mentorId: mentorIdFromParams } = useParams<TenantKeyMentorIdParams>();
+  const { getMentorId } = useNavigate();
+  const mentorId = getMentorId() ?? mentorIdFromParams ?? '';
+  const isStudent = useUserIsStudent();
+
   const [showAllMemories, setShowAllMemories] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [isAddingMemory, setIsAddingMemory] = useState(false);
-  const [editingMemory, setEditingMemory] = useState<string | null>(null);
-  const [newMemory, setNewMemory] = useState({
-    title: '',
-    content: '',
-    category: 'General',
-  });
-  const [editMemoryData, setEditMemoryData] = useState({
-    title: '',
-    content: '',
-    category: '',
-  });
+  const [editingMemoryId, setEditingMemoryId] = useState<number | null>(null);
+  const [editContent, setEditContent] = useState('');
+  const [editCategorySlug, setEditCategorySlug] = useState('');
+  const [newMemory, setNewMemory] = useState({ content: '', categorySlug: '' });
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
-  // Mock memory data - replace with actual data from your memory system
-  const [memories, setMemories] = useState<MemoryItem[]>([
-    {
-      id: '1',
-      title: 'JavaScript Fundamentals',
-      content:
-        'User is learning JavaScript basics, focusing on variables, functions, and loops',
-      timestamp: '2 hours ago',
-      category: 'Learning',
-    },
-    {
-      id: '2',
-      title: 'Code Project Setup',
-      content:
-        'Working on a React project with TypeScript, needs help with component structure',
-      timestamp: '1 day ago',
-      category: 'Development',
-    },
-    {
-      id: '3',
-      title: 'Career Goals',
-      content:
-        'Interested in becoming a full-stack developer, currently focusing on frontend',
-      timestamp: '3 days ago',
-      category: 'Career',
-    },
-    {
-      id: '4',
-      title: 'Study Schedule',
-      content:
-        'Prefers studying in the morning, works better with visual examples',
-      timestamp: '1 week ago',
-      category: 'Preferences',
-    },
-    {
-      id: '5',
-      title: 'Python Learning Path',
-      content:
-        'Started learning Python for data science, completed basic syntax',
-      timestamp: '2 weeks ago',
-      category: 'Learning',
-    },
-    {
-      id: '6',
-      title: 'Project Deadlines',
-      content:
-        'Has upcoming project deadline next month, needs time management help',
-      timestamp: '3 weeks ago',
-      category: 'Planning',
-    },
-  ]);
-
-  const categories = [
-    'General',
-    'Learning',
-    'Development',
-    'Career',
-    'Preferences',
-    'Planning',
-  ];
-
-  const handleDeleteMemory = (memoryId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setMemories(memories.filter((m) => m.id !== memoryId));
-  };
-
-  const handleMemoryClick = (memory: MemoryItem) => {
-    if (editingMemory === memory.id) return;
-    onSelectMemory(memory);
-    onClose(); // Close the menu after selection
-  };
-
-  const handleAddMemory = () => {
-    if (newMemory.title.trim() && newMemory.content.trim()) {
-      const memory: MemoryItem = {
-        id: Date.now().toString(),
-        title: newMemory.title,
-        content: newMemory.content,
-        category: newMemory.category,
-        timestamp: 'Just now',
-      };
-      setMemories([memory, ...memories]);
-      setNewMemory({ title: '', content: '', category: 'General' });
-      setIsAddingMemory(false);
+  // Build query params - add my_memory=true for students
+  const queryParams = useMemo(() => {
+    const params: Record<string, string> = {};
+    if (isStudent) {
+      params.my_memory = 'true';
     }
-  };
+    return Object.keys(params).length > 0 ? params : undefined;
+  }, [isStudent]);
 
-  const handleEditMemory = (memory: MemoryItem) => {
-    setEditingMemory(memory.id);
-    setEditMemoryData({
-      title: memory.title,
-      content: memory.content,
-      category: memory.category,
-    });
-  };
-
-  const handleSaveEdit = (memoryId: string) => {
-    setMemories(
-      memories.map((m) =>
-        m.id === memoryId
-          ? {
-              ...m,
-              title: editMemoryData.title,
-              content: editMemoryData.content,
-              category: editMemoryData.category,
-            }
-          : m,
-      ),
+  const { data: memoriesByCategoryResponse, isLoading } =
+    useGetMentorMemoriesQuery(
+      {
+        org: tenantKey ?? '',
+        userId: username ?? '',
+        mentorId,
+        // @ts-ignore - my_memory param exists on API but not typed
+        ...(queryParams ? { params: queryParams } : {}),
+      },
+      {
+        skip: !tenantKey || !username || !mentorId,
+      },
     );
-    setEditingMemory(null);
-    setEditMemoryData({ title: '', content: '', category: '' });
-  };
+
+  const { data: adminCategories } = useGetMemoryCategoriesAdminQuery(
+    {
+      org: tenantKey ?? '',
+      mentorId,
+    },
+    {
+      skip: !tenantKey || !mentorId,
+    },
+  );
+
+  const [deleteMentorMemory] = useDeleteMentorMemoryMutation();
+  const [updateMentorMemory, { isLoading: isUpdating }] =
+    useUpdateMentorMemoryMutation();
+  const [createMentorMemory, { isLoading: isCreating }] =
+    useCreateMentorMemoryMutation();
+
+  // Flatten the by-category response into a flat list
+  const memories: FlatMemory[] = useMemo(() => {
+    if (!memoriesByCategoryResponse) return [];
+    return memoriesByCategoryResponse.flatMap((item) =>
+      item.memories.map((memory: MentorMemory) => ({
+        id: memory.id,
+        content: memory.content,
+        category: {
+          id: memory.category.id,
+          name: memory.category.name,
+          slug: memory.category.slug,
+        },
+        username: memory.username,
+        createdAt: memory.created_at,
+      })),
+    );
+  }, [memoriesByCategoryResponse]);
+
+  // Build category list
+  const categories = useMemo(() => {
+    if (adminCategories && adminCategories.length > 0) {
+      return adminCategories.map((cat: MentorMemoryCategory) => ({
+        id: cat.id,
+        name: cat.name,
+        slug: cat.slug,
+      }));
+    }
+    if (!memoriesByCategoryResponse) return [];
+    return memoriesByCategoryResponse.map((item) => ({
+      id: item.category.id,
+      name: item.category.name,
+      slug: item.category.slug,
+    }));
+  }, [adminCategories, memoriesByCategoryResponse]);
 
   const filteredMemories = memories.filter(
     (memory) =>
-      memory.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
       memory.content.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      memory.category.toLowerCase().includes(searchQuery.toLowerCase()),
+      memory.category.name.toLowerCase().includes(searchQuery.toLowerCase()),
   );
+
+  const handleDeleteMemory = async (memoryId: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!tenantKey || !username) return;
+
+    setDeletingId(memoryId);
+    try {
+      await deleteMentorMemory({
+        org: tenantKey,
+        userId: username,
+        mentorId,
+        memoryId,
+      }).unwrap();
+      toast.success('Memory deleted');
+    } catch {
+      toast.error('Failed to delete memory');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleAddMemory = async () => {
+    if (!newMemory.content.trim() || !tenantKey || !username) return;
+
+    try {
+      await createMentorMemory({
+        org: tenantKey,
+        userId: username,
+        mentorId,
+        data: {
+          category_slug: newMemory.categorySlug || 'general',
+          content: newMemory.content.trim(),
+        },
+      }).unwrap();
+      setNewMemory({ content: '', categorySlug: '' });
+      setIsAddingMemory(false);
+      toast.success('Memory created');
+    } catch {
+      toast.error('Failed to create memory');
+    }
+  };
+
+  const startEdit = (memory: FlatMemory, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingMemoryId(memory.id);
+    setEditContent(memory.content);
+    setEditCategorySlug(memory.category.slug);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingMemoryId || !tenantKey || !username) return;
+
+    const original = memories.find((m) => m.id === editingMemoryId);
+    try {
+      await updateMentorMemory({
+        org: tenantKey,
+        userId: username,
+        mentorId,
+        memoryId: editingMemoryId,
+        data: {
+          content: editContent,
+          ...(original && editCategorySlug !== original.category.slug
+            ? { category_slug: editCategorySlug }
+            : {}),
+        },
+      }).unwrap();
+      setEditingMemoryId(null);
+      setEditContent('');
+      setEditCategorySlug('');
+      toast.success('Memory updated');
+    } catch {
+      toast.error('Failed to update memory');
+    }
+  };
+
+  const formatTimestamp = (dateStr?: string) => {
+    if (!dateStr) return '';
+    try {
+      return formatDistanceToNow(new Date(dateStr), { addSuffix: true });
+    } catch {
+      return dateStr;
+    }
+  };
 
   return (
     <>
@@ -187,7 +254,6 @@ export const MemoryMenu = ({
           </div>
         </div>
 
-        {/* Search Bar */}
         <div className="relative">
           <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
           <Input
@@ -199,7 +265,9 @@ export const MemoryMenu = ({
         </div>
 
         <p className="mt-2 text-sm text-gray-500">
-          Select memories to include in your conversation
+          {isStudent
+            ? 'Your saved memories for this mentor'
+            : 'Memories for this mentor'}
         </p>
       </div>
 
@@ -208,14 +276,6 @@ export const MemoryMenu = ({
         <div className="border-b border-gray-100 bg-gray-50 p-4">
           <h4 className="mb-3 font-medium text-gray-900">Add New Memory</h4>
           <div className="space-y-3">
-            <Input
-              placeholder="Memory title..."
-              value={newMemory.title}
-              onChange={(e) =>
-                setNewMemory({ ...newMemory, title: e.target.value })
-              }
-              className="h-8 rounded-md border border-gray-300 text-sm"
-            />
             <Textarea
               placeholder="Memory content..."
               value={newMemory.content}
@@ -224,31 +284,44 @@ export const MemoryMenu = ({
               }
               className="min-h-[60px] resize-none rounded-md border border-gray-300 text-sm"
             />
-            <select
-              value={newMemory.category}
-              onChange={(e) =>
-                setNewMemory({ ...newMemory, category: e.target.value })
-              }
-              className="h-8 w-full rounded-md border border-gray-300 bg-white px-2 text-sm"
-            >
-              {categories.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat}
-                </option>
-              ))}
-            </select>
+            {categories.length > 0 && (
+              <Select
+                value={newMemory.categorySlug}
+                onValueChange={(val) =>
+                  setNewMemory({ ...newMemory, categorySlug: val })
+                }
+              >
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue placeholder="Select category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.slug} value={cat.slug}>
+                      {cat.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             <div className="flex gap-2">
               <Button
                 size="sm"
                 onClick={handleAddMemory}
+                disabled={!newMemory.content.trim() || isCreating}
                 className="bg-[#38A1E5] text-white hover:bg-[#2891D5]"
               >
+                {isCreating ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : null}
                 Save
               </Button>
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => setIsAddingMemory(false)}
+                onClick={() => {
+                  setIsAddingMemory(false);
+                  setNewMemory({ content: '', categorySlug: '' });
+                }}
               >
                 Cancel
               </Button>
@@ -260,159 +333,143 @@ export const MemoryMenu = ({
       <div
         className={`${showAllMemories ? 'max-h-80' : 'max-h-64'} overflow-y-auto`}
       >
-        {filteredMemories
-          .slice(0, showAllMemories ? filteredMemories.length : 4)
-          .map((memory) => {
-            const isSelected = selectedMemories.some((m) => m.id === memory.id);
-            const isEditing = editingMemory === memory.id;
-
-            return (
-              <div
-                key={memory.id}
-                className={`border-b border-gray-50 p-3 transition-colors last:border-b-0 ${
-                  isSelected ? 'bg-blue-50' : 'hover:bg-gray-50'
-                }`}
-              >
-                {isEditing ? (
-                  <div className="space-y-3">
-                    <Input
-                      value={editMemoryData.title}
-                      onChange={(e) =>
-                        setEditMemoryData({
-                          ...editMemoryData,
-                          title: e.target.value,
-                        })
-                      }
-                      className="h-8 rounded-md border border-gray-300 text-sm font-medium"
-                      placeholder="Memory title..."
-                    />
-                    <Textarea
-                      value={editMemoryData.content}
-                      onChange={(e) =>
-                        setEditMemoryData({
-                          ...editMemoryData,
-                          content: e.target.value,
-                        })
-                      }
-                      className="min-h-[60px] resize-none rounded-md border border-gray-300 text-sm"
-                      placeholder="Memory content..."
-                    />
-                    <select
-                      value={editMemoryData.category}
-                      onChange={(e) =>
-                        setEditMemoryData({
-                          ...editMemoryData,
-                          category: e.target.value,
-                        })
-                      }
-                      className="h-8 w-full rounded-md border border-gray-300 bg-white px-2 text-sm"
-                    >
-                      {categories.map((cat) => (
-                        <option key={cat} value={cat}>
-                          {cat}
-                        </option>
-                      ))}
-                    </select>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        onClick={() => handleSaveEdit(memory.id)}
-                        className="bg-[#38A1E5] text-white hover:bg-[#2891D5]"
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => setEditingMemory(null)}
-                      >
-                        Cancel
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  <div
-                    className="cursor-pointer"
-                    onClick={() => handleMemoryClick(memory)}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2">
-                          <h4
-                            className={`text-sm font-medium ${isSelected ? 'text-blue-900' : 'text-gray-900'}`}
-                          >
-                            {memory.title}
-                          </h4>
-                          <span
-                            className={`rounded-full px-2 py-0.5 text-xs ${
-                              isSelected
-                                ? 'bg-blue-200 text-blue-800'
-                                : 'bg-blue-100 text-blue-700'
-                            }`}
-                          >
-                            {memory.category}
-                          </span>
-                        </div>
-                        <p
-                          className={`mt-1 line-clamp-2 text-xs ${isSelected ? 'text-blue-700' : 'text-gray-600'}`}
-                        >
-                          {memory.content}
-                        </p>
-                        <p
-                          className={`mt-1 text-xs ${isSelected ? 'text-blue-500' : 'text-gray-400'}`}
-                        >
-                          {memory.timestamp}
-                        </p>
-                      </div>
-                      <div className="ml-2 flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6 rounded-full hover:bg-blue-100"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleEditMemory(memory);
-                          }}
-                        >
-                          <Edit3 className="h-3 w-3 text-blue-500" />
-                        </Button>
-                        {showAllMemories && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-6 w-6 rounded-full hover:bg-red-100"
-                            onClick={(e) => handleDeleteMemory(memory.id, e)}
-                          >
-                            <Trash2 className="h-3 w-3 text-red-500" />
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-
-        {filteredMemories.length === 0 && (
-          <div className="p-4 text-center text-sm text-gray-500">
-            {searchQuery
-              ? 'No memories found matching your search.'
-              : 'No memories yet.'}
+        {isLoading ? (
+          <div className="flex items-center justify-center p-8">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
           </div>
+        ) : (
+          <>
+            {filteredMemories
+              .slice(0, showAllMemories ? filteredMemories.length : 4)
+              .map((memory) => {
+                const isEditing = editingMemoryId === memory.id;
+
+                return (
+                  <div
+                    key={memory.id}
+                    className="border-b border-gray-50 p-3 transition-colors last:border-b-0 hover:bg-gray-50"
+                  >
+                    {isEditing ? (
+                      <div className="space-y-3">
+                        <Textarea
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.target.value)}
+                          className="min-h-[60px] resize-none rounded-md border border-gray-300 text-sm"
+                          placeholder="Memory content..."
+                        />
+                        {categories.length > 0 && (
+                          <Select
+                            value={editCategorySlug}
+                            onValueChange={setEditCategorySlug}
+                          >
+                            <SelectTrigger className="h-8 text-sm">
+                              <SelectValue placeholder="Select category" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {categories.map((cat) => (
+                                <SelectItem key={cat.slug} value={cat.slug}>
+                                  {cat.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            onClick={handleSaveEdit}
+                            disabled={!editContent.trim() || isUpdating}
+                            className="bg-[#38A1E5] text-white hover:bg-[#2891D5]"
+                          >
+                            {isUpdating ? (
+                              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                            ) : null}
+                            Save
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setEditingMemoryId(null);
+                              setEditContent('');
+                              setEditCategorySlug('');
+                            }}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div>
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+                                {memory.category.name}
+                              </span>
+                            </div>
+                            <p className="mt-1 line-clamp-2 text-xs text-gray-600">
+                              {memory.content}
+                            </p>
+                            <p className="mt-1 text-xs text-gray-400">
+                              {formatTimestamp(memory.createdAt)}
+                            </p>
+                          </div>
+                          <div className="ml-2 flex items-center gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 rounded-full hover:bg-blue-100"
+                              onClick={(e) => startEdit(memory, e)}
+                            >
+                              <Edit3 className="h-3 w-3 text-blue-500" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 rounded-full hover:bg-red-100"
+                              disabled={deletingId === memory.id}
+                              onClick={(e) => handleDeleteMemory(memory.id, e)}
+                            >
+                              {deletingId === memory.id ? (
+                                <Loader2 className="h-3 w-3 animate-spin text-red-500" />
+                              ) : (
+                                <Trash2 className="h-3 w-3 text-red-500" />
+                              )}
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+
+            {filteredMemories.length === 0 && !isLoading && (
+              <div className="p-4 text-center text-sm text-gray-500">
+                {searchQuery
+                  ? 'No memories found matching your search.'
+                  : 'No memories yet.'}
+              </div>
+            )}
+          </>
         )}
       </div>
 
-      <div className="border-t border-gray-100 p-3">
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full bg-transparent text-xs"
-          onClick={() => setShowAllMemories(!showAllMemories)}
-        >
-          {showAllMemories ? 'Show Less' : 'View All Memories'}
-        </Button>
-      </div>
+      {filteredMemories.length > 4 && (
+        <div className="border-t border-gray-100 p-3">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full bg-transparent text-xs"
+            onClick={() => setShowAllMemories(!showAllMemories)}
+          >
+            {showAllMemories
+              ? 'Show Less'
+              : `View All Memories (${filteredMemories.length})`}
+          </Button>
+        </div>
+      )}
     </>
   );
 };

--- a/components/modals/edit-mentor-modal/__tests__/index.test.tsx
+++ b/components/modals/edit-mentor-modal/__tests__/index.test.tsx
@@ -103,7 +103,7 @@ vi.mock('@iblai/iblai-js/data-layer', async (importOriginal) => {
       isLoading: false,
       isSuccess: true,
     }),
-    useGetMemsearchConfigQuery: () => ({
+    useGetMemsearchStatusQuery: () => ({
       data: { enable_memsearch: mockMemsearchEnabled },
       isLoading: false,
       isSuccess: true,

--- a/components/modals/edit-mentor-modal/edit-mentor-modal.test.tsx
+++ b/components/modals/edit-mentor-modal/edit-mentor-modal.test.tsx
@@ -107,7 +107,7 @@ vi.mock('@iblai/iblai-js/data-layer', async (importOriginal) => {
       isLoading: false,
       isSuccess: mockIsSuccess,
     }),
-    useGetMemsearchConfigQuery: () => ({
+    useGetMemsearchStatusQuery: () => ({
       data: { enable_memsearch: true },
     }),
   };

--- a/components/modals/edit-mentor-modal/tabs/__tests__/tools-tab.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/__tests__/tools-tab.test.tsx
@@ -11,7 +11,7 @@ import { ToolsTab } from '../tools-tab';
 
 // ---- Mocks ----
 const mockGetToolsQuery = vi.fn();
-const mockGetMemsearchConfigQuery = vi.fn();
+const mockGetMemsearchStatusQuery = vi.fn();
 const mockGetMentorSettingsQuery = vi.fn();
 const mockToggleTools = vi.fn();
 
@@ -31,8 +31,8 @@ vi.mock('@/hooks/user-navigate', () => ({
 
 vi.mock('@iblai/iblai-js/data-layer', () => ({
   useGetToolsQuery: (...args: any[]) => mockGetToolsQuery(...args),
-  useGetMemsearchConfigQuery: (...args: any[]) =>
-    mockGetMemsearchConfigQuery(...args),
+  useGetMemsearchStatusQuery: (...args: any[]) =>
+    mockGetMemsearchStatusQuery(...args),
   useGetMentorSettingsQuery: (...args: any[]) =>
     mockGetMentorSettingsQuery(...args),
 }));
@@ -114,7 +114,7 @@ describe('ToolsTab', () => {
   beforeEach(() => {
     cleanup();
     mockGetToolsQuery.mockReset();
-    mockGetMemsearchConfigQuery.mockReset();
+    mockGetMemsearchStatusQuery.mockReset();
     mockGetMentorSettingsQuery.mockReset();
     mockToggleTools.mockReset();
     mockToggleTools.mockResolvedValue(undefined);
@@ -124,7 +124,7 @@ describe('ToolsTab', () => {
       isLoading: false,
     });
 
-    mockGetMemsearchConfigQuery.mockReturnValue({
+    mockGetMemsearchStatusQuery.mockReturnValue({
       data: { enable_memsearch: true },
     });
 
@@ -210,14 +210,14 @@ describe('ToolsTab', () => {
   // Historical note: earlier tests here asserted that the Memory tool was
   // hidden when the `enable_memsearch` config flag was false. `tools-tab.tsx`
   // currently has no memsearch gating — it renders every tool returned by
-  // `useGetToolsQuery` regardless of `useGetMemsearchConfigQuery`, which the
+  // `useGetToolsQuery` regardless of `useGetMemsearchStatusQuery`, which the
   // source does not even import. The tests below instead pin the actual
   // current invariant: memory-tool visibility is decoupled from the memsearch
   // config flag. If gating is later re-introduced into this component, these
   // tests will fail and the new gating tests should replace them.
   describe('Memory Tools Rendering (memsearch-independent)', () => {
     it('renders the Memory tool when enable_memsearch is true', () => {
-      mockGetMemsearchConfigQuery.mockReturnValue({
+      mockGetMemsearchStatusQuery.mockReturnValue({
         data: { enable_memsearch: true },
       });
 
@@ -228,7 +228,7 @@ describe('ToolsTab', () => {
     });
 
     it('still renders the Memory tool when enable_memsearch is false (no gating in this component)', () => {
-      mockGetMemsearchConfigQuery.mockReturnValue({
+      mockGetMemsearchStatusQuery.mockReturnValue({
         data: { enable_memsearch: false },
       });
 
@@ -239,7 +239,7 @@ describe('ToolsTab', () => {
     });
 
     it('still renders the Memory tool when the memsearch config is undefined', () => {
-      mockGetMemsearchConfigQuery.mockReturnValue({
+      mockGetMemsearchStatusQuery.mockReturnValue({
         data: undefined,
       });
 

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-categories-modal.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-categories-modal.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { ManageCategoriesModal } from '../manage-categories-modal';
+
+const mockGetCategoriesQuery = vi.fn();
+const mockCreateCategory = vi.fn();
+const mockUpdateCategory = vi.fn();
+const mockDeleteCategory = vi.fn();
+
+vi.mock('@iblai/iblai-js/data-layer', () => ({
+  useGetMemoryCategoriesAdminQuery: (...args: any[]) =>
+    mockGetCategoriesQuery(...args),
+  useCreateMemoryCategoryMutation: () => [
+    mockCreateCategory,
+    { isLoading: false },
+  ],
+  useUpdateMemoryCategoryMutation: () => [
+    mockUpdateCategory,
+    { isLoading: false },
+  ],
+  useDeleteMemoryCategoryMutation: () => [
+    mockDeleteCategory,
+    { isLoading: false },
+  ],
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Dialog ⇒ render children when open; skip Radix portals/animations.
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: any) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...rest }: any) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+const makeUnwrap = (mockFn: any) => {
+  // RTK Query's `.unwrap()` returns a Promise that resolves with the payload
+  // or rejects with the error.
+  mockFn.mockImplementation(() => ({
+    unwrap: () => Promise.resolve({}),
+  }));
+};
+
+const makeRejectingUnwrap = (mockFn: any, error: any) => {
+  mockFn.mockImplementation(() => ({
+    unwrap: () => Promise.reject(error),
+  }));
+};
+
+const baseCategories = [
+  { id: 1, name: 'General', slug: 'general' },
+  { id: 2, name: 'Work', slug: 'work' },
+];
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  tenantKey: 'org-1',
+  mentorId: 'mentor-1',
+};
+
+describe('ManageCategoriesModal', () => {
+  beforeEach(() => {
+    mockGetCategoriesQuery.mockReturnValue({
+      data: baseCategories,
+      isLoading: false,
+    });
+    makeUnwrap(mockCreateCategory);
+    makeUnwrap(mockUpdateCategory);
+    makeUnwrap(mockDeleteCategory);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it('renders existing categories from the query', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    expect(screen.getByText('General')).toBeTruthy();
+    expect(screen.getByText('Work')).toBeTruthy();
+  });
+
+  it('shows an empty state when no categories exist', () => {
+    mockGetCategoriesQuery.mockReturnValue({ data: [], isLoading: false });
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    expect(screen.getByText('No categories yet.')).toBeTruthy();
+  });
+
+  it('shows a loading state while the query is in flight', () => {
+    mockGetCategoriesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    expect(screen.getByText('Loading categories...')).toBeTruthy();
+  });
+
+  it('creates a new category with an auto-derived slug', async () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(
+      'New category name',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Deep Focus' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(mockCreateCategory).toHaveBeenCalledWith({
+        org: 'org-1',
+        mentorId: 'mentor-1',
+        data: { name: 'Deep Focus', slug: 'deep_focus' },
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Category created');
+    // Input should reset after success
+    expect(input.value).toBe('');
+  });
+
+  it('does nothing when the new category name is blank', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    const addButton = screen.getByRole('button', {
+      name: /add/i,
+    }) as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+    fireEvent.click(addButton);
+    expect(mockCreateCategory).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error when category creation fails', async () => {
+    makeRejectingUnwrap(mockCreateCategory, new Error('boom'));
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText('New category name'), {
+      target: { value: 'Bad' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to create category');
+    });
+  });
+
+  it('renames a category via the edit flow', async () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+
+    // Second input is the edit-row input (first is "New category name")
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    const editInput = inputs[1];
+    fireEvent.change(editInput, { target: { value: 'Workstream' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save category' }));
+
+    await waitFor(() => {
+      expect(mockUpdateCategory).toHaveBeenCalledWith({
+        org: 'org-1',
+        mentorId: 'mentor-1',
+        categoryId: 2,
+        data: { name: 'Workstream' },
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Category updated');
+  });
+
+  it('cancels an in-progress edit without calling the mutation', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel edit' }));
+
+    expect(mockUpdateCategory).not.toHaveBeenCalled();
+    // Row should return to display mode
+    expect(screen.getByText('Work')).toBeTruthy();
+  });
+
+  it('requires confirmation before deleting a category', async () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }));
+
+    // Delete has not been called yet — inline confirm is showing.
+    expect(mockDeleteCategory).not.toHaveBeenCalled();
+    expect(screen.getByText(/Delete .*Work.*\?/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockDeleteCategory).toHaveBeenCalledWith({
+        org: 'org-1',
+        mentorId: 'mentor-1',
+        categoryId: 2,
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Category deleted');
+  });
+
+  it('backs out of the delete confirmation with Cancel', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockDeleteCategory).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Delete .*Work.*\?/)).toBeNull();
+  });
+
+  it('toasts an error when deletion fails', async () => {
+    makeRejectingUnwrap(mockDeleteCategory, new Error('nope'));
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }));
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to delete category');
+    });
+  });
+
+  it('closes via the Done button', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ManageCategoriesModal {...defaultProps} onOpenChange={onOpenChange} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-categories-modal.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-categories-modal.test.tsx
@@ -41,9 +41,21 @@ vi.mock('sonner', () => ({
 }));
 
 // Dialog ⇒ render children when open; skip Radix portals/animations.
+// The hidden `dialog-dismiss` button exposes the component's onOpenChange
+// wrapper so tests can exercise the reset-on-close code path.
 vi.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ open, children }: any) =>
-    open ? <div role="dialog">{children}</div> : null,
+  Dialog: ({ open, onOpenChange, children }: any) =>
+    open ? (
+      <div role="dialog">
+        <button
+          data-testid="dialog-dismiss"
+          onClick={() => onOpenChange?.(false)}
+        >
+          dismiss
+        </button>
+        {children}
+      </div>
+    ) : null,
   DialogContent: ({ children }: any) => <div>{children}</div>,
   DialogHeader: ({ children }: any) => <div>{children}</div>,
   DialogTitle: ({ children }: any) => <h2>{children}</h2>,
@@ -258,5 +270,114 @@ describe('ManageCategoriesModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('creates a category when Enter is pressed inside the new-name input', async () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText('New category name');
+    fireEvent.change(input, { target: { value: 'Quick Add' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockCreateCategory).toHaveBeenCalledWith({
+        org: 'org-1',
+        mentorId: 'mentor-1',
+        data: { name: 'Quick Add', slug: 'quick_add' },
+      });
+    });
+  });
+
+  it('does not submit on Enter when the new-name input is empty', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText('New category name');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockCreateCategory).not.toHaveBeenCalled();
+  });
+
+  it('saves an edit when Enter is pressed inside the edit input', async () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    const editInput = (
+      screen.getAllByRole('textbox') as HTMLInputElement[]
+    )[1]!;
+    fireEvent.change(editInput, { target: { value: 'Work Renamed' } });
+    fireEvent.keyDown(editInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockUpdateCategory).toHaveBeenCalledWith({
+        org: 'org-1',
+        mentorId: 'mentor-1',
+        categoryId: 2,
+        data: { name: 'Work Renamed' },
+      });
+    });
+  });
+
+  it('cancels an edit when Escape is pressed inside the edit input', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    const editInput = (
+      screen.getAllByRole('textbox') as HTMLInputElement[]
+    )[1]!;
+    fireEvent.change(editInput, { target: { value: 'Scrap' } });
+    fireEvent.keyDown(editInput, { key: 'Escape' });
+
+    expect(mockUpdateCategory).not.toHaveBeenCalled();
+    expect(screen.getByText('Work')).toBeTruthy();
+  });
+
+  it('does not call update when the trimmed edit name is empty', () => {
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    const editInput = (
+      screen.getAllByRole('textbox') as HTMLInputElement[]
+    )[1]!;
+    fireEvent.change(editInput, { target: { value: '   ' } });
+    fireEvent.keyDown(editInput, { key: 'Enter' });
+
+    expect(mockUpdateCategory).not.toHaveBeenCalled();
+  });
+
+  it('resets transient state when the dialog dispatches onOpenChange(false)', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ManageCategoriesModal {...defaultProps} onOpenChange={onOpenChange} />,
+    );
+
+    // Populate new-name, start an edit, and stage a delete confirm so
+    // that every reset branch inside the wrapper has work to do.
+    fireEvent.change(screen.getByPlaceholderText('New category name'), {
+      target: { value: 'Draft' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }));
+
+    // Dispatch the close from the Dialog mock → component wrapper runs
+    // cancelEdit/setConfirmDeleteId(null)/setNewName('') before forwarding.
+    fireEvent.click(screen.getByTestId('dialog-dismiss'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('toasts an error when an update fails', async () => {
+    makeRejectingUnwrap(mockUpdateCategory, new Error('update boom'));
+    render(<ManageCategoriesModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Work' }));
+    const editInput = (
+      screen.getAllByRole('textbox') as HTMLInputElement[]
+    )[1]!;
+    fireEvent.change(editInput, { target: { value: 'Workflow' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save category' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to update category');
+    });
   });
 });

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
@@ -40,6 +40,14 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
     mockCreateMentorMemory,
     { isLoading: mockCreateMentorMemoryLoading() },
   ],
+  // Category mutation hooks used by ManageCategoriesModal. The modal itself
+  // is stubbed below via `vi.mock('../manage-categories-modal', ...)`, but
+  // these stubs guard against any transitive resolution of the module.
+  useCreateMemoryCategoryMutation: () => [vi.fn(), { isLoading: false }],
+  useUpdateMemoryCategoryMutation: () => [vi.fn(), { isLoading: false }],
+  useDeleteMemoryCategoryMutation: () => [vi.fn(), { isLoading: false }],
+  // Pulled in transitively via use-mentor-settings on some import chains.
+  useGetMemsearchConfigQuery: () => ({ data: undefined, isLoading: false }),
 }));
 
 vi.mock('sonner', () => ({
@@ -155,6 +163,11 @@ vi.mock('../edit-memory-modal', () => ({
         </button>
       </div>
     ) : null,
+}));
+
+vi.mock('../manage-categories-modal', () => ({
+  ManageCategoriesModal: ({ open }: any) =>
+    open ? <div data-testid="manage-categories-modal" /> : null,
 }));
 
 vi.mock('../add-memory-modal', () => ({

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
@@ -47,7 +47,7 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
   useUpdateMemoryCategoryMutation: () => [vi.fn(), { isLoading: false }],
   useDeleteMemoryCategoryMutation: () => [vi.fn(), { isLoading: false }],
   // Pulled in transitively via use-mentor-settings on some import chains.
-  useGetMemsearchConfigQuery: () => ({ data: undefined, isLoading: false }),
+  useGetMemsearchStatusQuery: () => ({ data: undefined, isLoading: false }),
 }));
 
 vi.mock('sonner', () => ({

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/__tests__/manage-memories.test.tsx
@@ -945,6 +945,67 @@ describe('ManageMemories', () => {
       expect(screen.getAllByText('alice').length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText('bob').length).toBeGreaterThanOrEqual(1);
     });
+
+    it('selects a learner from the user dropdown and re-queries with user_id', () => {
+      render(<ManageMemories {...defaultProps} />);
+      const callsBefore = mockGetMentorMemoriesQuery.mock.calls.length;
+
+      // CommandItems render inside the user combobox; the learner items
+      // come after the "All Users" item. Click the first learner item
+      // (which invokes onSelect → setSelectedLearner).
+      const commandItems = screen.getAllByRole('option');
+      // index 0 is "All Users", index 1+ are learner items.
+      fireEvent.click(commandItems[1]!);
+
+      // After selecting a learner, the filtered query re-runs — at
+      // least one of the new calls should carry user_id in params.
+      const newCalls = mockGetMentorMemoriesQuery.mock.calls.slice(callsBefore);
+      const withUserId = newCalls.find(
+        (call) => call[0]?.params && 'user_id' in call[0].params,
+      );
+      expect(withUserId).toBeTruthy();
+    });
+  });
+
+  describe('Category fallback when admin categories are unavailable', () => {
+    it('derives category tabs from the memories response when admin categories are empty', () => {
+      mockGetMemoryCategoriesAdminQuery.mockReturnValue({ data: [] });
+      render(<ManageMemories {...defaultProps} />);
+
+      // The derived categories include the seed "All" plus those found on
+      // the response payload — Preferences and Background.
+      expect(screen.getAllByText('Preferences').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Background').length).toBeGreaterThan(0);
+    });
+
+    it('falls back to just "All" when the memories response is undefined', () => {
+      mockGetMemoryCategoriesAdminQuery.mockReturnValue({ data: [] });
+      mockGetMentorMemoriesQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      });
+      render(<ManageMemories {...defaultProps} />);
+      // "All" still renders as the only category tab.
+      expect(screen.getAllByText('All').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Mobile category dropdown', () => {
+    it('selects a category via the mobile dropdown onClick', () => {
+      render(<ManageMemories {...defaultProps} />);
+
+      // Desktop tab renders "Background" as a <button>, mobile dropdown
+      // renders each category as a DropdownMenuItem (role=menuitem).
+      const backgroundMenuItem = screen
+        .getAllByRole('menuitem')
+        .find((el) => el.textContent === 'Background');
+      expect(backgroundMenuItem).toBeTruthy();
+      fireEvent.click(backgroundMenuItem!);
+
+      // Only "Background" memories should remain visible.
+      expect(screen.getByText('Former backend dev')).toBeInTheDocument();
+      expect(screen.queryByText('Loves dark mode')).not.toBeInTheDocument();
+    });
   });
 
   describe('Query skip logic', () => {

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/manage-categories-modal.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/manage-categories-modal.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Check, Pencil, Plus, Trash2, X } from 'lucide-react';
+import {
+  useGetMemoryCategoriesAdminQuery,
+  useCreateMemoryCategoryMutation,
+  useUpdateMemoryCategoryMutation,
+  useDeleteMemoryCategoryMutation,
+  type MentorMemoryCategory,
+} from '@iblai/iblai-js/data-layer';
+import { toast } from 'sonner';
+
+interface ManageCategoriesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tenantKey: string;
+  mentorId: string;
+}
+
+const toSlug = (name: string) =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+export function ManageCategoriesModal({
+  open,
+  onOpenChange,
+  tenantKey,
+  mentorId,
+}: ManageCategoriesModalProps) {
+  const { data: categories = [], isLoading } = useGetMemoryCategoriesAdminQuery(
+    { org: tenantKey, mentorId },
+    { skip: !open || !tenantKey || !mentorId },
+  );
+
+  const [createCategory, { isLoading: isCreating }] =
+    useCreateMemoryCategoryMutation();
+  const [updateCategory, { isLoading: isUpdating }] =
+    useUpdateMemoryCategoryMutation();
+  const [deleteCategory, { isLoading: isDeleting }] =
+    useDeleteMemoryCategoryMutation();
+
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
+  const handleCreate = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    try {
+      await createCategory({
+        org: tenantKey,
+        mentorId,
+        data: { name, slug: toSlug(name) },
+      }).unwrap();
+      setNewName('');
+      toast.success('Category created');
+    } catch (error) {
+      console.error('Failed to create category:', error);
+      toast.error('Failed to create category');
+    }
+  };
+
+  const startEdit = (category: MentorMemoryCategory) => {
+    setEditingId(category.id);
+    setEditName(category.name);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditName('');
+  };
+
+  const saveEdit = async (categoryId: number) => {
+    const name = editName.trim();
+    if (!name) return;
+    try {
+      await updateCategory({
+        org: tenantKey,
+        mentorId,
+        categoryId,
+        data: { name },
+      }).unwrap();
+      cancelEdit();
+      toast.success('Category updated');
+    } catch (error) {
+      console.error('Failed to update category:', error);
+      toast.error('Failed to update category');
+    }
+  };
+
+  const handleDelete = async (categoryId: number) => {
+    try {
+      await deleteCategory({
+        org: tenantKey,
+        mentorId,
+        categoryId,
+      }).unwrap();
+      setConfirmDeleteId(null);
+      toast.success('Category deleted');
+    } catch (error) {
+      console.error('Failed to delete category:', error);
+      toast.error('Failed to delete category');
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          cancelEdit();
+          setConfirmDeleteId(null);
+          setNewName('');
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="mx-4 max-w-md sm:mx-auto">
+        <DialogHeader>
+          <DialogTitle>Manage Categories</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex gap-2">
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="New category name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleCreate();
+              }
+            }}
+          />
+          <Button
+            className="ibl-button-primary"
+            onClick={handleCreate}
+            disabled={!newName.trim() || isCreating}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            Add
+          </Button>
+        </div>
+
+        <div className="max-h-[320px] space-y-2 overflow-y-auto">
+          {isLoading ? (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              Loading categories...
+            </p>
+          ) : categories.length === 0 ? (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No categories yet.
+            </p>
+          ) : (
+            categories.map((category: MentorMemoryCategory) => {
+              const isEditing = editingId === category.id;
+              const isConfirming = confirmDeleteId === category.id;
+
+              return (
+                <div
+                  key={category.id}
+                  className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-2"
+                >
+                  {isEditing ? (
+                    <>
+                      <Input
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            saveEdit(category.id);
+                          } else if (e.key === 'Escape') {
+                            cancelEdit();
+                          }
+                        }}
+                        className="h-8"
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={() => saveEdit(category.id)}
+                        disabled={!editName.trim() || isUpdating}
+                        aria-label="Save category"
+                      >
+                        <Check className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={cancelEdit}
+                        aria-label="Cancel edit"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </>
+                  ) : isConfirming ? (
+                    <>
+                      <span className="flex-1 text-sm text-gray-900">
+                        Delete &ldquo;{category.name}&rdquo;?
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setConfirmDeleteId(null)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDelete(category.id)}
+                        disabled={isDeleting}
+                      >
+                        {isDeleting ? 'Deleting...' : 'Delete'}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <span className="flex-1 text-sm text-gray-900">
+                        {category.name}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={() => startEdit(category)}
+                        aria-label={`Edit ${category.name}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-red-600 hover:text-red-700"
+                        onClick={() => setConfirmDeleteId(category.id)}
+                        aria-label={`Delete ${category.name}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="mt-2 flex justify-end">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/modals/edit-mentor-modal/tabs/memory-tab/manage-memories.tsx
+++ b/components/modals/edit-mentor-modal/tabs/memory-tab/manage-memories.tsx
@@ -12,6 +12,7 @@ import {
   Calendar,
   ChevronsUpDown,
   Check,
+  Settings,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -73,6 +74,14 @@ const BulkDeleteMemoryModal = dynamic(
   () =>
     import('./bulk-delete-memory-modal').then((module) => ({
       default: module.BulkDeleteMemoryModal,
+    })),
+  { ssr: false },
+);
+
+const ManageCategoriesModal = dynamic(
+  () =>
+    import('./manage-categories-modal').then((module) => ({
+      default: module.ManageCategoriesModal,
     })),
   { ssr: false },
 );
@@ -234,6 +243,7 @@ export function ManageMemories({
   const [showMobileDropdown, setShowMobileDropdown] = useState(false);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
   const [isBulkDeleting, setIsBulkDeleting] = useState(false);
+  const [showManageCategories, setShowManageCategories] = useState(false);
 
   const selectedCategoryName =
     categories.find((c) => c.slug === selectedCategorySlug)?.name ?? 'All';
@@ -534,6 +544,17 @@ export function ManageMemories({
             </div>
 
             <Button
+              onClick={() => setShowManageCategories(true)}
+              size="sm"
+              variant="outline"
+              className="shrink-0"
+              aria-label="Manage categories"
+            >
+              <Settings className="h-4 w-4 sm:mr-2" />
+              <span className="hidden sm:inline">Categories</span>
+            </Button>
+
+            <Button
               onClick={startAddMemory}
               size="sm"
               className="ibl-button-primary shrink-0"
@@ -662,6 +683,13 @@ export function ManageMemories({
         }
         onCancel={() => setShowDeleteConfirm(null)}
         isDeleting={isDeleting}
+      />
+
+      <ManageCategoriesModal
+        open={showManageCategories}
+        onOpenChange={setShowManageCategories}
+        tenantKey={tenantKey}
+        mentorId={mentorId}
       />
 
       <BulkDeleteMemoryModal

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-03-31 | 270 checkpoints | 36 journeys | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-04-13 | 276 checkpoints | 37 journeys | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -343,7 +343,7 @@ When adding a new page or modifying an existing user flow:
 
 ---
 
-## Journey 24: Mentor Memory Tab (7 checkpoints) — `journeys/24-mentor-memory-tab.spec.ts`
+## Journey 24: Mentor Memory Tab (8 checkpoints) — `journeys/24-mentor-memory-tab.spec.ts`
 
 **Source files:** `components/modals/edit-mentor-modal/tabs/memory-tab/index.tsx`, `components/modals/edit-mentor-modal/tabs/memory-tab/manage-memories.tsx`, `components/modals/edit-mentor-modal/tabs/memory-tab/learners-memories.tsx`
 
@@ -354,6 +354,7 @@ When adding a new page or modifying an existing user flow:
 - [x] CP-24.5: Admin can edit a memory entry via action menu
 - [x] CP-24.6: Admin can delete a memory entry via action menu with confirmation
 - [x] CP-24.7: User filter and date range filter are visible in manage memories
+- [x] CP-24.8: Memory button visibility in chat input reflects mentor memory setting
 
 ---
 
@@ -539,6 +540,14 @@ When adding a new page or modifying an existing user flow:
 - [x] Mentor copied with training data has datasets on the copy
 - [x] Mentor copied without training data has no datasets on the copy
 - [x] Mentor can be copied to a different tenant _(env-gated: requires user with multiple admin tenants)_
+
+---
+
+## Journey 38: Tenant Memory System Toggle (1 checkpoint) — `journeys/38-tenant-memory-system-toggle.spec.ts`
+
+**Source files:** `components/modals/settings-modal.tsx`
+
+- [x] TMS-38.1: Admin toggles Memory System in Advanced tab and the chat Memory button reflects it
 
 ---
 

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -2,10 +2,10 @@
   "version": 2,
   "lastUpdated": "2026-03-31",
   "summary": {
-    "totalCheckpoints": 270,
-    "coveredCheckpoints": 270,
+    "totalCheckpoints": 276,
+    "coveredCheckpoints": 276,
     "percent": 100,
-    "totalJourneys": 36
+    "totalJourneys": 37
   },
   "journeys": [
     {
@@ -1142,6 +1142,31 @@
           "id": "mem-03",
           "description": "User memories list shows entries or empty state and entry can be deleted",
           "status": "covered"
+        },
+        {
+          "id": "mem-04",
+          "description": "Admin creates a new memory from the memory tab",
+          "status": "covered"
+        },
+        {
+          "id": "mem-05",
+          "description": "Admin edits the first memory entry from the memory tab",
+          "status": "covered"
+        },
+        {
+          "id": "mem-06",
+          "description": "Admin manages memory categories (create, rename, delete)",
+          "status": "covered"
+        },
+        {
+          "id": "mem-07",
+          "description": "Admin creates then deletes a memory to verify full CRUD cycle",
+          "status": "covered"
+        },
+        {
+          "id": "mem-08",
+          "description": "Memory button visibility in chat input reflects mentor memory setting",
+          "status": "covered"
         }
       ]
     },
@@ -1822,6 +1847,21 @@
         {
           "id": "vsc-09",
           "description": "Admin creates mentor, enables tools, opens canvas, screen share does not submit form",
+          "status": "covered"
+        }
+      ]
+    },
+    {
+      "id": "tenant-memory-system-toggle",
+      "name": "Tenant Memory System Toggle",
+      "spec": "38-tenant-memory-system-toggle.spec.ts",
+      "sourceFiles": [
+        "components/modals/settings-modal.tsx"
+      ],
+      "checkpoints": [
+        {
+          "id": "tms-01",
+          "description": "Admin toggles Memory System in Advanced tab and the chat Memory button reflects it",
           "status": "covered"
         }
       ]

--- a/e2e/journeys/24-mentor-memory-tab.spec.ts
+++ b/e2e/journeys/24-mentor-memory-tab.spec.ts
@@ -24,17 +24,16 @@ test.describe('Journey 24: Mentor Memory Tab', () => {
     await editMentorPage.close();
   });
 
-  test('admin goes to memory tab and enables then disables the Reference saved memories toggle', async ({
-    page,
+  test('admin goes to memory tab and enables then disables the Enable Memory toggle', async ({
     editMentorPage,
   }) => {
-    const wasEnabled = await editMentorPage.memory.isReferenceEnabled();
-    await editMentorPage.memory.toggleReference();
-    await editMentorPage.memory.toggleReference();
+    const wasEnabled = await editMentorPage.memory.isEnableMemoryChecked();
+    await editMentorPage.memory.toggleEnableMemory();
+    await editMentorPage.memory.toggleEnableMemory();
     // Restore original state
-    const currentState = await editMentorPage.memory.isReferenceEnabled();
+    const currentState = await editMentorPage.memory.isEnableMemoryChecked();
     if (currentState !== wasEnabled) {
-      await editMentorPage.memory.toggleReference();
+      await editMentorPage.memory.toggleEnableMemory();
     }
     await editMentorPage.close();
   });
@@ -53,13 +52,159 @@ test.describe('Journey 24: Mentor Memory Tab', () => {
       await editMentorPage.close();
       return;
     }
-    const initialCount = await editMentorPage.memory.deleteButtons.count();
+    const initialCount = await editMentorPage.memory.getMemoryCount();
     await editMentorPage.memory.deleteFirst();
     await editMentorPage.page.waitForTimeout(2_000);
-    const finalCount = await editMentorPage.memory.deleteButtons
-      .count()
-      .catch(() => 0);
+    const finalCount = await editMentorPage.memory.getMemoryCount();
     expect(finalCount).toBeLessThan(initialCount);
     await editMentorPage.close();
+  });
+
+  test('admin creates a new memory from the memory tab', async ({
+    editMentorPage,
+  }) => {
+    const testContent = `E2E test memory ${Date.now()}`;
+    await editMentorPage.memory.createMemory(testContent);
+    // Verify the new memory appears in the list
+    await editMentorPage.page.waitForTimeout(2_000);
+    const hasMemories = await editMentorPage.memory.hasMemories();
+    expect(hasMemories).toBe(true);
+    await editMentorPage.close();
+  });
+
+  test('admin edits the first memory entry from the memory tab', async ({
+    editMentorPage,
+  }) => {
+    // Ensure there is at least one memory to edit
+    const hasMemories = await editMentorPage.memory.hasMemories();
+    if (!hasMemories) {
+      // Create a memory first so we have something to edit
+      await editMentorPage.memory.createMemory(`Seed memory ${Date.now()}`);
+      await editMentorPage.page.waitForTimeout(2_000);
+    }
+
+    const updatedContent = `Updated memory ${Date.now()}`;
+    await editMentorPage.memory.editFirst(updatedContent);
+
+    // Verify the memory was updated
+    await editMentorPage.page.waitForTimeout(2_000);
+    const firstContent = await editMentorPage.memory.getFirstMemoryContent();
+    expect(firstContent).toContain('Updated memory');
+    await editMentorPage.close();
+  });
+
+  test('admin manages memory categories (create, rename, delete)', async ({
+    editMentorPage,
+  }) => {
+    const suffix = Date.now();
+    const created = `E2E Cat ${suffix}`;
+    const renamed = `E2E Cat Renamed ${suffix}`;
+
+    await editMentorPage.memory.openManageCategories();
+
+    try {
+      await editMentorPage.memory.createCategory(created);
+      expect(await editMentorPage.memory.hasCategory(created)).toBe(true);
+
+      await editMentorPage.memory.renameCategory(created, renamed);
+      expect(await editMentorPage.memory.hasCategory(renamed)).toBe(true);
+      expect(await editMentorPage.memory.hasCategory(created)).toBe(false);
+
+      await editMentorPage.memory.deleteCategory(renamed);
+      expect(await editMentorPage.memory.hasCategory(renamed)).toBe(false);
+    } finally {
+      // Best-effort cleanup in case an assertion failed mid-flow.
+      for (const name of [created, renamed]) {
+        if (await editMentorPage.memory.hasCategory(name)) {
+          await editMentorPage.memory
+            .deleteCategory(name)
+            .catch(() => undefined);
+        }
+      }
+      await editMentorPage.memory.closeManageCategories();
+    }
+
+    await editMentorPage.close();
+  });
+
+  test('admin creates then deletes a memory to verify full CRUD cycle', async ({
+    editMentorPage,
+  }) => {
+    const testContent = `CRUD test memory ${Date.now()}`;
+    await editMentorPage.memory.createMemory(testContent);
+    await editMentorPage.page.waitForTimeout(2_000);
+
+    const countAfterCreate = await editMentorPage.memory.getMemoryCount();
+    expect(countAfterCreate).toBeGreaterThan(0);
+
+    // Delete the memory we just created
+    await editMentorPage.memory.deleteFirst();
+    await editMentorPage.page.waitForTimeout(2_000);
+
+    const countAfterDelete = await editMentorPage.memory.getMemoryCount();
+    expect(countAfterDelete).toBeLessThan(countAfterCreate);
+    await editMentorPage.close();
+  });
+});
+
+test.describe('Journey 24: Memory in Prompt Box', () => {
+  test('Memory button visibility in chat input reflects mentor memory setting', async ({
+    page,
+    chatPage,
+    editMentorPage,
+  }) => {
+    await navigateToMentorApp(page);
+    const isAdmin = await checkAdminStatus(page);
+    if (!isAdmin) {
+      test.skip(true, 'Requires admin access');
+      return;
+    }
+
+    // First ensure memory is enabled on the mentor
+    await editMentorPage.open('Memory');
+    await waitForPageReady(page);
+
+    const wasEnabled = await editMentorPage.memory.isEnableMemoryChecked();
+    if (!wasEnabled) {
+      await editMentorPage.memory.toggleEnableMemory();
+    }
+    await editMentorPage.close();
+    await page.waitForTimeout(2_000);
+
+    // Check if Memory button is visible in the chat input area
+    // Note: visibility also depends on tenant-level memsearch config
+    const memoryBtnVisible = await chatPage.memoryButton
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+
+    if (memoryBtnVisible) {
+      // If visible, clicking it should open the memory popover
+      await chatPage.memoryButton.click();
+      await expect(
+        page.getByText('Your Memory').or(page.getByText('Your saved memories')),
+      ).toBeVisible({ timeout: 10_000 });
+    }
+
+    // Now disable memory on the mentor and verify button disappears
+    await editMentorPage.open('Memory');
+    await waitForPageReady(page);
+    const isCurrentlyEnabled =
+      await editMentorPage.memory.isEnableMemoryChecked();
+    if (isCurrentlyEnabled) {
+      await editMentorPage.memory.toggleEnableMemory();
+    }
+    await editMentorPage.close();
+    await page.waitForTimeout(2_000);
+
+    // Memory button should not be visible when memory is disabled
+    await expect(chatPage.memoryButton).not.toBeVisible({ timeout: 5_000 });
+
+    // Restore original state
+    if (wasEnabled) {
+      await editMentorPage.open('Memory');
+      await waitForPageReady(page);
+      await editMentorPage.memory.toggleEnableMemory();
+      await editMentorPage.close();
+    }
   });
 });

--- a/e2e/journeys/38-tenant-memory-system-toggle.spec.ts
+++ b/e2e/journeys/38-tenant-memory-system-toggle.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '../fixtures/mentor-test';
+import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import { waitForPageReady } from '../utils/resilient';
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Navigate to Account Settings → Advanced tab and return the dialog locator.
+ * Mirrors the pattern used by journey 30 — the "Advanced" tab lives inside
+ * the User Profile dialog reached via More Options → platform name.
+ */
+async function openAdvancedTab(page: Page): Promise<Locator> {
+  const profileBtn = page.getByRole('button', { name: 'More options' });
+  await expect(profileBtn).toBeVisible({ timeout: 15_000 });
+  await profileBtn.click();
+
+  const menu = page.getByRole('menu', { name: 'More options' });
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+
+  const platformName = await page.evaluate(() => {
+    const raw = localStorage.getItem('current_tenant');
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw)?.platform_name ?? null;
+    } catch {
+      return null;
+    }
+  });
+
+  if (!platformName) {
+    throw new Error(
+      'Could not retrieve platform_name from localStorage — cannot navigate to account settings',
+    );
+  }
+
+  const tenantMenuItem = menu.getByText(platformName, { exact: true });
+  await expect(tenantMenuItem).toBeVisible({ timeout: 5_000 });
+  await tenantMenuItem.click();
+
+  const accountDialog = page.getByRole('dialog', { name: 'User Profile' });
+  await expect(accountDialog).toBeVisible({ timeout: 10_000 });
+
+  const advancedTab = accountDialog.getByRole('button', { name: 'Advanced' });
+  await expect(advancedTab).toBeVisible({ timeout: 5_000 });
+  await advancedTab.click();
+
+  // Wait for the Memory System row inside the advanced content area.
+  await expect(accountDialog.getByText('Memory System')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  return accountDialog;
+}
+
+/**
+ * Locator for the Memory System switch in the Advanced tab. The switch's
+ * aria-label reflects state ("Memory system enabled" or "Memory system
+ * disabled"), so we match on the prefix to find it regardless of state.
+ */
+function memorySystemSwitch(dialog: Locator): Locator {
+  return dialog.getByRole('switch', { name: /^Memory system/i });
+}
+
+async function isMemorySystemEnabled(dialog: Locator): Promise<boolean> {
+  const state = await memorySystemSwitch(dialog)
+    .getAttribute('aria-checked')
+    .catch(() => 'false');
+  return state === 'true';
+}
+
+async function setMemorySystem(
+  dialog: Locator,
+  page: Page,
+  desired: boolean,
+): Promise<void> {
+  const current = await isMemorySystemEnabled(dialog);
+  if (current === desired) return;
+
+  const toggle = memorySystemSwitch(dialog);
+  await toggle.click();
+  // The aria-label is rebuilt from the updated state after the mutation
+  // resolves — waiting for it asserts the switch actually flipped instead
+  // of relying on a brittle toast match.
+  await expect(toggle).toHaveAttribute(
+    'aria-label',
+    desired ? /enabled/i : /disabled/i,
+    { timeout: 10_000 },
+  );
+  // Let tenant settings propagate through RTK Query caches before the next
+  // page action reads them.
+  await page.waitForTimeout(1_000);
+}
+
+async function closeAccountDialog(dialog: Locator, page: Page): Promise<void> {
+  const closeBtn = dialog.getByRole('button', { name: /close/i }).last();
+  if (await closeBtn.isVisible().catch(() => false)) {
+    await closeBtn.click();
+  } else {
+    await page.keyboard.press('Escape');
+  }
+  await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('Journey 38: Tenant Memory System toggle', () => {
+  test('admin toggles Memory System in Advanced tab and the chat Memory button reflects it', async ({
+    page,
+    chatPage,
+    editMentorPage,
+  }) => {
+    await navigateToMentorApp(page);
+    const isAdmin = await checkAdminStatus(page);
+    if (!isAdmin) {
+      test.skip(true, 'Tenant Memory System toggle requires admin access');
+      return;
+    }
+    await waitForPageReady(page);
+
+    // Ensure the mentor itself has memory enabled — the chat Memory button
+    // only appears when BOTH the tenant memsearch config and the mentor's
+    // enable_memory_component are on (see hooks/use-mentors/use-mentor-settings.ts).
+    await editMentorPage.open('Memory');
+    await waitForPageReady(page);
+    const mentorMemoryWasEnabled =
+      await editMentorPage.memory.isEnableMemoryChecked();
+    if (!mentorMemoryWasEnabled) {
+      await editMentorPage.memory.toggleEnableMemory();
+    }
+    await editMentorPage.close();
+    await page.waitForTimeout(1_000);
+
+    // Snapshot original tenant-level state so we can restore it later.
+    let accountDialog = await openAdvancedTab(page);
+    const tenantMemoryWasEnabled = await isMemorySystemEnabled(accountDialog);
+
+    try {
+      // --- Disable Memory System at tenant level ---
+      await setMemorySystem(accountDialog, page, false);
+      await closeAccountDialog(accountDialog, page);
+      await waitForPageReady(page);
+
+      await expect(chatPage.memoryButton).not.toBeVisible({ timeout: 10_000 });
+
+      // --- Re-enable Memory System at tenant level ---
+      accountDialog = await openAdvancedTab(page);
+      await setMemorySystem(accountDialog, page, true);
+      await closeAccountDialog(accountDialog, page);
+      await waitForPageReady(page);
+
+      await expect(chatPage.memoryButton).toBeVisible({ timeout: 10_000 });
+    } finally {
+      // Restore tenant state.
+      const restoreDialog = await openAdvancedTab(page).catch(() => null);
+      if (restoreDialog) {
+        await setMemorySystem(
+          restoreDialog,
+          page,
+          tenantMemoryWasEnabled,
+        ).catch(() => undefined);
+        await closeAccountDialog(restoreDialog, page).catch(() => undefined);
+      }
+
+      // Restore mentor memory state.
+      if (!mentorMemoryWasEnabled) {
+        await editMentorPage.open('Memory');
+        await waitForPageReady(page);
+        const stillOn = await editMentorPage.memory.isEnableMemoryChecked();
+        if (stillOn) {
+          await editMentorPage.memory.toggleEnableMemory();
+        }
+        await editMentorPage.close();
+      }
+    }
+  });
+});

--- a/e2e/page-objects/chat.page.ts
+++ b/e2e/page-objects/chat.page.ts
@@ -9,6 +9,7 @@ export class ChatPage {
   readonly userMessages: Locator;
   readonly aiMessages: Locator;
   readonly canvasToggle: Locator;
+  readonly memoryButton: Locator;
   readonly createMentorDialog: Locator;
   readonly loginBanner: Locator;
   readonly uploadButton: Locator;
@@ -27,6 +28,7 @@ export class ChatPage {
     this.userMessages = page.locator('.chat-user-message-query');
     this.aiMessages = page.locator('.chat-ai-message-response');
     this.canvasToggle = page.getByRole('button', { name: /canvas/i });
+    this.memoryButton = page.getByRole('button', { name: /memory/i });
     this.createMentorDialog = page.getByRole('dialog', {
       name: /create.*mentor/i,
     });

--- a/e2e/page-objects/edit-mentor/memory.tab.ts
+++ b/e2e/page-objects/edit-mentor/memory.tab.ts
@@ -4,8 +4,9 @@ export class MemoryTab {
   readonly page: Page;
   readonly dialog: Locator;
 
-  readonly referenceToggle: Locator;
+  readonly enableMemoryToggle: Locator;
   readonly addMemoryButton: Locator;
+  readonly manageCategoriesButton: Locator;
   readonly emptyState: Locator;
   // Each memory entry has an unnamed icon button (MoreHorizontal) as its action trigger.
   // We use these as a proxy for the memory entry count.
@@ -22,14 +23,17 @@ export class MemoryTab {
   constructor(page: Page, dialog: Locator) {
     this.page = page;
     this.dialog = dialog;
-    this.referenceToggle = dialog
-      .getByText('Reference saved memories')
+    this.enableMemoryToggle = dialog
+      .getByText('Enable Memory')
       .locator('..')
       .locator('..')
       .getByRole('switch');
     this.addMemoryButton = dialog
       .locator('button')
       .filter({ hasText: /add memory/i });
+    this.manageCategoriesButton = dialog.getByRole('button', {
+      name: 'Manage categories',
+    });
     this.emptyState = dialog.getByText('No saved memories yet.');
     // The per-memory action button is an unnamed icon-only button (MoreHorizontal).
     // It lives inside each memory entry card alongside the memory content text.
@@ -39,19 +43,22 @@ export class MemoryTab {
       .or(dialog.locator('button[class*="ghost"][class*="h-6"]'));
   }
 
-  async isReferenceEnabled(): Promise<boolean> {
+  async isEnableMemoryChecked(): Promise<boolean> {
     return (
-      (await this.referenceToggle
+      (await this.enableMemoryToggle
         .getAttribute('aria-checked')
         .catch(() => 'false')) === 'true'
     );
   }
 
-  async toggleReference(): Promise<void> {
-    await expect(this.referenceToggle).toBeVisible({ timeout: 10_000 });
-    await this.referenceToggle.click();
+  async toggleEnableMemory(): Promise<void> {
+    await expect(this.enableMemoryToggle).toBeVisible({ timeout: 10_000 });
+    await this.enableMemoryToggle.click();
+    // Toast says "Memory enabled" or "Memory disabled". Use .first() to
+    // avoid strict-mode violations when a prior toggle's toast is still
+    // fading out in the Sonner stack.
     await expect(
-      this.page.getByText('Reference saved memories updated'),
+      this.page.getByText(/Memory enabled|Memory disabled/).first(),
     ).toBeVisible({ timeout: 10_000 });
   }
 
@@ -60,6 +67,79 @@ export class MemoryTab {
       .isVisible({ timeout: 5_000 })
       .catch(() => false);
     return !empty;
+  }
+
+  /**
+   * Creates a new memory via the Add Memory button + dialog.
+   * @param content - The memory content text.
+   * @param category - Optional category to select from the dropdown.
+   */
+  async createMemory(content: string, category?: string): Promise<void> {
+    await expect(this.addMemoryButton).toBeVisible({ timeout: 10_000 });
+    await this.addMemoryButton.click();
+
+    const addDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: /add memory/i })
+      .last();
+    await expect(addDialog).toBeVisible({ timeout: 10_000 });
+
+    // Always pick a concrete category — the modal pre-fills the current
+    // filter (often "All"), which gets filtered out of the dropdown and
+    // falls back to a non-existent slug server-side. Picking the first
+    // real option keeps the create request valid.
+    const selectTrigger = addDialog.getByRole('combobox').first();
+    await selectTrigger.click();
+    const option = category
+      ? this.page.getByRole('option', { name: category, exact: true })
+      : this.page.getByRole('option').first();
+    await expect(option).toBeVisible({ timeout: 5_000 });
+    await option.click();
+
+    const textarea = addDialog.locator('textarea');
+    await textarea.fill(content);
+
+    const saveButton = addDialog.getByRole('button', { name: /save/i });
+    await expect(saveButton).toBeEnabled({ timeout: 5_000 });
+    await saveButton.click();
+
+    await expect(this.page.getByText(/Memory created/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Edits the first memory entry by clicking its action menu and selecting "Edit".
+   * @param newContent - The updated memory content.
+   */
+  async editFirst(newContent: string): Promise<void> {
+    const firstActionBtn = this.memoryActionButtons.first();
+    await expect(firstActionBtn).toBeVisible({ timeout: 10_000 });
+    await firstActionBtn.click();
+
+    const editMenuItem = this.page
+      .getByRole('menuitem', { name: /edit/i })
+      .last();
+    await expect(editMenuItem).toBeVisible({ timeout: 5_000 });
+    await editMenuItem.click();
+
+    const editDialog = this.page
+      .getByRole('dialog')
+      .filter({ hasText: /edit memory/i })
+      .last();
+    await expect(editDialog).toBeVisible({ timeout: 10_000 });
+
+    const textarea = editDialog.locator('textarea');
+    await textarea.clear();
+    await textarea.fill(newContent);
+
+    const saveButton = editDialog.getByRole('button', { name: /save/i });
+    await expect(saveButton).toBeEnabled({ timeout: 5_000 });
+    await saveButton.click();
+
+    await expect(this.page.getByText(/Memory updated/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
   }
 
   /**
@@ -93,5 +173,120 @@ export class MemoryTab {
         .last()
         .click();
     }
+  }
+
+  /**
+   * Returns the number of visible memory entries.
+   */
+  async getMemoryCount(): Promise<number> {
+    return this.memoryActionButtons.count().catch(() => 0);
+  }
+
+  /**
+   * Locator for the Manage Categories dialog, scoped by its heading.
+   */
+  get categoriesDialog(): Locator {
+    return this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Manage Categories' });
+  }
+
+  /**
+   * Opens the Manage Categories modal from the memory tab.
+   */
+  async openManageCategories(): Promise<void> {
+    await expect(this.manageCategoriesButton).toBeVisible({ timeout: 10_000 });
+    await this.manageCategoriesButton.click();
+    await expect(this.categoriesDialog).toBeVisible({ timeout: 10_000 });
+  }
+
+  /**
+   * Closes the Manage Categories modal via the Done button.
+   */
+  async closeManageCategories(): Promise<void> {
+    await this.categoriesDialog.getByRole('button', { name: 'Done' }).click();
+    await expect(this.categoriesDialog).not.toBeVisible({ timeout: 10_000 });
+  }
+
+  /**
+   * Creates a new category inside the Manage Categories modal.
+   * Assumes the modal is already open.
+   */
+  async createCategory(name: string): Promise<void> {
+    const modal = this.categoriesDialog;
+    const input = modal.getByPlaceholder('New category name');
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(name);
+    await modal.getByRole('button', { name: /^add$/i }).click();
+    await expect(this.page.getByText('Category created')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(modal.getByText(name, { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Renames an existing category in the Manage Categories modal.
+   * Assumes the modal is already open and the category is in the list.
+   */
+  async renameCategory(oldName: string, newName: string): Promise<void> {
+    const modal = this.categoriesDialog;
+    await modal.getByRole('button', { name: `Edit ${oldName}` }).click();
+    // Edit row injects a second <input> (first is the "new category" input).
+    const editInput = modal.locator('input').nth(1);
+    await expect(editInput).toBeVisible({ timeout: 5_000 });
+    await editInput.fill(newName);
+    await modal.getByRole('button', { name: 'Save category' }).click();
+    await expect(this.page.getByText('Category updated')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(modal.getByText(newName, { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Deletes a category from the Manage Categories modal.
+   * Handles the inline confirmation step. Assumes the modal is already open.
+   */
+  async deleteCategory(name: string): Promise<void> {
+    const modal = this.categoriesDialog;
+    await modal.getByRole('button', { name: `Delete ${name}` }).click();
+    // Inline confirm shows a destructive Delete button in the same row.
+    const confirmButton = modal
+      .getByRole('button', { name: /^delete$/i })
+      .last();
+    await expect(confirmButton).toBeVisible({ timeout: 5_000 });
+    await confirmButton.click();
+    await expect(this.page.getByText('Category deleted')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(modal.getByText(name, { exact: true })).not.toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Checks whether a category with the given name is visible in the
+   * Manage Categories modal. Assumes the modal is already open.
+   */
+  async hasCategory(name: string): Promise<boolean> {
+    return this.categoriesDialog
+      .getByText(name, { exact: true })
+      .isVisible({ timeout: 3_000 })
+      .catch(() => false);
+  }
+
+  /**
+   * Returns the text content of the first memory entry.
+   */
+  async getFirstMemoryContent(): Promise<string> {
+    // Memory content is rendered inside a div with text-sm class within the entry card
+    const firstEntry = this.dialog
+      .locator('.space-y-3 > div')
+      .first()
+      .locator('.text-sm.leading-relaxed');
+    return (await firstEntry.textContent().catch(() => '')) ?? '';
   }
 }

--- a/hooks/__tests__/use-mentor-segments.test.tsx
+++ b/hooks/__tests__/use-mentor-segments.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { MentorVisibilityEnum } from '@iblai/iblai-api';
 
-import {
-  useMentorSegments,
-  MENTOR_SEGMENTS,
-} from '../use-mentor-segments';
+import { useMentorSegments, MENTOR_SEGMENTS } from '../use-mentor-segments';
 import { MODALS, UserType } from '@/lib/constants';
 import { EDIT_MENTOR_TAB_COMPONENTS } from '@/components/modals/edit-mentor-modal';
 

--- a/hooks/__tests__/use-mentor-segments.test.tsx
+++ b/hooks/__tests__/use-mentor-segments.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
     data: mockMentorSettings(),
     isSuccess: mockMentorSettings() !== undefined,
   }),
-  useGetMemsearchConfigQuery: () => ({
+  useGetMemsearchStatusQuery: () => ({
     data: { enable_memsearch: mockMemsearchEnabled() },
   }),
 }));

--- a/hooks/use-mentor-segments.ts
+++ b/hooks/use-mentor-segments.ts
@@ -21,7 +21,7 @@ import {
 import { MentorVisibilityEnum } from '@iblai/iblai-api';
 import {
   useGetMentorSettingsQuery,
-  useGetMemsearchConfigQuery,
+  useGetMemsearchStatusQuery,
 } from '@iblai/iblai-js/data-layer';
 
 import { MODALS, UserType } from '@/lib/constants';
@@ -352,13 +352,15 @@ export function useMentorSegments(options: UseMentorSegmentsOptions = {}) {
     },
   );
 
-  const { data: memsearchConfig } = useGetMemsearchConfigQuery(
+  const { data: memsearchConfig } = useGetMemsearchStatusQuery(
     {
       org: tenantKey,
       userId: username ?? '',
     },
     {
       skip: !tenantKey || !username,
+      refetchOnMountOrArgChange: true,
+      refetchOnFocus: true,
     },
   );
 

--- a/hooks/use-mentor-segments.ts
+++ b/hooks/use-mentor-segments.ts
@@ -286,9 +286,7 @@ export function filterMentorSegments<T extends MentorSegment>(
         !ctx.isAdmin && ctx.tenantKey === mainTenantKey;
       const visibilityAllowed = visibilityMatches && !isNonAdminOnMainTenant;
 
-      return (
-        isAdminOnMainTenant || mentorNotOnMainTenant || visibilityAllowed
-      );
+      return isAdminOnMainTenant || mentorNotOnMainTenant || visibilityAllowed;
     })
     .filter((segment) => {
       const hasFieldPermission = rbacPermissionToDisplay(
@@ -382,13 +380,7 @@ export function useMentorSegments(options: UseMentorSegmentsOptions = {}) {
       flags: { isMemsearchEnabled },
       isUserTypeAllowed: (segment) => isUserTypeAllowedRef.current(segment),
     }),
-    [
-      isAdmin,
-      tenantKey,
-      mentorSettings,
-      rbacPermissions,
-      isMemsearchEnabled,
-    ],
+    [isAdmin, tenantKey, mentorSettings, rbacPermissions, isMemsearchEnabled],
   );
 
   const filteredSegments = useMemo(

--- a/hooks/use-mentors/__tests__/use-mentor-settings.test.ts
+++ b/hooks/use-mentors/__tests__/use-mentor-settings.test.ts
@@ -22,6 +22,7 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
     mockUseGetMentorSettingsQuery(...args),
   useGetMentorPublicSettingsQuery: (...args: unknown[]) =>
     mockUseGetMentorPublicSettingsQuery(...args),
+  useGetMemsearchConfigQuery: () => ({ data: undefined, isLoading: false }),
 }));
 
 const mockGetCachedApiResponse = vi.fn();

--- a/hooks/use-mentors/__tests__/use-mentor-settings.test.ts
+++ b/hooks/use-mentors/__tests__/use-mentor-settings.test.ts
@@ -22,7 +22,7 @@ vi.mock('@iblai/iblai-js/data-layer', () => ({
     mockUseGetMentorSettingsQuery(...args),
   useGetMentorPublicSettingsQuery: (...args: unknown[]) =>
     mockUseGetMentorPublicSettingsQuery(...args),
-  useGetMemsearchConfigQuery: () => ({ data: undefined, isLoading: false }),
+  useGetMemsearchStatusQuery: () => ({ data: undefined, isLoading: false }),
 }));
 
 const mockGetCachedApiResponse = vi.fn();

--- a/hooks/use-mentors/use-mentor-settings.ts
+++ b/hooks/use-mentors/use-mentor-settings.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import {
   useGetMentorPublicSettingsQuery,
   useGetMentorSettingsQuery,
-  useGetMemsearchConfigQuery,
+  useGetMemsearchStatusQuery,
 } from '@iblai/iblai-js/data-layer';
 
 import { useUsername } from '@/providers/use-user';
@@ -104,13 +104,15 @@ export function useMentorSettings({
     },
   );
 
-  const { data: memsearchConfig } = useGetMemsearchConfigQuery(
+  const { data: memsearchConfig } = useGetMemsearchStatusQuery(
     {
       org: tenantKey ?? '',
       userId: username ?? '',
     },
     {
       skip: !tenantKey || !username || isOffline,
+      refetchOnMountOrArgChange: true,
+      refetchOnFocus: true,
     },
   );
 

--- a/hooks/use-mentors/use-mentor-settings.ts
+++ b/hooks/use-mentors/use-mentor-settings.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import {
   useGetMentorPublicSettingsQuery,
   useGetMentorSettingsQuery,
+  useGetMemsearchConfigQuery,
 } from '@iblai/iblai-js/data-layer';
 
 import { useUsername } from '@/providers/use-user';
@@ -100,6 +101,16 @@ export function useMentorSettings({
     },
     {
       skip: !tenantKey || !mentorId || isOffline,
+    },
+  );
+
+  const { data: memsearchConfig } = useGetMemsearchConfigQuery(
+    {
+      org: tenantKey ?? '',
+      userId: username ?? '',
+    },
+    {
+      skip: !tenantKey || !username || isOffline,
     },
   );
 
@@ -248,6 +259,13 @@ export function useMentorSettings({
 
       starterPrompts: (effectiveSettings?.starter_prompts ??
         effectivePublicSettings?.starter_prompts) as string | undefined,
+
+      // @ts-ignore - enable_memory_component exists in API response but not in type
+      memoryEnabled:
+        (memsearchConfig?.enable_memsearch ?? false) &&
+        (effectiveSettings?.enable_memory_component ??
+          effectivePublicSettings?.enable_memory_component ??
+          false),
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@iblai/iblai-api": "4.166.0-ai",
-    "@iblai/iblai-js": "1.3.10",
+    "@iblai/iblai-js": "1.4.1",
     "@iblai/iblai-web-mentor": "1.3.4",
     "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 4.166.0-ai
         version: 4.166.0-ai
       '@iblai/iblai-js':
-        specifier: 1.3.10
-        version: 1.3.10(@axe-core/playwright@4.10.2(playwright-core@1.56.0))(@floating-ui/dom@1.7.6)(@iblai/iblai-api@4.166.0-ai)(@playwright/test@1.56.0)(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@tauri-apps/api@2.10.1)(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(next@15.3.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        specifier: 1.4.1
+        version: 1.4.1(@axe-core/playwright@4.10.2(playwright-core@1.56.0))(@floating-ui/dom@1.7.6)(@iblai/iblai-api@4.166.0-ai)(@playwright/test@1.56.0)(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@tauri-apps/api@2.10.1)(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(next@15.3.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@iblai/iblai-web-mentor':
         specifier: 1.3.4
         version: 1.3.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.1)(typescript@5.9.3)
@@ -1021,8 +1021,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@iblai/data-layer@1.2.8':
-    resolution: {integrity: sha512-kh0ws8etjok4I0PUw6Wh+nlWqDaiLXyfB5pY2AdOiJqCvLI3GXenoAJK5Di8ox8AqcubvyqGwsvzuGGEpIiXhA==}
+  '@iblai/data-layer@1.3.1':
+    resolution: {integrity: sha512-6fdYSBbA5IQyaYD+Prbvhn3fDABiwXXCWkdXr/jlYCBpLWHnqo2afYtgDMiBF4DX5WShFC9n9C0xUzth5TaLVA==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@reduxjs/toolkit': 2.7.0
@@ -1033,8 +1033,8 @@ packages:
   '@iblai/iblai-api@4.166.0-ai':
     resolution: {integrity: sha512-dY9Jv+CkXEyTxRsOQFay5YvYe8K2LSQluJJvtssGQV2RbrxPPzONaKfnhcyarDs7Ft35Xqk1fuErjhUwNG3OIg==}
 
-  '@iblai/iblai-js@1.3.10':
-    resolution: {integrity: sha512-Zz9OuNGW/Y568FixaBB4v+zdML+LHLgd9RKlhFWMRsSnHvEq6EsKjBA3pnXsxmFWeb87x2suyd/swwluaOX3zw==}
+  '@iblai/iblai-js@1.4.1':
+    resolution: {integrity: sha512-vFNYkhwlKYD1lXTMTrC3dEuGPFAZQGbyD0L9CGlkQrSLas3KPPINSOD4kVwdgAJ5hvfu2zLQ7rNoy7UpRVDsjg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -1057,13 +1057,13 @@ packages:
   '@iblai/iblai-web-mentor@1.3.4':
     resolution: {integrity: sha512-w0K22cQl/LquXDDnVi7DgiOeuS+iha85poZxuLCtJqvwyCxAMLch1DWN3LbNCxw+YGhrV7BOEENp8s7bZ+7ZGw==}
 
-  '@iblai/mcp@1.2.3':
-    resolution: {integrity: sha512-tuaVs2gzR8OYoCHT0gxOB3VSC9LbC8RdWGC/Nd7PVimcK+1HxPWP8mX5GWyzDgn1sJf/Pi5onFGGBHbRzbR7+Q==}
+  '@iblai/mcp@1.3.0':
+    resolution: {integrity: sha512-tvFcGVJjZmgVttb7lqZ/JxfPewlRfdJb3rZ7MYXAH+wpXjtwJVNX28r3yrOC3QAzJIIW2+Jk1ixJJyKkOHKDPw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@iblai/web-containers@1.2.6':
-    resolution: {integrity: sha512-ZUFOMVxeC77r+pevDelWVGgRdjBby83XqTnaaVmOiUwZrqXiO7dwJM4O3msUvOiczsO/Pa9/Z0fHeZRoueMdjg==}
+  '@iblai/web-containers@1.3.1':
+    resolution: {integrity: sha512-SR/x1ZUGfsYVTjiaHVmskp1oATzpUKP4X44eILz7DeqJCL6oIRXiTxa0xAQfB9jtYWykjFXVLS4zI8GxkH3L1A==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@iblai/data-layer': ^1.1.2
@@ -10526,7 +10526,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@iblai/data-layer@1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@iblai/data-layer@1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -10540,13 +10540,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@iblai/iblai-js@1.3.10(@axe-core/playwright@4.10.2(playwright-core@1.56.0))(@floating-ui/dom@1.7.6)(@iblai/iblai-api@4.166.0-ai)(@playwright/test@1.56.0)(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@tauri-apps/api@2.10.1)(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(next@15.3.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@iblai/iblai-js@1.4.1(@axe-core/playwright@4.10.2(playwright-core@1.56.0))(@floating-ui/dom@1.7.6)(@iblai/iblai-api@4.166.0-ai)(@playwright/test@1.56.0)(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@tauri-apps/api@2.10.1)(@tiptap/extensions@3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0))(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(next@15.3.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@iblai/data-layer': 1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/mcp': 1.2.3
-      '@iblai/web-containers': 1.2.6(3b0fe009e2d75c342de69df85b800857)
-      '@iblai/web-utils': 1.2.8(@iblai/data-layer@1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
+      '@iblai/mcp': 1.3.0
+      '@iblai/web-containers': 1.3.1(9529272d30fb025efb58b5334009bb37)
+      '@iblai/web-utils': 1.2.8(@iblai/data-layer@1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
       '@reduxjs/toolkit': 2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.13.6
       dotenv: 16.6.1
@@ -10583,7 +10583,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@iblai/mcp@1.2.3':
+  '@iblai/mcp@1.3.0':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
@@ -10591,11 +10591,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@iblai/web-containers@1.2.6(3b0fe009e2d75c342de69df85b800857)':
+  '@iblai/web-containers@1.3.1(9529272d30fb025efb58b5334009bb37)':
     dependencies:
-      '@iblai/data-layer': 1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.2.8(@iblai/data-layer@1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
+      '@iblai/web-utils': 1.2.8(@iblai/data-layer@1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)
       '@radix-ui/react-accordion': 1.2.8(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.7(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox': 1.2.3(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -10665,9 +10665,9 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/web-utils@1.2.8(@iblai/data-layer@1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)':
+  '@iblai/web-utils@1.2.8(@iblai/data-layer@1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.10.1)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)':
     dependencies:
-      '@iblai/data-layer': 1.2.8(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.3.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.13.6

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit';
 
 import {
   mentorReducer,
@@ -6,6 +6,8 @@ import {
   mentorMiddleware,
   mcpApiSlice,
   workflowsApiSlice,
+  memoryApiSlice,
+  MEMORY_QUERY_KEYS,
 } from '@iblai/iblai-js/data-layer';
 import { userReducer } from '@/features/users/slice';
 import { authApiSlice } from '@/features/auth/api-slice';
@@ -25,6 +27,30 @@ import { chatSliceReducerShared } from '@iblai/iblai-js/web-utils';
 import { analyticsReducer } from '@/features/analytics/slice';
 import { chatInputSliceReducer } from '@/features/chat-input/api-slice';
 import rbacReducer from '@/features/rbac/rbac-slice';
+
+// Bridge: the data layer's `updateMemsearchConfig` mutation only invalidates
+// the MEMSEARCH_PLATFORM_CONFIG tag, but our app reads memsearch state via
+// `getMemsearchStatus` (which provides MEMSEARCH_STATUS). Invalidate the
+// status tag whenever the config mutation succeeds so the UI updates without
+// a page reload when the toggle in the Profile dialog flips.
+const memsearchStatusBridge = createListenerMiddleware();
+memsearchStatusBridge.startListening({
+  predicate: (action) => {
+    const a = action as {
+      type?: string;
+      meta?: { arg?: { endpointName?: string } };
+    };
+    return (
+      a.type === `${memoryApiSlice.reducerPath}/executeMutation/fulfilled` &&
+      a.meta?.arg?.endpointName === 'updateMemsearchConfig'
+    );
+  },
+  effect: (_action, listenerApi) => {
+    listenerApi.dispatch(
+      memoryApiSlice.util.invalidateTags(MEMORY_QUERY_KEYS.MEMSEARCH_STATUS()),
+    );
+  },
+});
 
 export const store = configureStore({
   reducer: {
@@ -66,6 +92,7 @@ export const store = configureStore({
       workflowsApiSlice.middleware,
       providerAssociationApiSlice.middleware,
       ...mentorMiddleware,
+      memsearchStatusBridge.middleware,
     ),
 });
 


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes

- Added ManageCategoriesModal for add/rename/delete memory categories, wired via a new "Categories" button in the memory tab
- Hide Memory button in chat input for anonymous mentors (allowAnonymous) and embed mode
- Removed stale "Reference saved memories" toggle from e2e page object and journey 24
- Fixed strict-mode toast violations with .first() in memory page object
- Fixed flaky createMemory e2e helper to always pick a real category
- Added missing data-layer hook stubs (useGetMemsearchConfigQuery, category mutations) to broken unit tests
- Added memoryApiSlice to the a11y test store
- Added e2e test for memory category CRUD in journey 24
- Added new journey 38 for tenant-level Memory System toggle in Advanced tab
- Added unit tests for manage-categories-modal, memory-button, memory-menu
- Added unit tests for anonymous/embed gating in inside-buttons
- Brought all four flagged files to ≥95% line coverage


<img width="750" height="476" alt="Screenshot 2026-04-14 at 3 37 44 AM" src="https://github.com/user-attachments/assets/ac6c44c9-887c-4b35-8ff4-9fd971615464" />

<img width="1483" height="737" alt="Screenshot 2026-04-15 at 5 32 59 AM" src="https://github.com/user-attachments/assets/24bb37a8-0491-436d-a7f9-8b044c71f4fa" />
<img width="1483" height="747" alt="Screenshot 2026-04-15 at 5 33 09 AM" src="https://github.com/user-attachments/assets/cc476532-6dcb-4492-b8e3-14515c6126b8" />


![WhatsApp Image 2026-04-13 at 21 38 52](https://github.com/user-attachments/assets/ad6229fd-9900-493c-9983-034d6502a9ed)

![WhatsApp Image 2026-04-13 at 21 38 52 (1)](https://github.com/user-attachments/assets/7e1a73ae-8df2-4502-a811-d2ea539bcb5e)

![WhatsApp Image 2026-04-13 at 21 38 51](https://github.com/user-attachments/assets/e2de0369-5070-46de-8f45-9c5a0538ec6d)


![WhatsApp Image 2026-04-13 at 21 38 51 (1)](https://github.com/user-attachments/assets/9ea8e52b-147b-4851-a439-70527eef9acd)
