### PR TITLE
ci: run summary job on github-hosted runner

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -106,7 +106,7 @@ jobs:
   summary:
     needs: [build-app-image, build-playwright-image, run-tests]
     if: always()
-    runs-on: iblai-stg-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Results
         run: |


### PR DESCRIPTION
Moves the `summary` job in `pr-e2e-tests.yml` to `ubuntu-latest`. The job only writes a markdown table and an exit code, so it has no need for the self-hosted runner.