### PR TITLE
fix(sentry): skip sourcemap generation when there's no auth token

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ import type { RemotePattern } from 'next/dist/shared/lib/image-config';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
+// Sourcemap generation is heavy (multi-GB) and only pays off if the maps are
+// actually uploaded to Sentry — which requires SENTRY_AUTH_TOKEN at build time.
+// With no token they were generated and thrown away, OOM-ing the 7GB CI runners
+// (the "stuck PR builds"). Gate the Sentry sourcemap pipeline on the token.
+const uploadSourcemaps = !!process.env.SENTRY_AUTH_TOKEN;
+
 const envPatterns = process.env.NEXT_IMAGE_PATTERNS?.trim();
 const rawPatterns = envPatterns
   ? envPatterns.split(',')
@@ -113,10 +119,13 @@ const sentryWebpackPluginOptions = {
   silent: false,
   org: 'ibl-ai',
   project: 'mentorai-iblai-app',
-  widenClientFileUpload: true,
+  widenClientFileUpload: uploadSourcemaps,
   // Upload source maps to Sentry (requires SENTRY_AUTH_TOKEN at build time),
   // then delete the emitted .map files so they are never served publicly.
+  // When there's no token, disable the whole pipeline so `next build` doesn't
+  // generate multi-GB maps only to discard them (the OOM/hang root cause).
   sourcemaps: {
+    disable: !uploadSourcemaps,
     deleteSourcemapsAfterUpload: true,
   },
   // Sentry SDK v10 moved these under `webpack`:


### PR DESCRIPTION
## Problem
PR E2E image builds OOM/hang on the 7 GB GitHub runners. `next build` generates full client sourcemaps that **peak at ~8.8 GB** and are then **thrown away** — there's no `SENTRY_AUTH_TOKEN`, so nothing is uploaded.

`700a37d3` set `productionBrowserSourceMaps: false`, but that alone wasn't enough: the **Sentry** plugin still generated client sourcemaps (`widenClientFileUpload: true`, `sourcemaps` not disabled). Verified — PRs #298/#303 re-run on that commit still wedged ~28 min on the runner.

## Fix
Gate the entire Sentry sourcemap pipeline on the token actually being present:
```ts
const uploadSourcemaps = !!process.env.SENTRY_AUTH_TOKEN;
...
widenClientFileUpload: uploadSourcemaps,
sourcemaps: { disable: !uploadSourcemaps, deleteSourcemapsAfterUpload: true },
```
- **No token (today):** no sourcemap work → light build.
- **Add the token later:** maps generate → upload → get deleted, exactly as intended.

**Verified on a 64 GB build host:** the same commit that hung 13+ min at 8.8 GB completed in **~200 s at ~6.5 GB peak** with sourcemaps gated off. Does **not** change the app bundle — sourcemaps are separate debug artifacts.

## Heads-up
Peak is still ~6.5 GB — fits under 7 GB but not by much once you subtract OS/docker overhead. If the bundle keeps growing this could creep back, so consider bumping the PR-build runner to a larger instance for headroom. And if you *do* want Sentry sourcemaps for release debugging, add the `SENTRY_AUTH_TOKEN` secret (there is none today, so **no** build uploads maps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
