### PR TITLE
fix(app): foreground main window before navigating on popup return

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -123,17 +123,27 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle, title: &str) -> Result
         if is_callback || is_custom_scheme || is_app_return {
             println!("[OAuth Popup] Callback/return detected: {}", url_str);
 
-            // Navigate the main window to the callback URL
+            let target_url = if is_custom_scheme {
+                // Convert custom scheme to app URL
+                let path = url_str
+                    .replace("iblai-mentor://", "/")
+                    .replace("ai.ibl.mentorai://", "/");
+                format!("{}{}", get_app_url(), path)
+            } else {
+                url_str.to_string()
+            };
+
+            // Close the popup and foreground the main window BEFORE navigating.
+            // A backgrounded WebView (behind the popup) is heavily throttled on
+            // macOS, so navigating it first showed up as a long delay before the
+            // main window actually loaded the return URL.
+            if let Some(oauth_win) = app_handle_clone.get_webview_window("oauth-popup") {
+                println!("[OAuth Popup] Closing popup window");
+                let _ = oauth_win.close();
+            }
+
             if let Some(main_win) = app_handle_clone.get_webview_window("main") {
-                let target_url = if is_custom_scheme {
-                    // Convert custom scheme to app URL
-                    let path = url_str
-                        .replace("iblai-mentor://", "/")
-                        .replace("ai.ibl.mentorai://", "/");
-                    format!("{}{}", get_app_url(), path)
-                } else {
-                    url_str.to_string()
-                };
+                let _ = main_win.set_focus();
 
                 println!("[OAuth Popup] Navigating main window to: {}", target_url);
                 // For app-domain returns (e.g. Stripe checkout completing), force a
@@ -161,13 +171,6 @@ fn open_oauth_in_popup(url: &str, app_handle: &AppHandle, title: &str) -> Result
                 if !navigated {
                     let _ = main_win.eval(&format!("window.location.href = '{}';", target_url));
                 }
-                let _ = main_win.set_focus();
-            }
-
-            // Close the OAuth popup
-            if let Some(oauth_win) = app_handle_clone.get_webview_window("oauth-popup") {
-                println!("[OAuth Popup] Closing popup window");
-                let _ = oauth_win.close();
             }
 
             return false; // Don't navigate the popup


### PR DESCRIPTION
## Summary

Follow-up to #314. The `navigate()` handoff works, but after the in-app popup closed there was a **noticeable delay** before the main window loaded the return URL.

## Cause

The handler navigated the main window **while it was still behind the popup**. A backgrounded WebView is heavily throttled on macOS, so the navigation/load was deferred until the main window came to the foreground (after the popup closed).

## Fix

Reorder the handoff so the main window is already foreground when it navigates:

1. Compute the target URL.
2. **Close the popup.**
3. **Focus the main window.**
4. **Then** navigate it (`navigate()` for app-domain returns, `eval` fallback / OAuth path).

No behavior change beyond timing — the same URL is loaded, just without the background-throttle delay.

## Verification

- `cargo check` passes.
- Requires a **desktop rebuild** to take effect.

