### PR TITLE
ci: push release image to iblai-os-spa ECR repo

### DIFF
--- a/.github/workflows/reusable-spa-docker-build.yml
+++ b/.github/workflows/reusable-spa-docker-build.yml
@@ -67,6 +67,9 @@ jobs:
             mentor)
               echo "image_name=iblai-mentor-spa-pro" >> $GITHUB_OUTPUT
               ;;
+            os)
+              echo "image_name=iblai-os-spa" >> $GITHUB_OUTPUT
+              ;;
             skills)
               echo "image_name=iblai-skills-spa-pro" >> $GITHUB_OUTPUT
               ;;
@@ -104,7 +107,7 @@ jobs:
           # whitespace or shell metachars are passed through intact.
           BUILD_ARGS=()
 
-          if [ "${{ inputs.app_name }}" = "mentor" ]; then
+          if [ "${{ inputs.app_name }}" = "mentor" ] || [ "${{ inputs.app_name }}" = "os" ]; then
             if [ -n "${{ inputs.next_image_patterns }}" ]; then
               BUILD_ARGS+=(--build-arg "NEXT_IMAGE_PATTERNS=${{ inputs.next_image_patterns }}")
             fi

--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*'
 
-run-name: 'Build mentor ${{ github.ref_name }}'
+run-name: 'Build os ${{ github.ref_name }}'
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/reusable-spa-docker-build.yml
     with:
-      app_name: mentor
+      app_name: os
       source_repo: ${{ github.repository }}
       source_ref: ${{ github.ref }}
       version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## What

Points the **release** build at the new `iblai-os-spa` ECR repo. New `v*` tags publish to `iblai-os-spa` **only**:

- `765174860755.dkr.ecr.us-east-1.amazonaws.com/iblai-os-spa:<version>`
- `765174860755.dkr.ecr.us-east-1.amazonaws.com/iblai-os-spa:latest`

## Backward compatibility

Existing `iblai-mentor-spa-pro` tags stay in ECR and remain pullable, so clients still referencing the old repo keep working on the images already published there. They simply won't receive new releases under the old name — new versions go to `iblai-os-spa`.

## Changes

- **`trigger-docker-build.yml`** — `app_name: mentor` → `os` (`run-name` → "Build os").
- **`reusable-spa-docker-build.yml`** — new `os)` case → `iblai-os-spa`; the mentor build-arg block now also covers `os`, so the image keeps its `NEXT_IMAGE_PATTERNS` / `SENTRY_AUTH_TOKEN` build args (os is the same Next.js bundle, just renamed).

## Notes

- The `iblai-os-spa` ECR repo already exists in account `765174860755` (us-east-1), so no missing-repo push failure.
- **Out of scope:** the OCIR PR/E2E test images in `pr-e2e-tests.yml` (`iblai-mentor-spa-pro` / `ibl-mentor-playwright`) are unchanged — different registry (OCIR), coupled to the stg1 `/ibl/app/ibl-spa/mentor` deploy path.
- Naming note: siblings use a `-pro` suffix; `iblai-os-spa` is used exactly as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
