### PR TITLE
ci(test-full-pipeline): make EC2 termination optional

### DIFF
--- a/.github/workflows/test-full-pipeline.yml
+++ b/.github/workflows/test-full-pipeline.yml
@@ -11,6 +11,11 @@ on:
         description: 'Browsers to test'
         required: false
         default: 'chrome'
+      terminate:
+        description: 'Terminate the launched instance when done (uncheck to keep it running for debugging)'
+        required: false
+        type: boolean
+        default: true
 
 run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }})'
 
@@ -178,7 +183,7 @@ jobs:
   # ============================================================
   terminate:
     needs: [launch-infra, run-tests]
-    if: always() && needs.launch-infra.result != 'skipped'
+    if: always() && needs.launch-infra.result != 'skipped' && inputs.terminate
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.SERVICE_UPDATE_ACCESS_KEY }}
@@ -215,3 +220,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Instance: ${{ needs.launch-infra.outputs.instance-id }}" >> $GITHUB_STEP_SUMMARY
           echo "Test result: ${{ needs.run-tests.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.terminate }}" != "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Instance kept running (terminate=false). IP: ${{ needs.launch-infra.outputs.instance-ip }}" >> $GITHUB_STEP_SUMMARY
+            echo "Remember to terminate it manually when you're done." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- Adds a boolean `terminate` input to the Full Pipeline Test workflow_dispatch form (default: `true`, matching today's behavior).
- When unchecked, the `terminate` job is skipped so the launched EC2 instance stays up for manual debugging.
- Summary step now flags when the instance was kept and prints its IP so you don't have to dig through the launch job log.

## Why
Sometimes you want to poke at the instance after a test run — today it's always terminated automatically.

## Test plan
- [ ] Dispatch with `terminate` checked (default) → `terminate` job runs, instance is killed. Same behavior as before.
- [ ] Dispatch with `terminate` unchecked → `terminate` job is skipped; summary shows "Instance kept running" with the IP; verify instance still exists in EC2 console.
- [ ] Confirm `stg-slot` / `browsers` inputs still behave normally.