### PR TITLE
fix(test-full-pipeline): wrap run-tests `if:` with always() so skipped launch-infra doesn't skip tests

### DIFF
--- a/.github/workflows/test-full-pipeline.yml
+++ b/.github/workflows/test-full-pipeline.yml
@@ -177,9 +177,10 @@ jobs:
   # ============================================================
   run-tests:
     needs: [build-playwright-image, launch-infra]
-    # Run tests when the playwright image built AND either (a) launch-infra succeeded
-    # or (b) it was skipped because skip-infra-launch=true (tests hit the existing slot).
-    if: needs.build-playwright-image.result == 'success' && (needs.launch-infra.result == 'success' || (needs.launch-infra.result == 'skipped' && inputs.skip-infra-launch))
+    # `always()` is required to override GHA's default transitive-skip: without it,
+    # a skipped `launch-infra` auto-skips this job regardless of the `if:` result.
+    # Then we gate on the actual conditions we care about.
+    if: always() && needs.build-playwright-image.result == 'success' && (needs.launch-infra.result == 'success' || (needs.launch-infra.result == 'skipped' && inputs.skip-infra-launch))
     uses: iblai/iblai-web-ops/.github/workflows/reusable-oci-test-runner.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Follow-up to #146. When `skip-infra-launch=true`, `launch-infra` is skipped (correct), but the first dispatch showed `run-tests` ALSO getting skipped — despite the `if:` expression being logically true.

[Evidence](https://github.com/iblai/mentorai/actions/runs/24792062653): all four of `build-playwright-image=success`, `launch-infra=skipped`, `inputs.skip-infra-launch=true`, yet `run-tests=skipped`.

## Root cause

GHA implicit rule: when any `needs:` dependency reports `skipped`, the downstream job is **automatically skipped** regardless of how its `if:` evaluates. The `if:` override only takes effect when combined with `always()` (or a status-check function like `success()` / `skipped()`).

The existing `terminate` job in the same workflow already uses this pattern (`if: always() && needs.launch-infra.result != 'skipped' && inputs.terminate`). `run-tests` needs the same treatment.

## Fix

```yaml
# before
if: needs.build-playwright-image.result == 'success' && (needs.launch-infra.result == 'success' || (needs.launch-infra.result == 'skipped' && inputs.skip-infra-launch))

# after
if: always() && needs.build-playwright-image.result == 'success' && (needs.launch-infra.result == 'success' || (needs.launch-infra.result == 'skipped' && inputs.skip-infra-launch))
```

No other behaviour change — the original conditions are preserved; `always()` just opts out of the implicit skip-propagation.

## Test plan

- [ ] Dispatch with `skip-infra-launch=true` (default) → `run-tests` fires against the existing stg slot
- [ ] Dispatch with `skip-infra-launch=false` → current full-launch flow continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)