### PR TITLE
fix(mentor): show share button to anonymous users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Chores
 
-* add iblai-mentor scheme to redirectToAuthSpa from sdk ([49bea52](https://github.com/iblai/os/commit/49bea520dd98487d361f36f85989191e6a79214f))
+- add iblai-mentor scheme to redirectToAuthSpa from sdk ([49bea52](https://github.com/iblai/os/commit/49bea520dd98487d361f36f85989191e6a79214f))
 
 ## [0.73.1](https://github.com/iblai/os/compare/v0.73.0...v0.73.1) (2026-06-05)
 

--- a/components/chat/__tests__/ai-message-bubble.test.tsx
+++ b/components/chat/__tests__/ai-message-bubble.test.tsx
@@ -223,12 +223,30 @@ describe('AIMessageBubble', () => {
       expect(screen.getByTestId('ai-message-copy')).toBeInTheDocument();
     });
 
-    it('should render share button when not in shared chat', () => {
+    it('should render share button when logged in and not in shared chat', () => {
       renderWithRedux(<AIMessageBubble {...defaultProps} />);
       expect(screen.getByTestId('ai-message-share')).toBeInTheDocument();
     });
 
-    it('should not render share button when in shared chat', () => {
+    // Issue #1546: anonymous users (opened a chat via a ?token= shareable
+    // link, not logged in) must still be able to share.
+    it('should render share button when NOT logged in and not in shared chat', async () => {
+      const { isLoggedIn } = await import('@/lib/utils');
+      vi.mocked(isLoggedIn).mockReturnValue(false);
+      renderWithRedux(<AIMessageBubble {...defaultProps} />);
+      expect(screen.getByTestId('ai-message-share')).toBeInTheDocument();
+    });
+
+    it('should not render share button when in shared chat (logged in)', () => {
+      mockShowingSharedChat = true;
+      renderWithRedux(<AIMessageBubble {...defaultProps} />, true);
+      expect(screen.queryByTestId('ai-message-share')).not.toBeInTheDocument();
+      mockShowingSharedChat = false; // Reset for other tests
+    });
+
+    it('should not render share button when in shared chat (anonymous)', async () => {
+      const { isLoggedIn } = await import('@/lib/utils');
+      vi.mocked(isLoggedIn).mockReturnValue(false);
       mockShowingSharedChat = true;
       renderWithRedux(<AIMessageBubble {...defaultProps} />, true);
       expect(screen.queryByTestId('ai-message-share')).not.toBeInTheDocument();

--- a/components/chat/ai-message-bubble.tsx
+++ b/components/chat/ai-message-bubble.tsx
@@ -151,7 +151,7 @@ export const AIMessageBubble = forwardRef<
                 />
               )}
 
-              {isLoggedIn() && !showingSharedChat && (
+              {!showingSharedChat && (
                 <AIMessageShare sessionId={sessionId} tenantKey={tenantKey} />
               )}
 


### PR DESCRIPTION
Anonymous users (who open a chat via a shareable token link rather than logging in) were unable to share a chat because the share button was gated behind isLoggedIn(). The backend now authorizes anonymous principals on the session-sharing endpoint, so gate the button only by the read-only shared-chat view.


## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Closes https://github.com/iblai/iblai-platform/issues/1546
