### PR TITLE
ci: PR image build timeout + drop dead SENTRY_AUTH_TOKEN reference

### DIFF
--- a/.github/workflows/reusable-pr-docker-build.yml
+++ b/.github/workflows/reusable-pr-docker-build.yml
@@ -57,6 +57,10 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
+    # Fail fast instead of hanging: a stalled `docker build` or OCIR push should
+    # time out (~30m) rather than sit until GitHub's 6h default and block the gate.
+    # A timed-out job also leaves a downloadable log; an in-progress hung one does not.
+    timeout-minutes: 30
     env:
       OCIR_REGISTRY: iad.ocir.io
       OCIR_NAMESPACE: idcwyla5j5cr
@@ -148,16 +152,16 @@ jobs:
         env:
           IMAGE_URI: ${{ steps.build-ecr.outputs.image-uri || steps.build-ocir.outputs.image-uri }}
           IMAGE_TAG: ${{ steps.final-tag.outputs.tag }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           echo "Building Docker image: $IMAGE_URI"
           echo "Dockerfile: ${{ inputs.dockerfile-path }}"
           echo "Context: ${{ inputs.build-context }}"
 
+          # No SENTRY_AUTH_TOKEN: the secret isn't configured (org or repo), so
+          # the old reference was dead — `[ -n "$SENTRY_AUTH_TOKEN" ]` was always
+          # false and no sourcemap upload ever ran. Dropped it. No-op for the
+          # built app (the token only gates the upload side-effect, not the bundle).
           BUILD_ARGS="--build-arg APP_VERSION=$IMAGE_TAG"
-          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
-            BUILD_ARGS="$BUILD_ARGS --build-arg SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN"
-          fi
 
           docker build -f "${{ inputs.dockerfile-path }}" -t $IMAGE_URI --no-cache $BUILD_ARGS "${{ inputs.build-context }}"
           docker push $IMAGE_URI


### PR DESCRIPTION
## What

Two changes to `reusable-pr-docker-build.yml`, **neither of which changes what the app builds**:

1. **`timeout-minutes: 30`** on the `build` job — PR E2E image builds have repeatedly wedged for hours (normal ~8–9 min), blocking the required **PR Validation** gate until GitHub's 6-hour cap. A timeout makes a stall fail fast **and** leaves a downloadable log (an in-progress hung job's logs can't be retrieved — which is why we couldn't see where the current ones are stuck).

2. **Drop the dead `SENTRY_AUTH_TOKEN` reference** — the secret is **not configured** at org or repo level, so `[ -n "$SENTRY_AUTH_TOKEN" ]` was always false and no sourcemap upload ever ran. It was misleading dead config. Removing it is a **no-op**: the token only gates the sourcemap *upload*, never the bundle or instrumentation, so the built image is byte-identical.

## Honest note on root cause

I earlier suspected the Sentry sourcemap upload — that was **wrong**: with no token configured, CI never uploaded, so Sentry can't be it. The hang is in the app build **+ OCIR push** on the GitHub-hosted runner (the lighter playwright image pushes fine; the large app image is the leading suspect for a stalled push). `next build` itself is exonerated — it ran clean in 4.2 min reproducing on iblai.org, though that reproduction built only and **did not push**. This PR's `timeout-minutes` converts the next hang into a failed job whose log will show plainly whether it's stuck in `docker build` or `docker push`.

## Follow-up (not here)
The **release** path (`reusable-spa-docker-build.yml`) has the same 6h-hang exposure and deserves the same timeout — left out of this PR to avoid conflicting with the rename PR #304, which also edits that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
