### PR TITLE
test: verify run-tests label triggers E2E (do not merge)

### DIFF
--- a/components/modals/create-mentor-modal.tsx
+++ b/components/modals/create-mentor-modal.tsx
@@ -30,3 +30,5 @@ export function CreateMentorModal({
     </Dialog>
   );
 }
+
+// no-op: dummy change to exercise run-tests label / E2E trigger


### PR DESCRIPTION
Throwaway draft PR to test that the **run-tests** label triggers the **PR E2E Tests (Required)** workflow.

- Touches `components/modals/create-mentor-modal.tsx` (a watched path) with a no-op comment so the workflow's `paths:` filter matches.
- Add the **run-tests** label to trigger the run; remove + re-add to re-trigger.
- Close + delete branch when done — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)