### PR TITLE
feat(test-full-pipeline): add skip-infra-launch input (default true)

### DIFF
--- a/.github/workflows/test-full-pipeline.yml
+++ b/.github/workflows/test-full-pipeline.yml
@@ -20,8 +20,13 @@ on:
         description: 'iblai-prod-images git ref (tag/branch/sha). Pins both the iblai-cli-ops CLI and the container image tags. Default: main (latest).'
         required: false
         default: 'main'
+      skip-infra-launch:
+        description: 'Skip the infra launch + service-update. Run tests against whatever instance is already in the stg slot''s target group. Defaults to true — untick to launch a fresh EC2 from the slot''s AMI.'
+        required: false
+        type: boolean
+        default: true
 
-run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }}) @ ${{ inputs.prod-images-tag }}'
+run-name: 'Full Pipeline — stg${{ inputs.stg-slot }} (${{ inputs.browsers }})${{ inputs.skip-infra-launch && '' [skip-launch]'' || format('' @ {0}'', inputs.prod-images-tag) }}'
 
 permissions:
   contents: read
@@ -46,6 +51,7 @@ jobs:
   # LAUNCH INFRASTRUCTURE
   # ============================================================
   launch-infra:
+    if: ${{ !inputs.skip-infra-launch }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -171,7 +177,9 @@ jobs:
   # ============================================================
   run-tests:
     needs: [build-playwright-image, launch-infra]
-    if: needs.launch-infra.result == 'success' && needs.build-playwright-image.result == 'success'
+    # Run tests when the playwright image built AND either (a) launch-infra succeeded
+    # or (b) it was skipped because skip-infra-launch=true (tests hit the existing slot).
+    if: needs.build-playwright-image.result == 'success' && (needs.launch-infra.result == 'success' || (needs.launch-infra.result == 'skipped' && inputs.skip-infra-launch))
     uses: iblai/iblai-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
     secrets: inherit
     with:
@@ -224,9 +232,13 @@ jobs:
           echo "| Run Tests (${{ inputs.browsers }}) | ${{ needs.run-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Terminate | ${{ needs.terminate.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Instance: ${{ needs.launch-infra.outputs.instance-id }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.skip-infra-launch }}" = "true" ]; then
+            echo "Mode: skip-infra-launch — tests ran against the pre-existing stg${{ inputs.stg-slot }} instance." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Instance: ${{ needs.launch-infra.outputs.instance-id }}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "Test result: ${{ needs.run-tests.outputs.result }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ inputs.terminate }}" != "true" ]; then
+          if [ "${{ inputs.skip-infra-launch }}" != "true" ] && [ "${{ inputs.terminate }}" != "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Instance kept running (terminate=false). IP: ${{ needs.launch-infra.outputs.instance-ip }}" >> $GITHUB_STEP_SUMMARY
             echo "Remember to terminate it manually when you're done." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a new boolean input `skip-infra-launch` to `test-full-pipeline.yml` (default `true`).

- **true (default)** — skip `launch-infra` entirely; `run-tests` fires against whatever instance is already in the stg slot's TG.
- **false** — current behaviour: launch fresh EC2 from the slot's AMI, service-update, register to TG, then tests.

## Why default true

The common day-to-day case is re-running the E2E suite against an already-provisioned slot. The full launch path takes 20–40 min (ECR cold pull + service-update + migrations) and is only needed when validating a new AMI or `prod-images-tag`. Defaulting to skip matches actual usage and saves runner minutes.

## Downstream job changes

- **`run-tests`** — condition widened to allow `launch-infra.result == 'skipped'` when `skip-infra-launch=true`. Without this, GHA cancels `run-tests` as soon as a dependency is skipped.
- **`terminate`** — already guarded by `needs.launch-infra.result != 'skipped'`, so it naturally no-ops in skip mode. No change.
- **`summary`** — prints `Mode: skip-infra-launch — tests ran against the pre-existing stgN instance.` instead of `Instance: ...` when skipping. Suppresses the "kept running, remember to terminate" warning that doesn't apply.
- **`run-name`** — becomes `Full Pipeline — stg1 (firefox) [skip-launch]` in skip mode, `Full Pipeline — stg1 (firefox) @ 1.3.1` when launching.

## Test plan

- [ ] Trigger with \`skip-infra-launch=true\` (default) — \`launch-infra\` skipped, \`run-tests\` fires against existing stg slot, \`terminate\` skipped.
- [ ] Trigger with \`skip-infra-launch=false\` — full current behaviour (launch EC2, service-update, register TG, tests, terminate).
- [ ] Verify \`run-name\` reflects both modes.
- [ ] Verify summary output in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)