### PR TITLE
Feat/tenant switch sdk migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
         tauri-build-windows tauri-build-windows-arm \
         tauri-build-linux tauri-build-linux-arm \
         tauri-android-init tauri-android-dev tauri-android-build tauri-android-build-aab \
+        android-deep-link-scheme \
         tauri-ios-init tauri-ios-dev tauri-ios-build \
         tauri-info tauri-update tauri-clean tauri-icons \
         tauri-build-all-desktop tauri-build-all-mobile
@@ -198,10 +199,17 @@ tauri-build-linux-arm:
 # Initialize Android project (run once)
 tauri-android-init:
 	cargo tauri android init
+	@bash scripts/android-add-deep-link-scheme.sh
+
+# Re-apply the iblai-mentor:// custom URL scheme intent filters to the generated
+# (gitignored) Android manifest so SSO deep links route the browser back into the
+# app. Idempotent; runs automatically before every Android build/dev target.
+android-deep-link-scheme:
+	@bash scripts/android-add-deep-link-scheme.sh
 
 # Run Android dev build (auto-detects local IP for dev server)
 # Run 'make dev-mobile' first in another terminal
-tauri-android-dev:
+tauri-android-dev: android-deep-link-scheme
 	@LOCAL_IP=$$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null); \
 	if [ -z "$$LOCAL_IP" ]; then \
 		echo "Error: Could not detect local IP address"; \
@@ -212,11 +220,11 @@ tauri-android-dev:
 		--config '{"build":{"devUrl":"http://'"$$LOCAL_IP"':3001","frontendDist":"http://'"$$LOCAL_IP"':3001"}}'
 
 # Build for Android (release APK)
-tauri-android-build:
+tauri-android-build: android-deep-link-scheme
 	cargo tauri android build
 
 # Build for Android (release AAB for Play Store)
-tauri-android-build-aab:
+tauri-android-build-aab: android-deep-link-scheme
 	cargo tauri android build --aab true
 
 # ============================================

