### PR TITLE
feat: pin prod-images-tag + run DM migrations + seed_rbac_data in test-full-pipeline

### DIFF
--- a/.github/workflows/test-full-pipeline.yml
+++ b/.github/workflows/test-full-pipeline.yml
@@ -16,8 +16,12 @@ on:
         required: false
         type: boolean
         default: true
+      prod-images-tag:
+        description: 'iblai-prod-images git ref (tag/branch/sha). Pins both the iblai-cli-ops CLI and the container image tags. Default: main (latest).'
+        required: false
+        default: 'main'
 
-run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }})'
+run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }}) @ ${{ inputs.prod-images-tag }}'
 
 permissions:
   contents: read
@@ -130,7 +134,8 @@ jobs:
           iblai infra service-update \
             --host ${{ steps.launch.outputs.instance-ip }} \
             --ssh-key ~/.ssh/deploy-key \
-            --git-token ${{ secrets.GIT_TOKEN }}
+            --git-token ${{ secrets.GIT_TOKEN }} \
+            --prod-images-tag ${{ inputs.prod-images-tag }}
 
       - name: Register new target then deregister old
         run: |


### PR DESCRIPTION
## Summary

Two related workflow hardening changes:

### 1. `prod-images-tag` input for reproducibility

One git ref (tag / branch / sha) pins both `iblai-cli-ops` CLI and container image tags — they're bundled in the same `iblai-images` package:

```yaml
# ibl_cli_ops Ansible role
uv pip install 'iblai-images[sumac] @ git+.../iblai-prod-images@{{ prod_images_tag }}#egg=iblai-images'
```

Default `main` preserves current behaviour (latest). `run-name` now shows the ref: `Full Pipeline — stg3 (chrome) @ v1.2.3`.

### 2. DM migrations + RBAC seeding at end of launch-infra

Two new steps run on every workflow invocation, after health check, before SSH revoke:

- `./manage.py migrate --noinput` — applies any new migrations bundled with the pinned image tag
- `./manage.py seed_rbac_data` — keeps RBAC policies/roles in sync with the app's seed definitions

Previously these had to be run manually after each launch; codifying them avoids env drift.

## Usage

```
# Default (latest main):
Run workflow → leave prod-images-tag blank

# Pin to a release:
Run workflow → prod-images-tag = v1.2.3
```

## Test plan

- [ ] Trigger with default — should behave as current workflow + now also migrate/seed at end
- [ ] Trigger with a pinned tag — verify `iblai-images` installs that exact ref
- [ ] Confirm migrations and seed_rbac_data show in the run's log as separate steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)