### PR TITLE
feat(app): route open_external_url to an in-app popup by URL pattern

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,7 +30,8 @@ use tauri::{command, AppHandle, Emitter, Listener, Manager, Window};
 use tokio::sync::RwLock;
 
 use tauri::WebviewWindowBuilder;
-// OpenerExt is used to open external URLs in the system browser (non-iOS).
+use tokio::sync::oneshot;
+// OpenerExt opens URLs in the system browser (non-iOS).
 #[cfg(not(target_os = "ios"))]
 use tauri_plugin_opener::OpenerExt;
 
@@ -56,9 +57,24 @@ fn is_oauth_url(url: &str) -> bool {
         .any(|pattern| url.contains(pattern))
 }
 
+// (URL substring, popup window title) for flows that, when passed to
+// `open_external_url`, should open in an in-app popup window instead of the
+// system browser. Add entries here for any flow that must stay inside the app
+// (e.g. Stripe checkout, which relies on the app session). Anything not matched
+// here opens in the system browser.
+const IN_APP_URL_PATTERNS: &[(&str, &str)] = &[("stripe.com", "Checkout")];
+
+/// Returns the popup title if `url` should open in an in-app window, else None.
+fn in_app_popup_title(url: &str) -> Option<&'static str> {
+    IN_APP_URL_PATTERNS
+        .iter()
+        .find(|(pattern, _)| url.contains(pattern))
+        .map(|(_, title)| *title)
+}
+
 /// Open OAuth URL in an in-app popup window
 /// The window monitors for callback URLs and closes automatically when auth completes
-fn open_oauth_in_popup(url: &str, app_handle: &AppHandle) -> Result<(), String> {
+fn open_oauth_in_popup(url: &str, app_handle: &AppHandle, title: &str) -> Result<(), String> {
     println!("[ibl.ai] Opening OAuth in popup window: {}", url);
 
     let app_handle_clone = app_handle.clone();
@@ -69,7 +85,7 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle) -> Result<(), String> 
         "oauth-popup",
         tauri::WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {}", e))?),
     )
-    .title("Sign In")
+    .title(title)
     .inner_size(500.0, 700.0)
     .center()
     .focused(true)
@@ -88,8 +104,24 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle) -> Result<(), String> 
         let is_custom_scheme =
             url_str.starts_with("iblai-mentor://") || url_str.starts_with("ai.ibl.mentorai://");
 
-        if is_callback || is_custom_scheme {
-            println!("[OAuth Popup] Auth callback detected: {}", url_str);
+        // Treat a return to the app's own domain (e.g. os.ibl.ai/...) as
+        // completion. In-app flows like Stripe checkout redirect back to the
+        // app when done, so hand off to the main window and close the popup.
+        // Boundary-checked so lookalike hosts (os.ibl.ai.evil.com) don't match.
+        let app_base = get_app_url();
+        let app_base = app_base.trim_end_matches('/');
+        let is_app_return = url_str
+            .strip_prefix(app_base)
+            .map(|rest| {
+                rest.is_empty()
+                    || rest.starts_with('/')
+                    || rest.starts_with('?')
+                    || rest.starts_with('#')
+            })
+            .unwrap_or(false);
+
+        if is_callback || is_custom_scheme || is_app_return {
+            println!("[OAuth Popup] Callback/return detected: {}", url_str);
 
             // Navigate the main window to the callback URL
             if let Some(main_win) = app_handle_clone.get_webview_window("main") {
@@ -2004,13 +2036,34 @@ async fn foundry_chat(
         .ok_or_else(|| "Failed to extract content from Foundry response".to_string())
 }
 
-/// Open an external URL in the system's default browser.
-/// Needed for flows (OAuth, Stripe checkout, external links) that must leave
-/// the WebView. The web frontend invokes this via `openExternalUrl`; without it
-/// registered the invoke fails and the URL wrongly loads inside the WebView.
+/// Open a URL requested by the web frontend's `openExternalUrl`.
+///
+/// URLs matching `IN_APP_URL_PATTERNS` (e.g. Stripe checkout) open in an in-app
+/// popup window — matching the SSO login experience — because those flows rely
+/// on the app session. Everything else opens in the system browser.
+///
+/// The in-app popup reuses `open_oauth_in_popup`, which monitors for auth
+/// callbacks and hands the result back to the main window. Because this is an
+/// explicit `invoke` (not a main-window navigation), it never hits the main
+/// window's `on_navigation` interceptor, so it opens the popup itself. Window
+/// creation must run on the main thread.
 #[command]
 async fn open_external_url(app: AppHandle, url: String) -> Result<(), String> {
-    println!("[ibl.ai] Opening external URL: {}", url);
+    if let Some(title) = in_app_popup_title(&url) {
+        println!("[ibl.ai] Opening URL in in-app window: {}", url);
+        let app_for_main = app.clone();
+        let title = title.to_string();
+        let (tx, rx) = oneshot::channel();
+        app.run_on_main_thread(move || {
+            let _ = tx.send(open_oauth_in_popup(&url, &app_for_main, &title));
+        })
+        .map_err(|e| format!("Failed to schedule in-app window: {}", e))?;
+        return rx
+            .await
+            .unwrap_or_else(|_| Err("Failed to open in-app window".to_string()));
+    }
+
+    println!("[ibl.ai] Opening URL in system browser: {}", url);
     app.opener()
         .open_url(&url, None::<&str>)
         .map_err(|e| format!("Failed to open URL: {}", e))
@@ -2365,7 +2418,7 @@ fn main() {
                     // Check if this is an OAuth URL - open in popup window
                     if is_oauth_url(url_str) {
                         println!("[ibl.ai] OAuth URL detected, opening in popup: {}", url_str);
-                        if let Err(e) = open_oauth_in_popup(url_str, &app_handle) {
+                        if let Err(e) = open_oauth_in_popup(url_str, &app_handle, "Sign In") {
                             println!("[ibl.ai] Failed to open OAuth popup: {}", e);
                             return true; // Allow navigation as last resort
                         }


### PR DESCRIPTION
## Summary

Follow-up to #311, which registered `open_external_url` on desktop but always opened the **system browser**. Some flows (e.g. **Stripe checkout**) rely on the app session and should stay **inside the app**, like SSO login.

## Behavior

Route by URL:

- URLs matching `IN_APP_URL_PATTERNS` (currently **`stripe.com`**) open in an **in-app popup window** (reusing `open_oauth_in_popup`). Each entry carries its own popup **title** (Stripe → "Checkout", OAuth → "Sign In"); add more patterns/titles in that one list.
- **Everything else** keeps opening in the **system browser**.

**Return handling:** the popup's navigation handler now detects a return to the app's own domain (`get_app_url()`, e.g. `os.ibl.ai/...`). When an in-app flow like Stripe checkout redirects back to the app, the popup **closes** and the **main window** is navigated to that URL. The match is boundary-checked so lookalike hosts (`os.ibl.ai.evil.com`) don't trigger it.

The handoff uses `WebviewWindow::navigate()` (a hard load) rather than assigning `window.location.href`, so the Next.js SPA router can't swallow the navigation and leave the main window on the page that opened the popup. The OAuth callback path keeps using `eval` (unchanged).

Popup window creation is dispatched to the main thread (`run_on_main_thread`), since it's an explicit `invoke` and never hits the main window's `on_navigation` interceptor.

## Verification

- `cargo check` passes (the only warning — `unused import: tokio::sync::oneshot` — is pre-existing in `lib.rs`).

## Notes

- Requires a **desktop rebuild** to take effect (the fix is in the Rust binary).

