### PR TITLE
Add manual docker build workflow

### DIFF
--- a/.github/workflows/manual-docker-build.yml
+++ b/.github/workflows/manual-docker-build.yml
@@ -1,0 +1,27 @@
+name: Manual Docker Build
+run-name: 'Rebuild mentor ${{ inputs.source_ref }} -> ${{ inputs.version }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source tag / branch / SHA to build from'
+        required: true
+        default: v0.46.2
+        type: string
+      version:
+        description: 'Image tag to push (e.g. v0.46.2-updated)'
+        required: true
+        default: v0.46.2-updated
+        type: string
+
+jobs:
+  build:
+    uses: iblai/iblai-web-ops/.github/workflows/reusable-spa-docker-build.yml@main
+    with:
+      app_name: mentor
+      source_repo: ${{ github.repository }}
+      source_ref: ${{ inputs.source_ref }}
+      version: ${{ inputs.version }}
+      next_image_patterns: ${{ vars.NEXT_IMAGE_PATTERNS }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/manual-docker-build.yml` — a `workflow_dispatch`-only wrapper around the shared `iblai/iblai-web-ops/.github/workflows/reusable-spa-docker-build.yml` reusable workflow.
- Lets us rebuild mentor from any tag / branch / SHA and push under an arbitrary image tag, without cutting a new release.
- Defaults to rebuilding `v0.46.2` and pushing as `v0.46.2-updated` — intended for the first use immediately after the `NEXT_IMAGE_PATTERNS` quote-escaping fix merged in `iblai-web-ops` PR #3.

## Test plan

- [ ] Actions → *Manual Docker Build* → Run workflow, accept defaults (`source_ref=v0.46.2`, `version=v0.46.2-updated`).
- [ ] Build completes and pushes `iblai-mentor-spa-pro:v0.46.2-updated` to ECR.
- [ ] Exec into the image, confirm `NEXT_IMAGE_PATTERNS` env var has no stray `"` characters.
- [ ] Inspect the rendered Next.js config's `remotePatterns`: first entry (`vercel-storage.com`) is present and last entry (`api.life.edu.ph`) has a clean hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)