### PR TITLE
fix(app): register open_external_url on desktop and route by URL pattern

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,9 @@ use tauri::{command, AppHandle, Emitter, Listener, Manager, Window};
 use tokio::sync::RwLock;
 
 use tauri::WebviewWindowBuilder;
+// OpenerExt is used to open external URLs in the system browser (non-iOS).
+#[cfg(not(target_os = "ios"))]
+use tauri_plugin_opener::OpenerExt;
 
 // OAuth provider URL patterns that should be opened in a separate auth window
 // Note: login.iblai.app loads in the main window - only OAuth providers need a separate window
@@ -2001,6 +2004,18 @@ async fn foundry_chat(
         .ok_or_else(|| "Failed to extract content from Foundry response".to_string())
 }
 
+/// Open an external URL in the system's default browser.
+/// Needed for flows (OAuth, Stripe checkout, external links) that must leave
+/// the WebView. The web frontend invokes this via `openExternalUrl`; without it
+/// registered the invoke fails and the URL wrongly loads inside the WebView.
+#[command]
+async fn open_external_url(app: AppHandle, url: String) -> Result<(), String> {
+    println!("[ibl.ai] Opening external URL: {}", url);
+    app.opener()
+        .open_url(&url, None::<&str>)
+        .map_err(|e| format!("Failed to open URL: {}", e))
+}
+
 fn main() {
     // Load .env file if present (for local development and custom builds)
     // First try current directory (dev mode), then try next to the executable (bundled app)
@@ -2645,6 +2660,7 @@ fn main() {
             get_offline_context,
             get_os_type,
             allow_in_app_purchase,
+            open_external_url,
             ollama_chat,
             ollama_chat_stream,
             oauth::oauth_start,


### PR DESCRIPTION
## Problem

On the **desktop** app, `openExternalUrl` failed with `Command open_external_url not found` and fell back to `window.location.href`, loading the URL **inside the main WebView**.

**Root cause:** the Tauri backend has two builders — `lib.rs` (mobile entry) registered `open_external_url`, but `main.rs` (`fn main()`, the **desktop** entry) did not, and didn't define it at all.

## Behavior

Define and register the command on desktop, and **route by URL pattern**:

- URLs matching `IN_APP_URL_PATTERNS` (currently **`stripe.com`**) open in an **in-app popup window** (reusing `open_oauth_in_popup`), matching the SSO login experience — these flows rely on the app session. Each entry carries its own popup **title** (Stripe → "Checkout", OAuth → "Sign In"); add more patterns/titles in that one list.
- **Everything else** opens in the **system browser** via the opener plugin.

**Return handling:** the popup's navigation handler now also detects a return to the app's own domain (`get_app_url()`, e.g. `os.ibl.ai/...`). When an in-app flow like Stripe checkout redirects back to the app, the popup **closes** and the **main window** navigates to that URL. The match is boundary-checked so lookalike hosts (`os.ibl.ai.evil.com`) don't trigger it.

Window creation for the popup is dispatched to the main thread (`run_on_main_thread`), since it's an explicit `invoke` and never hits the main window's `on_navigation` interceptor.

## Verification

- `cargo check` passes (the only warning — `unused import: tokio::sync::oneshot` — is pre-existing in `lib.rs`).

## Notes

- Requires a **desktop rebuild** to take effect (the fix is in the Rust binary).

