### PR TITLE
fix(ci): pin E2E coverage bot to claude-sonnet-4-6 (retired model 404)

### DIFF
--- a/.github/workflows/e2e-coverage-bot.yml
+++ b/.github/workflows/e2e-coverage-bot.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Claude E2E coverage analysis and review
         uses: anthropics/claude-code-action@beta
         with:
+          # Pin a current model — without this the action defaults to a retired
+          # snapshot (claude-sonnet-4-20250514) and every run 404s.
+          model: claude-sonnet-4-6
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.E2E_COVERAGE_BOT_TOKEN }}
           allowed_tools: 'Bash,Read,Write,Edit,Glob,Grep'


### PR DESCRIPTION
## Problem
The **E2E Coverage Bot** (`claude-code-action@beta`) had no `model:` input, so it used the action’\s default — the **retired** snapshot `claude-sonnet-4-20250514`. The API now 404s it:

```
API Error: 404 not_found_error: "model: claude-sonnet-4-20250514"
→ exit code 1
```

So every coverage-bot run fails. Both os and lms had the same gap.

## Fix
Pin a current model explicitly:

```yaml
uses: anthropics/claude-code-action@beta
with:
  model: claude-sonnet-4-6   # current Sonnet; exact string, no date suffix
  anthropic_api_key: ...
```

`claude-sonnet-4-6` is the drop-in for the retired Sonnet 4 and is cost-appropriate for a per-PR review bot. Pinning also prevents the default from floating to another retired model later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)