### PR TITLE
fix(ci): copy patches/ before pnpm install (pnpm patchedDependency ENOENT)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 # Copy package manifests first (for layer caching)
 COPY package.json .
 COPY pnpm-lock.yaml .
+# pnpm patchedDependencies reference files under patches/ that must exist at
+# install time (pnpm hashes them), so copy them before install.
+COPY patches ./patches
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -17,6 +17,9 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # Copy package manifests from repo root (deps live here, not in e2e/)
 COPY package.json pnpm-lock.yaml ./
+# pnpm patchedDependencies reference files under patches/ that must exist at
+# install time (pnpm hashes them), so copy them before install.
+COPY patches ./patches
 
 # Install dependencies (skip postinstall scripts)
 RUN pnpm install --frozen-lockfile --ignore-scripts --no-optional


### PR DESCRIPTION
## Root cause
The repo patches a dependency via pnpm:
```json
"patchedDependencies": { "google-drive-picker@1.1.29": "patches/google-drive-picker@1.1.29.patch" }
```
Both Dockerfiles copy only `package.json` + `pnpm-lock.yaml` before `pnpm install --frozen-lockfile`, so pnpm reads the patch reference from the lockfile and tries to open a file that isn't in the image yet:
```
ENOENT: no such file or directory, open '/app/patches/google-drive-picker@1.1.29.patch'
→ exit code 254
```
pnpm needs the patch file present **at install time** (it hashes it). This started failing once the patched dependency was added; the Dockerfiles were never updated to copy `patches/`.

## Fix
Copy `patches/` alongside the manifests, **before** `pnpm install`, in both `Dockerfile` (build-app-image) and `e2e/Dockerfile` (build-playwright-image). 2 files, +3 lines each.

## Notes
- **Not** related to the new `.dockerignore` — that doesn't exclude `patches/` (verified).
- **lms is unaffected** — it has no `patchedDependencies` / `patches/`.
- Layer caching preserved (patches change rarely, copied with the manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)