--- a/e2e/journeys/07-mentor-settings-tab-unique-id.spec.ts
+++ b/e2e/journeys/07-mentor-settings-tab-unique-id.spec.ts
@@ -229,7 +229,7 @@ test.describe('Journey 7: Mentor Settings Tab — Unique ID', () => {
 
     await expect(
       page.getByRole('tooltip', {
-        name: /multiple search queries from a single user question/i,
+        name: /runs several search queries per question to pull more relevant documents/i,
       }),
     ).toBeVisible({ timeout: 5_000 });
     logger.info('uid-07: Enhanced RAG tooltip content is visible');

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -104,6 +104,7 @@ vi.mock('@iblai/iblai-js/web-utils', () => ({
 
 vi.mock('@iblai/iblai-js/web-utils/auth', () => ({
   redirectToAuthSpa: vi.fn(),
+  handleTenantSwitch: vi.fn(),
 }));
 
 // Mock localStorage with spied functions
@@ -2330,99 +2331,49 @@ describe('handleLogout function', () => {
   });
 });
 
+// handleTenantSwitch is a thin wrapper over the SDK's cross-tab tenant switch
+// (the actual coordination/redirect logic is unit-tested in @iblai/web-utils).
+// These tests assert the wrapper delegates with mentorai's injected config.
 describe('handleTenantSwitch function', () => {
-  let locationHrefSpy: string;
-
   beforeEach(() => {
-    locationHrefSpy = '';
-    // Clear cookies from previous tests
-    document.cookie =
-      'ibl_tenant_switching=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    document.cookie =
-      'ibl_login_timestamp=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    document.cookie =
-      'ibl_logout_timestamp=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-      writable: true,
-      configurable: true,
-    });
-    Object.defineProperty(window, 'location', {
-      value: {
-        origin: 'https://example.com',
-        hostname: 'example.com',
-        pathname: '/current-path',
-        search: '?query=value',
-        set href(value: string) {
-          locationHrefSpy = value;
-        },
-        get href() {
-          return locationHrefSpy || 'https://example.com';
-        },
-      },
-      writable: true,
-      configurable: true,
-    });
-    localStorageMock.clear();
     vi.clearAllMocks();
   });
 
-  it('should switch to new tenant', async () => {
-    await handleTenantSwitch('new-tenant');
-    expect(localStorageMock.getItem('tenant')).toBe('new-tenant');
-    expect(locationHrefSpy).toContain(
-      'https://auth.example.com/login/complete',
+  it('delegates to the SDK handleTenantSwitch with mentorai config', async () => {
+    const { handleTenantSwitch: sdkSwitch } = await import(
+      '@iblai/iblai-js/web-utils/auth'
     );
-  });
-
-  it('should include redirect URL', async () => {
-    await handleTenantSwitch('new-tenant', false, 'https://custom.com');
-    expect(locationHrefSpy).toContain('new-tenant');
-    expect(locationHrefSpy).toContain(encodeURIComponent('https://custom.com'));
-  });
-
-  it('should save redirect path when requested', async () => {
-    await handleTenantSwitch('new-tenant', true);
-    expect(localStorageMock.getItem('redirect-to')).toBe(
-      '/current-path?query=value',
-    );
-  });
-
-  it('should clear localStorage before switching', async () => {
-    localStorageMock.setItem('old-key', 'old-value');
-    await handleTenantSwitch('new-tenant');
-    expect(localStorageMock.getItem('old-key')).toBeNull();
-  });
-
-  it('should include JWT token in URL when token exists in localStorage', async () => {
-    localStorageMock.setItem('edx_jwt_token', 'test-jwt-token-123');
-    await handleTenantSwitch('new-tenant');
-    expect(locationHrefSpy).toContain('token=test-jwt-token-123');
-  });
-
-  it('should not include JWT token in URL when no token in localStorage', async () => {
-    // localStorage is cleared by beforeEach, so no token exists
-    await handleTenantSwitch('new-tenant');
-    expect(locationHrefSpy).not.toContain('token=');
-  });
-
-  it('should preserve JWT token before clearing localStorage', async () => {
-    localStorageMock.setItem('edx_jwt_token', 'preserved-token');
-    localStorageMock.setItem('other-key', 'other-value');
-    await handleTenantSwitch('new-tenant');
-
-    // Other keys should be cleared
-    expect(localStorageMock.getItem('other-key')).toBeNull();
-    // Token should be in the redirect URL
-    expect(locationHrefSpy).toContain('token=preserved-token');
-  });
-
-  it('should call clearCurrentTenantCookie', async () => {
     const { clearCurrentTenantCookie } = await import(
       '@iblai/iblai-js/web-utils'
     );
     await handleTenantSwitch('new-tenant');
-    expect(clearCurrentTenantCookie).toHaveBeenCalled();
+    expect(sdkSwitch).toHaveBeenCalledWith(
+      'new-tenant',
+      expect.objectContaining({
+        authUrl: 'https://auth.example.com',
+        redirectPathStorageKey: 'redirect-to',
+        queryParams: { redirectTo: 'redirect-to' },
+        clearCurrentTenantCookie,
+        saveRedirect: false,
+        redirectUrl: undefined,
+        broadcast: true,
+      }),
+    );
+  });
+
+  it('forwards saveRedirect, redirectUrl and broadcast flags', async () => {
+    const { handleTenantSwitch: sdkSwitch } = await import(
+      '@iblai/iblai-js/web-utils/auth'
+    );
+    await handleTenantSwitch('t', true, 'https://custom.com', false);
+    expect(sdkSwitch).toHaveBeenCalledWith(
+      't',
+      expect.objectContaining({
+        saveRedirect: true,
+        redirectUrl: 'https://custom.com',
+        broadcast: false,
+      }),
+    );
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,7 +24,13 @@ import { isTauriApp } from '@/types/tauri';
 import { isTauriOfflineMode } from '@/lib/tauri-api-cache';
 import { isOfflineServerOrigin } from '@/hooks/use-tauri-offline';
 import type { Tenant } from '@iblai/iblai-js/web-utils';
-import { redirectToAuthSpa as sdkRedirectToAuthSpa } from '@iblai/iblai-js/web-utils/auth';
+// NOTE: clearCurrentTenantCookie is imported dynamically inside handleTenantSwitch
+// (not statically) — the main web-utils entry pulls in React providers, which
+// would break this module when it's loaded in a React Server Component.
+import {
+  redirectToAuthSpa as sdkRedirectToAuthSpa,
+  handleTenantSwitch as sdkHandleTenantSwitch,
+} from '@iblai/iblai-js/web-utils/auth';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -591,83 +597,29 @@ export function canSwitchProvider(providers: Provider[], name: string) {
   return !!provider?.chat_models && provider.chat_models.length > 0;
 }
 
+// Cross-tab tenant switching now lives in the SDK
+// (@iblai/iblai-js/web-utils). This thin wrapper injects mentorai's config;
+// all coordination (TTL lock + BroadcastChannel) is handled in the SDK.
 export const handleTenantSwitch = async (
   tenant: string,
   saveRedirect = false,
   redirectUrl?: string,
   broadcastTenantSwitching = true,
-) => {
-  console.log('############### HANDLE TENANT SWITCHING ###############', {
-    broadcastTenantSwitching,
+): Promise<void> => {
+  // Lazy import: the main web-utils entry pulls in React providers, so importing
+  // it at module top-level would break this file inside a Server Component.
+  const { clearCurrentTenantCookie } = await import(
+    '@iblai/iblai-js/web-utils'
+  );
+  return sdkHandleTenantSwitch(tenant, {
+    authUrl: config.authUrl(),
+    redirectPathStorageKey: REDIRECT_PATH_LOCAL_STORAGE_KEY,
+    queryParams: { redirectTo: REDIRECT_PATH_LOCAL_STORAGE_KEY },
+    clearCurrentTenantCookie,
+    saveRedirect,
+    redirectUrl,
+    broadcast: broadcastTenantSwitching,
   });
-  // Signal to the app that a tenant switch is in progress
-  if (
-    document.cookie.includes('ibl_tenant_switching') &&
-    broadcastTenantSwitching
-  ) {
-    console.log(
-      '[handleTenantSwitch] Skipping tenant switch - tenant switching',
-    );
-    return;
-  }
-  if (tenant === localStorage.getItem('tenant')) {
-    console.log(
-      '[handleTenantSwitch] Skipping tenant switch - tenant is the same',
-    );
-    console.log(
-      `[handleTenantSwitch] Switching from ${localStorage.getItem('tenant')} to ${tenant}`,
-    );
-    return;
-  }
-
-  if (broadcastTenantSwitching) {
-    setCookieForAuth('ibl_tenant_switching', 'true');
-  }
-  // Notify other tabs/windows that a tenant switch is starting
-  if (typeof BroadcastChannel !== 'undefined' && broadcastTenantSwitching) {
-    const channel = new BroadcastChannel('ibl-tenant-switch');
-    channel.postMessage({ type: 'TENANT_SWITCHING', tenant });
-    channel.close();
-  }
-  if (broadcastTenantSwitching) {
-    // Clear current tenant cookie before switching
-    const { clearCurrentTenantCookie } = await import(
-      '@iblai/iblai-js/web-utils'
-    );
-    clearCurrentTenantCookie();
-  }
-  // Preserve the current path before clearing localStorage
-  const currentPath = `${window.location.pathname}${window.location.search}`;
-  // Get JWT token before clearing localStorage
-  const jwtToken = localStorage.getItem('edx_jwt_token');
-  console.log('[handleTenantSwitch] clearing local storage', {
-    tenant,
-    currentTenant: localStorage.getItem('tenant'),
-  });
-  if (broadcastTenantSwitching) {
-    console.log('[handleTenantSwitch] clearing local storage');
-    localStorage.clear();
-  }
-  const url = `${config.authUrl()}/login/complete`;
-  const params: Record<string, string> = {
-    tenant,
-    [REDIRECT_PATH_LOCAL_STORAGE_KEY]: redirectUrl ?? window.location.origin,
-  };
-
-  // Add token if it exists
-  if (jwtToken) {
-    params.token = jwtToken;
-  }
-
-  const param = new URLSearchParams(params).toString();
-
-  localStorage.setItem('tenant', tenant);
-  if (saveRedirect) {
-    // Restore the redirect path after setting tenant
-    localStorage.setItem(REDIRECT_PATH_LOCAL_STORAGE_KEY, currentPath);
-  }
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  window.location.href = `${url}?${param}`;
 };
 
 export const canSwitchLLm = (llm: {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@iblai/agent-ai": "2.5.2",
     "@iblai/iblai-api": "4.166.0-ai",
-    "@iblai/iblai-js": "1.18.1",
+    "@iblai/iblai-js": "1.19.0",
     "@iblai/iblai-web-mentor": "1.3.4",
     "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 4.166.0-ai
         version: 4.166.0-ai
       '@iblai/iblai-js':
-        specifier: 1.18.1
-        version: 1.18.1(42ea00cef529f8d05a76c6945e050e01)
+        specifier: 1.19.0
+        version: 1.19.0(42ea00cef529f8d05a76c6945e050e01)
       '@iblai/iblai-web-mentor':
         specifier: 1.3.4
         version: 1.3.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.2)(typescript@5.9.3)
@@ -829,8 +829,8 @@ packages:
   '@iblai/iblai-api@4.166.0-ai':
     resolution: {integrity: sha512-dY9Jv+CkXEyTxRsOQFay5YvYe8K2LSQluJJvtssGQV2RbrxPPzONaKfnhcyarDs7Ft35Xqk1fuErjhUwNG3OIg==}
 
-  '@iblai/iblai-js@1.18.1':
-    resolution: {integrity: sha512-etVVl+1tD1fGl+XcxP15+vfSD6iqWf0VNdusq9Eji+aBD8R9q2+QDEYK+/V0zxqtqXK5XB/ARjmTTr4x226p6A==}
+  '@iblai/iblai-js@1.19.0':
+    resolution: {integrity: sha512-pkIUYC94Fu61/H89iYrpkfER+w5crIly6yEtwYlob5ffrYsHiHBm9H7rPLX4xE/Ok3tmlfrrqOuRZL4UA3Of0A==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -854,18 +854,18 @@ packages:
   '@iblai/iblai-web-mentor@1.3.4':
     resolution: {integrity: sha512-w0K22cQl/LquXDDnVi7DgiOeuS+iha85poZxuLCtJqvwyCxAMLch1DWN3LbNCxw+YGhrV7BOEENp8s7bZ+7ZGw==}
 
-  '@iblai/mcp@1.6.0':
-    resolution: {integrity: sha512-e2D3Q1w8KTvnfhzayCMH23dbSH3m8/sJYGsgB4cWFLBt+8VffByeLR3fm5yPG2+cnxHD4DMgL9zYCUXnVWFOxA==}
+  '@iblai/mcp@1.7.0':
+    resolution: {integrity: sha512-hUgr370reZ3YaMWTIZFwjzOnnlrJXFzUY8Lj95kyCzNf9qeA0zfDQ2uTe3UhOv5BS0czjXGFZ49azKUkXTY9DQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@iblai/web-containers@1.9.1':
-    resolution: {integrity: sha512-y3F/FdqoISI6R61uEx/METlWM6/mzkq8osQHY1Z5G6W5TBm/+pRqW242royNuvtgPec/DzloVfyZc5SI6fp9aw==}
+  '@iblai/web-containers@1.9.2':
+    resolution: {integrity: sha512-vuJUzeAyZZu3/DIpax5dF8plRiEVMbtzK0V2bwjQ9GydC1J45rb2ukLWqkFfHEMjiW9ANMTfVGBC8aiRpWHcqg==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@iblai/data-layer': 1.8.1
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.10.11
+      '@iblai/web-utils': 1.10.12
       '@livekit/components-react': 2.8.1
       '@radix-ui/react-dialog': ^1.1.7
       '@reduxjs/toolkit': 2.7.0
@@ -885,8 +885,8 @@ packages:
       sonner:
         optional: true
 
-  '@iblai/web-utils@1.10.11':
-    resolution: {integrity: sha512-YY6qjzolEDcywiWOafbDhbAq5d+W+aqMBKWlWMXaoLHkL6IVYkF81VSfuzSneOaRyQloha2YCLw4Ngvd/djOeg==}
+  '@iblai/web-utils@1.11.0':
+    resolution: {integrity: sha512-m616JhQhctaw57HoSCwU/UCiOqUb+96zAJXdtjabfEl+9oc2vXEYwyhCFXbx5byjCC7g5MUa5xW7W/d4CKRB5A==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@iblai/data-layer': ^1.1.2
@@ -9737,13 +9737,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@iblai/iblai-js@1.18.1(42ea00cef529f8d05a76c6945e050e01)':
+  '@iblai/iblai-js@1.19.0(42ea00cef529f8d05a76c6945e050e01)':
     dependencies:
       '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/mcp': 1.6.0
-      '@iblai/web-containers': 1.9.1(b74f8bac754dcf27ee7e6b69e7f6fda6)
-      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/mcp': 1.7.0
+      '@iblai/web-containers': 1.9.2(05de6d3b10d65d4517b4da8095c89120)
+      '@iblai/web-utils': 1.11.0(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@reduxjs/toolkit': 2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.16.1
@@ -9784,7 +9784,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@iblai/mcp@1.6.0':
+  '@iblai/mcp@1.7.0':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
@@ -9792,11 +9792,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@iblai/web-containers@1.9.1(b74f8bac754dcf27ee7e6b69e7f6fda6)':
+  '@iblai/web-containers@1.9.2(05de6d3b10d65d4517b4da8095c89120)':
     dependencies:
       '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/web-utils': 1.11.0(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-accordion': 1.2.8(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.7(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox': 1.2.3(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9878,7 +9878,7 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/web-utils@1.10.11(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@iblai/web-utils@1.11.0(@iblai/data-layer@1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@iblai/data-layer': 1.8.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai

--- a/providers/__tests__/index.test.tsx
+++ b/providers/__tests__/index.test.tsx
@@ -255,6 +255,9 @@ let mentorProviderCallbacksToInvoke: Array<{ name: string; args?: unknown[] }> =
   [];
 
 vi.mock('@iblai/iblai-js/web-utils', () => ({
+  useTenantSwitchSync: vi.fn(),
+  refreshTenantSwitchLock: vi.fn(),
+  isTenantSwitchInProgress: vi.fn(() => false),
   useTenantMetadata: () => ({
     metadata: mockMetadata,
     platformName: null,

--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -39,6 +39,11 @@ import { useTenantKey } from '@/hooks/use-tenants';
 import { TenantKeyMentorIdParams } from '@/lib/types';
 import { handleTenantSwitch } from '@/lib/utils';
 import {
+  useTenantSwitchSync,
+  refreshTenantSwitchLock,
+  isTenantSwitchInProgress,
+} from '@iblai/iblai-js/web-utils';
+import {
   AuthProvider,
   TenantProvider,
   MentorProvider,
@@ -78,30 +83,20 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     deleteCookieOnAllDomains('ibl_tenant_switching', window.location.hostname);
+    // If we just landed from a tenant switch, extend the suppression window
+    // from this load so a stale tab can't revert after the round-trip settles.
+    // (Lock is shared across tabs; refreshTenantSwitchLock is a no-op when no
+    // active lock exists, so normal loads are unaffected.)
+    refreshTenantSwitchLock();
     sendMessageToParentWebsite({
       loaded: true,
       auth: { ...localStorage },
     });
   }, []);
 
-  // Listen for tenant switch events from other tabs/windows via BroadcastChannel
-  useEffect(() => {
-    if (typeof BroadcastChannel === 'undefined') return;
-    const channel = new BroadcastChannel('ibl-tenant-switch');
-
-    channel.onmessage = (event) => {
-      const { type, tenant } = event.data ?? {};
-      if (type === 'TENANT_SWITCHING') {
-        console.log(
-          '[Providers] Received TENANT_SWITCHING from another tab, target:',
-          tenant,
-        );
-        handleTenantSwitch(tenant, false, undefined, false);
-      }
-    };
-
-    return () => channel.close();
-  }, []);
+  // Keep this tab in sync with tenant switches from other tabs (self-echo
+  // filtered, shared lock refreshed). Coordination lives in the SDK.
+  useTenantSwitchSync();
 
   const handlers = useIframeHandlers();
 
@@ -546,6 +541,16 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           onLoadPlatformPermissions={onLoadPlatformpermissions}
           skipCustomDomainCheck={window.location.origin === config.mentorUrl()}
           onTenantMismatch={() => {
+            // During a switch window, a stale tab legitimately sees its old
+            // route != the new session tenant. Suppress the revert so tabs
+            // don't ping-pong; once the lock TTL expires and the session is
+            // consistent, a real mismatch resolves normally.
+            if (isTenantSwitchInProgress()) {
+              console.log(
+                '[TenantProvider] Tenant mismatch during switch window — suppressing revert',
+              );
+              return;
+            }
             console.log(
               '[TenantProvider] Tenant mismatch - redirecting to home',
             );

--- a/scripts/android-add-deep-link-scheme.sh
+++ b/scripts/android-add-deep-link-scheme.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Re-apply the custom URL scheme intent filters to the generated Android manifest.
+#
+# Why this exists:
+#   The auth flow finishes by redirecting the system browser to a custom scheme,
+#   iblai-mentor:///sso-login-complete?data=…, which must route back into the app.
+#   iOS handles this scheme via its WebView delegate; Android requires an explicit
+#   <intent-filter> in AndroidManifest.xml. Once the OS routes it, the deep-link
+#   plugin emits the URL and handle_deep_link_url (src-tauri/src/lib.rs) navigates
+#   the WebView to the real https completion URL.
+#
+#   src-tauri/gen/android is generated and gitignored, so a fresh checkout or a
+#   `cargo tauri android init` loses the manifest edit. This script re-applies it
+#   and is wired into the `tauri-android-*` Makefile targets so it runs before
+#   every Android build. It is idempotent.
+set -e
+
+MANIFEST="$(dirname "$0")/../src-tauri/gen/android/app/src/main/AndroidManifest.xml"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "⚠ Android manifest not found at: $MANIFEST"
+  echo "  Run 'cargo tauri android init' (make tauri-android-init) first."
+  exit 0
+fi
+
+if grep -q 'android:scheme="iblai-mentor"' "$MANIFEST"; then
+  echo "✓ Custom-scheme intent filters already present in AndroidManifest.xml — nothing to do."
+  exit 0
+fi
+
+echo "→ Injecting iblai-mentor / ai.ibl.mentorai intent filters into AndroidManifest.xml…"
+
+# Insert the filters immediately before the closing </activity> of MainActivity
+# (the manifest has a single <activity>).
+awk '
+  /<\/activity>/ && !done {
+    print "            <!-- Custom URL scheme for the SSO deep-link return from the"
+    print "                 system browser (iblai-mentor:///sso-login-complete?data=…)."
+    print "                 iOS handles this scheme via its WebView delegate; Android"
+    print "                 needs an explicit intent filter so the OS routes the redirect"
+    print "                 back into the app. Re-applied by"
+    print "                 scripts/android-add-deep-link-scheme.sh because gen/android is"
+    print "                 generated/gitignored. Custom schemes cannot use autoVerify. -->"
+    print "            <intent-filter>"
+    print "                <action android:name=\"android.intent.action.VIEW\" />"
+    print "                <category android:name=\"android.intent.category.DEFAULT\" />"
+    print "                <category android:name=\"android.intent.category.BROWSABLE\" />"
+    print "                <data android:scheme=\"iblai-mentor\" />"
+    print "            </intent-filter>"
+    print "            <intent-filter>"
+    print "                <action android:name=\"android.intent.action.VIEW\" />"
+    print "                <category android:name=\"android.intent.category.DEFAULT\" />"
+    print "                <category android:name=\"android.intent.category.BROWSABLE\" />"
+    print "                <data android:scheme=\"ai.ibl.mentorai\" />"
+    print "            </intent-filter>"
+    done = 1
+  }
+  { print }
+' "$MANIFEST" > "$MANIFEST.tmp" && mv "$MANIFEST.tmp" "$MANIFEST"
+
+echo "✓ Intent filters injected into AndroidManifest.xml."

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,11 +66,8 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle) -> Result<(), String> 
         println!("[OAuth Popup] Navigation to: {}", url_str);
 
         // Check if this is a callback URL (auth completed)
-        let is_callback = url_str.contains("login.iblai.app") &&
-            (url_str.contains("/callback") ||
-             url_str.contains("code=") ||
-             url_str.contains("token=") ||
-             url_str.contains("access_token="));
+        let is_callback = url_str.contains("mentorai.iblai.app") ||
+            url_str.starts_with("https://mentorai.iblai.app");
 
         // Also check for custom scheme callbacks
         let is_custom_scheme = url_str.starts_with("iblai-mentor://") ||
@@ -168,7 +165,7 @@ fn get_app_url() -> String {
 
     // Default: localhost for debug, production URL for release
     #[cfg(debug_assertions)]
-    return "https://mentorai.iblai.org".to_string();
+    return "https://mentorai.iblai.app".to_string();
 
     #[cfg(not(debug_assertions))]
     return "https://mentorai.iblai.app".to_string();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -76,7 +76,8 @@
     "deep-link": {
       "mobile": [
         { "host": "mentorai.iblai.app", "pathPrefix": ["/"] },
-        { "host": "login.iblai.app", "pathPrefix": ["/"] }
+        { "host": "login.iblai.app", "pathPrefix": ["/"] },
+        { "scheme": ["iblai-mentor", "ai.ibl.mentorai"] }
       ],
       "desktop": {
         "schemes": ["iblai-mentor", "ai.ibl.mentorai"]


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- **Tenant switching now comes from the SDK.** mentorai imports cross-tab tenant
  switching from `@iblai/iblai-js/web-utils` instead of a local copy:
  - `handleTenantSwitch` → thin config wrapper over the SDK (lazy-imports
    `clearCurrentTenantCookie` so `lib/utils` stays RSC-safe).
  - `providers` use `useTenantSwitchSync()` and gate `onTenantMismatch` with
    `isTenantSwitchInProgress()`.
  - Bump `@iblai/iblai-js` → `1.19.0`; tests updated to assert wrapper delegation.
- This consolidates the fix for the multi-tab tenant "ping-pong" (a stale tab
  reverting the session) — now owned by the SDK via a shared TTL lock + BroadcastChannel.
- **Also included:** Android SSO deep-link fix — registers the `iblai-mentor://`
  scheme so the post-login redirect routes back into the app.