### PR TITLE
ci: skip PR workflows for external pull requests

### DIFF
--- a/.github/workflows/e2e-coverage-bot.yml
+++ b/.github/workflows/e2e-coverage-bot.yml
@@ -28,8 +28,12 @@ jobs:
   coverage-bot:
     name: E2E Coverage Bot
     runs-on: ubuntu-latest
-    # Skip commits made by the bot itself (prevent loops) and Dependabot PRs (no secret access)
-    if: github.actor != 'mamigot' && github.actor != 'dependabot[bot]'
+    # Skip commits made by the bot itself (prevent loops), Dependabot PRs (no secret
+    # access), and PRs opened from forks (no secret access either).
+    if: |
+      github.actor != 'mamigot' &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write # allow Claude to commit coverage file updates
       pull-requests: write # allow gh pr review to post reviews

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -38,7 +38,9 @@ jobs:
   # GATE — only run when the `run-tests` label is present
   # ============================================================
   gate:
-    if: contains(github.event.pull_request.labels.*.name, 'run-tests')
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'run-tests') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: iblai-stg-runner
     steps:
       - run: echo "run-tests label detected — proceeding"


### PR DESCRIPTION
Limits `pr-e2e-tests.yml` and `e2e-coverage-bot.yml` to PRs opened from branches in this repo. Internal contributor flow is unchanged.