### PR TITLE
fix(deploy): make standalone deployment resilient to lockfile-induced output nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Build, deploy, and manage intelligent conversational agents — from prototype t
 
 _[Demo](https://youtu.be/5LOAZyTbRQs) by Miguel Amigot, CTO at ibl.ai_
 
-[Features](#features) · [Screenshots](#screenshots) · [Quick Start](#quick-start) · [Deployment](#deployment) · [Contributing](#contributing)
+[Features](#features) · [Screenshots](#screenshots) · [Quick Start](#quick-start) · [Deployment](#deployment) · [Troubleshooting](#troubleshooting) · [Contributing](#contributing)
 
 </div>
 
@@ -153,6 +153,13 @@ If you already have an ibl.ai tenant (organization key):
    PORT=3000 node server-wrapper.js
    ```
 
+   The build emits a self-contained server under `.next/standalone/` (Next.js
+   [standalone output](https://nextjs.org/docs/app/api-reference/config/next-config-js/output)).
+   `next.config.ts` pins `outputFileTracingRoot` to the project directory so the
+   output always lands at `.next/standalone/server.js` with its static assets
+   alongside it. See [Troubleshooting](#troubleshooting) if the app loads to a
+   blank screen.
+
 ### Option B: Enterprise Deployment
 
 If you need full backend infrastructure:
@@ -172,6 +179,33 @@ If you need full backend infrastructure:
 See [docs/development.md](docs/development.md) for native app build instructions.
 
 Full deployment docs: [Docker & Standalone](docs/standalone-deployment.md)
+
+### Troubleshooting
+
+**The app loads to a blank page or stays stuck on the loading spinner (no redirect to login).**
+
+Open your browser's DevTools → Network tab and reload. If every request under
+`/_next/static/...` and `/env.js` returns `404`/`503`, the server isn't finding
+its static assets. Two common causes:
+
+- **A duplicate or stale server is bound to the port.** An older `node`/`next`
+  process from a previous run can keep listening on `:3000` and shadow the new
+  one (a process bound to a specific address such as `127.0.0.1` wins over a
+  wildcard bind). Find and stop strays before starting fresh:
+
+  ```bash
+  lsof -nP -iTCP:3000 -sTCP:LISTEN   # list listeners on the port
+  kill <PID>                         # stop the stale one
+  ```
+
+- **The standalone output was nested under an unexpected path.** Next.js infers
+  the file-tracing root from the nearest lockfile. A stray lockfile in a _parent_
+  directory (e.g. `~/package-lock.json`) makes it treat your home directory as
+  the workspace root and emit the server at `.next/standalone/<path-to-project>/server.js`
+  instead of `.next/standalone/server.js` — `post-build.sh` then copies static
+  assets next to the wrong path and `server-wrapper.js` can't find the server.
+  This repo pins `outputFileTracingRoot` in `next.config.ts` to prevent it; if
+  you still hit nesting, remove the stray parent lockfile and rebuild.
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,12 @@ const assetPrefix = basePath ? `${basePath}/` : '';
 
 const nextConfig: NextConfig = {
   output: 'standalone', // <- this generates .next/standalone
+  // Pin the file-tracing root to this project so the standalone output lands at
+  // .next/standalone/server.js. Without this, a stray lockfile in a parent dir
+  // (e.g. ~/package-lock.json) makes Next infer a higher workspace root and nest
+  // the output under .next/standalone/<path>/, which breaks server-wrapper.js and
+  // static asset serving.
+  outputFileTracingRoot: process.cwd(),
   basePath,
   assetPrefix,
   trailingSlash: !!basePath,


### PR DESCRIPTION
## What

- Pin `outputFileTracingRoot` to the project directory in `next.config.ts`.
- Add a **Troubleshooting** section to the README's Deployment docs covering the two failure modes below.

## The issue (why this is needed)

Following the README's standalone deploy path (`pnpm build` → `PORT=3000 node server-wrapper.js`), the app would build and return `200` for `/`, but render a permanent **"Loading…" screen and never redirect to the login SPA**. DevTools showed **every `/_next/static/*` chunk, CSS file, font, and `/env.js` returning 404/503**, so no client JS executed and the auth-redirect never ran.

Root cause: **Next.js infers the file-tracing root from the nearest lockfile.** When a stray lockfile exists in a _parent_ directory (e.g. `~/package-lock.json`), Next treats the home directory as the workspace root and emits the standalone server at:

```
.next/standalone/<path-to-project>/server.js     # nested
```

instead of the expected:

```
.next/standalone/server.js
```

`scripts/post-build.sh` (and `server-wrapper.js`) assume the un-nested layout, so static assets get copied next to the wrong path and the wrapper falls back to a non-existent `server.js`. The result is a server that serves HTML but 404s every static asset.

### Fix

Setting `outputFileTracingRoot: process.cwd()` forces the project directory as the tracing root regardless of any parent-directory lockfiles, so the standalone output is always emitted at `.next/standalone/server.js` with its assets alongside it — and the README's documented command works as written.

### Bonus troubleshooting note

While debugging this, a second, unrelated trap surfaced: a **stale server process from an earlier run can keep listening on the port and shadow the new one** (a process bound to a specific address like `127.0.0.1` wins over a wildcard `*` bind), making a freshly-fixed build appear still-broken. The README Troubleshooting section documents how to spot and kill strays with `lsof`.

## Testing

- Verified the standalone build now emits `.next/standalone/server.js` (no nesting).
- `PORT=3000 node server-wrapper.js` serves all `/_next/static/*` and `/env.js` with `200`, and the app correctly redirects to the ibl.ai login SPA.
- Pre-push hooks (typecheck, lint, build, unit tests, e2e coverage) pass.

## Scope

Config + docs only. No change to application behavior or user-facing features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)