### PR TITLE
ci: grant contents:read to GITHUB_TOKEN so checkout can fetch the repo

### DIFF
--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -7,7 +7,8 @@ on:
 
 run-name: 'Build mentor ${{ github.ref_name }}'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary
- The tag-triggered \`Docker Build\` workflow currently sets \`permissions: {}\`, which strips **all** scopes from the built-in \`GITHUB_TOKEN\`. \`actions/checkout@v4\` then fails with \`remote: Repository not found\` — the token has zero rights, so GitHub returns 404 instead of confirming the repo exists.
- Fix: grant \`contents: read\` at the workflow level, which is the minimum \`actions/checkout\` needs.

## Why it broke
\`permissions: {}\` is the documented "deny all" setting — usually intended as a minimal-privilege baseline. The author likely meant "locked down" but forgot that the default \`GITHUB_TOKEN\` path used by \`actions/checkout\` requires \`contents: read\` to fetch the repo itself.

## Failing run
- https://github.com/iblai/mentorai/actions/runs/24747645186/job/72403217690
- Error: \`fatal: repository 'https://github.com/iblai/mentorai/' not found\` at the \`Fetching the repository\` step of \`actions/checkout@v4\`.

## Follow-up
- The \`v0.50.0\` tag's commit still has \`permissions: {}\` (tag-triggered workflows run from the workflow file at the tag's commit). After this PR merges, \`v0.50.0\` will still fail on rerun — cut a new tag (\`v0.50.1\`) or force-move \`v0.50.0\` to the fixed commit to re-run that build successfully.

## Test plan
- [ ] Merge to \`main\`
- [ ] Cut a new tag (e.g. \`v0.50.1\`) on the post-merge commit
- [ ] Confirm the \`Docker Build\` workflow's \`Prepare\` job reaches past checkout and completes \`Extract version from package.json\`
- [ ] Confirm the reusable \`build\` job continues successfully (if it needs additional scopes like \`id-token: write\` or \`packages: write\`, add them here in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)