### PR TITLE
ci(test-full-pipeline): grant contents:read so reusable checkout works

### DIFF
--- a/.github/workflows/test-full-pipeline.yml
+++ b/.github/workflows/test-full-pipeline.yml
@@ -19,7 +19,8 @@ on:
 
 run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }})'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   # ============================================================


### PR DESCRIPTION
The top-level permissions: {} was denying GITHUB_TOKEN every scope, which made actions/checkout inside reusable-pr-docker-build.yml fail with "Repository not found" (GitHub hides private-repo existence from unauthorized tokens).


## Checklist
- [ ] Tests were added/updated according to the feature/bugfix/change made
- [ ] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
