### PR TITLE
ci: add .dockerignore (keep docs/agent/VCS files out of the SPA build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Exclude files not needed to build the SPA from the Docker build context.
+# Why this matters:
+#  1) The builder does `COPY . .` and Next.js (`output: 'standalone'`) file-tracing
+#     walks the whole project AND follows symlinks. A dangling doc symlink
+#     (CLAUDE.md -> "AGENTS.md\n", a stray newline) crashed `next build` with
+#     `ENOENT stat /app/CLAUDE.md`. Keeping docs/agent files out of the context
+#     removes that entire class of foot-gun.
+#  2) Smaller, faster build context and image.
+# Verified: nothing in next.config or app source reads these. Do NOT add app
+# sources, public/, server-wrapper.js, entrypoint.sh, package.json,
+# pnpm-lock.yaml, or pnpm-workspace.yaml here — the build/runtime need them.
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Dependencies & build output (reinstalled / regenerated inside the image;
+# excluding node_modules also stops a local copy from clobbering the image's)
+node_modules
+.next
+
+# Agent instructions, docs, CI & editor metadata — not part of the app build
+CLAUDE.md
+AGENTS.md
+.claude
+.github
+docs
+*.md
+.vscode
+.cursor
+.idea
+.editorconfig
+
+# Logs
+*.log


### PR DESCRIPTION
## What
Adds a `.dockerignore` (neither repo had one) so the SPA Docker build excludes files it does not need.

## Why
The builder runs `COPY . .` and Next.js (`output: 'standalone'`) file-tracing walks the whole project **and follows symlinks**. A dangling doc symlink (`CLAUDE.md → "AGENTS.md\n"`, a stray newline — fixed separately) crashed `next build`:

```
[Error: ENOENT: no such file or directory, stat '/app/CLAUDE.md']
```

Keeping docs/agent/VCS files out of the build context removes that **whole class** of foot-gun (any future dangling doc symlink can no longer reach the build) and shrinks the context/image.

## Excluded (verified not needed by the build)
`CLAUDE.md`, `AGENTS.md`, `.claude/`, `.github/`, `docs/`, root `*.md`, editor dirs, `node_modules`, `.next`, `.git`. 

Verified nothing in `next.config` or app source reads these; the runner image only copies `.next` output + `public/` + `server-wrapper.js`/`entrypoint.sh`, none of which are excluded. Excluding `node_modules` is also protective — it stops a local `node_modules` from overwriting the freshly-installed one during `COPY . .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)