### PR TITLE
fix(app): hard-navigate the main window on in-app popup return

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -136,7 +136,31 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle, title: &str) -> Result
                 };
 
                 println!("[OAuth Popup] Navigating main window to: {}", target_url);
-                let _ = main_win.eval(&format!("window.location.href = '{}';", target_url));
+                // For app-domain returns (e.g. Stripe checkout completing), force a
+                // hard navigation. Assigning `window.location.href` can be swallowed
+                // by the SPA router (which may restore the previous route), leaving
+                // the main window on the page that opened the popup. The OAuth
+                // callback path keeps using eval, which it already relies on.
+                let navigated = if is_app_return {
+                    match target_url.parse() {
+                        Ok(parsed) => match main_win.navigate(parsed) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                println!("[OAuth Popup] navigate() failed: {}", e);
+                                false
+                            }
+                        },
+                        Err(e) => {
+                            println!("[OAuth Popup] invalid return URL: {}", e);
+                            false
+                        }
+                    }
+                } else {
+                    false
+                };
+                if !navigated {
+                    let _ = main_win.eval(&format!("window.location.href = '{}';", target_url));
+                }
                 let _ = main_win.set_focus();
             }
 


### PR DESCRIPTION
## Summary

Follow-up to #312. When an in-app flow (e.g. **Stripe checkout**) redirected back to the app's own domain (`os.ibl.ai/...`), the popup closed correctly but the **main window stayed on the page that opened it** instead of following to the return URL.

## Cause

The handoff navigated the main window by assigning `window.location.href`. On the Next.js SPA already loaded on `os.ibl.ai`, that assignment gets **swallowed by the client-side router** (which can restore the previous route), so the navigation never takes effect.

## Fix

Use `WebviewWindow::navigate()` for the app-domain return path — a **hard page load** the SPA router can't intercept — falling back to the `eval` assignment if `navigate()` fails. The OAuth callback path is unchanged (still `eval`).

```rust
let navigated = if is_app_return {
    match target_url.parse() {
        Ok(parsed) => main_win.navigate(parsed).is_ok(), // hard load
        Err(_) => false,
    }
} else { false };
if !navigated {
    let _ = main_win.eval(&format!("window.location.href = '{}';", target_url)); // fallback
}
```

## Verification

- `cargo check` passes.
- Requires a **desktop rebuild** to take effect. The console line `[OAuth Popup] Navigating main window to: <X>` shows the target URL; if it still lands on the initiating page after this, that would indicate frontend route-restoration (separate fix).


