### PR TITLE
ci: fall back to github.token for SPA docker build source checkout

### DIFF
--- a/.github/workflows/reusable-spa-docker-build.yml
+++ b/.github/workflows/reusable-spa-docker-build.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: ${{ inputs.source_repo }}
           ref: ${{ inputs.source_ref }}
-          token: ${{ secrets.GIT_TOKEN }}
+          token: ${{ secrets.GIT_TOKEN || github.token }}
           fetch-depth: 1
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Problem

The vendored `reusable-spa-docker-build.yml` clones the source repo with a bare:

```yaml
token: ${{ secrets.GIT_TOKEN }}
```

`GIT_TOKEN` is **not available to this public repo** — it is not a repo secret, and it is not among the org secrets scoped to this repo (only `AWS_*` / `OCIR_*` are). So `secrets.GIT_TOKEN` resolves to empty and `actions/checkout` fails immediately:

```
##[error]Input required and not supplied: token
```

This blocked the tag-triggered **Docker Build** (e.g. mentor v0.74.1 / the next skills release) right after the runner-group access was restored.

## Fix

`source_repo` is always `${{ github.repository }}` — i.e. **this public repo** — which the automatic `GITHUB_TOKEN` can clone without a PAT. Fall back to it when `GIT_TOKEN` is absent:

```yaml
token: ${{ secrets.GIT_TOKEN || github.token }}
```

This is the **same pattern already used** in `reusable-pr-docker-build.yml` for the ops checkout. Removes the dependency on a `GIT_TOKEN` secret for building this repo's own (public) source.

## Effect / how to land

Takes effect on the **next tag/release** (the Docker Build resolves the reusable at the tag commit). After merge, cut a fresh tag and the build will clone via `github.token` and push to ECR (AWS creds are already available to this repo; `SENTRY_AUTH_TOKEN` is optional and already absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)