### PR TITLE
feat(sidebar): enlarge and center the platform logo in the header

### DIFF
--- a/app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx
+++ b/app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx
@@ -1931,8 +1931,10 @@ export function AppSidebar() {
           {/* Header */}
           <div
             className={cn(
-              'shrink-0 pt-[18px] pb-[25px]',
-              railCollapsed ? 'px-2' : 'px-[10px]',
+              'shrink-0',
+              railCollapsed
+                ? 'px-2 pt-[18px] pb-[25px]'
+                : 'px-[10px] py-[10px]',
             )}
           >
             <div
@@ -1942,9 +1944,15 @@ export function AppSidebar() {
               )}
             >
               {!railCollapsed && (
-                <div className="flex min-w-0 flex-1 items-center">
-                  <Logo className="max-h-[30px] w-auto object-contain" />
-                </div>
+                <>
+                  {/* Spacer matching the collapse button's width so the logo
+                      sits at the true horizontal center of the header rather
+                      than being pushed left by the button on the right. */}
+                  <span className="size-7 shrink-0" aria-hidden />
+                  <div className="flex min-w-0 flex-1 items-center justify-center">
+                    <Logo className="h-[51px] max-h-none w-auto max-w-full object-contain" />
+                  </div>
+                </>
               )}
               <SidebarCollapsedLabelFlyout
                 label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}


### PR DESCRIPTION
## What

Makes the platform sidebar's top-left logo larger and centered, instead of a small mark pinned to the corner.

| | Before | After |
|---|---|---|
| Height | `max-h-[30px]` | fixed `h-[51px]` (fills the header) |
| Alignment | left-aligned | centered across the full bar |

## Why

The logo read as small and tucked into the top-left corner with a lot of empty header space around it. Enlarging it and centering it makes it the clear focal point of the sidebar header.

## How

In `app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx`:

- Logo `max-h-[30px]` → fixed `h-[51px] max-h-none w-auto max-w-full object-contain` (taller; `max-w-full` keeps wide tenant wordmarks from overflowing).
- Header vertical padding tightened (`pt-[18px] pb-[25px]` → `py-[10px]`, expanded state only) so the taller logo fills the header cleanly.
- Added a spacer matching the collapse-sidebar button's width on the left, so the logo is centered across the **full** header width rather than being pushed left by the button on the right.
- Collapsed (rail) state is unchanged.

## Testing

- Verified against a faithful reproduction of the header markup using a real tenant logo (256px sidebar width, same paddings, same collapse button).
- Pre-push hooks (typecheck, lint, build, unit tests, e2e coverage) pass.

## Scope

Single-file UI change. No behavior or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)