### PR TITLE
Fix/2155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,41 @@
 
 ### Bug Fixes
 
-* **mentor:** stop retrieved-document sidebar items from being clickable ([2aa4688](https://github.com/iblai/os/commit/2aa4688ce0400a5f8e41d5df2a711747ac5a373a))
+- **mentor:** stop retrieved-document sidebar items from being clickable ([2aa4688](https://github.com/iblai/os/commit/2aa4688ce0400a5f8e41d5df2a711747ac5a373a))
 
 ### Styles
 
-* normalize pre-existing prettier drift ([69597a2](https://github.com/iblai/os/commit/69597a2821a3897634b9cefc70edf47cbd7f4eec))
+- normalize pre-existing prettier drift ([69597a2](https://github.com/iblai/os/commit/69597a2821a3897634b9cefc70edf47cbd7f4eec))
 
 ## [0.102.1](https://github.com/iblai/os/compare/v0.102.0...v0.102.1) (2026-07-23)
 
 ### Bug Fixes
 
-* **mentor:** decouple Shareable Link toggle from embed-form validation ([a3e389f](https://github.com/iblai/os/commit/a3e389f3dad3078151c601c967525d6524f94b1e)), closes [#2153](https://github.com/iblai/os/issues/2153)
+- **mentor:** decouple Shareable Link toggle from embed-form validation ([a3e389f](https://github.com/iblai/os/commit/a3e389f3dad3078151c601c967525d6524f94b1e)), closes [#2153](https://github.com/iblai/os/issues/2153)
 
 ### Tests
 
-* **e2e:** clean up mentors created by issue [#2153](https://github.com/iblai/os/issues/2153) shareable-link specs ([f024298](https://github.com/iblai/os/commit/f0242983792558d1c07143b784c3be01317a4ead))
+- **e2e:** clean up mentors created by issue [#2153](https://github.com/iblai/os/issues/2153) shareable-link specs ([f024298](https://github.com/iblai/os/commit/f0242983792558d1c07143b784c3be01317a4ead))
 
 ## [0.102.0](https://github.com/iblai/os/compare/v0.101.1...v0.102.0) (2026-07-23)
 
 ### Features
 
-* **security:** nonce-based CSP via Next.js middleware ([9cbefa1](https://github.com/iblai/os/commit/9cbefa1de35a4a723550db44c6c2fb3173dc2afa))
+- **security:** nonce-based CSP via Next.js middleware ([9cbefa1](https://github.com/iblai/os/commit/9cbefa1de35a4a723550db44c6c2fb3173dc2afa))
 
 ### Bug Fixes
 
-* **security:** only emit upgrade-insecure-requests when enforcing ([b6de0ca](https://github.com/iblai/os/commit/b6de0ca46ef51c9c93f27b7efd2a10e37917d688))
+- **security:** only emit upgrade-insecure-requests when enforcing ([b6de0ca](https://github.com/iblai/os/commit/b6de0ca46ef51c9c93f27b7efd2a10e37917d688))
 
 ## [0.101.1](https://github.com/iblai/os/compare/v0.101.0...v0.101.1) (2026-07-23)
 
 ### Bug Fixes
 
-* **security:** patch 3 high-severity transitive advisories ([9b9a509](https://github.com/iblai/os/commit/9b9a5091d0bd03148a4c13b78f65ba4bfd1e6bf0))
+- **security:** patch 3 high-severity transitive advisories ([9b9a509](https://github.com/iblai/os/commit/9b9a5091d0bd03148a4c13b78f65ba4bfd1e6bf0))
 
 ### Chores
 
-* **deps:** bump @iblai/iblai-js 1.25.3 → 1.26.7 ([3727180](https://github.com/iblai/os/commit/3727180b18ca25eb715a117f1a55e0082de9b8c0)), closes [#1935](https://github.com/iblai/os/issues/1935)
+- **deps:** bump @iblai/iblai-js 1.25.3 → 1.26.7 ([3727180](https://github.com/iblai/os/commit/3727180b18ca25eb715a117f1a55e0082de9b8c0)), closes [#1935](https://github.com/iblai/os/issues/1935)
 
 ## [0.101.0](https://github.com/iblai/os/compare/v0.100.1...v0.101.0) (2026-07-22)
 

--- a/components/__tests__/chat-input-form.test.tsx
+++ b/components/__tests__/chat-input-form.test.tsx
@@ -44,9 +44,33 @@ const mockUseMentorSettings = vi.hoisted(() => vi.fn());
 const mockUseModelFileUploadCapabilities = vi.hoisted(() => vi.fn());
 const mockCheckRbacPermission = vi.hoisted(() => vi.fn(() => true));
 
+// Shareable-link token present in the URL (`?token=...`). When set, the RBAC
+// chat gate must be bypassed. Controlled per-test and reset in beforeEach.
+let mockShareableToken: string | null = null;
+
 // Mock all dependencies
 vi.mock('react-responsive', () => ({
   useMediaQuery: vi.fn(() => mockIsTabletOrMobile),
+}));
+
+vi.mock('next/navigation', () => ({
+  // `useParams` previously resolved to null outside a route; keep mentorId
+  // undefined so downstream hooks (e.g. chat privacy) behave as before.
+  useParams: () => ({}),
+  useSearchParams: () =>
+    new URLSearchParams(
+      mockShareableToken ? `token=${mockShareableToken}` : '',
+    ),
+}));
+
+// The component reads chat-privacy state via web-containers' useChatPrivacy,
+// which internally selects from the SDK chat slice that this test's mock store
+// does not provide. Mock it (as sibling tests do) so the component renders.
+vi.mock('@iblai/iblai-js/web-containers', () => ({
+  useChatPrivacy: () => ({
+    effective: { mode: 'enabled', source: 'session', is_locked: false },
+    isEffectiveReady: true,
+  }),
 }));
 
 vi.mock('next/dynamic', () => ({
@@ -139,12 +163,13 @@ vi.mock('@/components/chat/submit-message-button', () => ({
     isPreviewMode,
     isUploading,
     allowAnonymousAccess,
+    disabled,
   }: any) => (
     <button
       data-testid="submit-button"
       data-allow-anon={allowAnonymousAccess ? 'true' : 'false'}
       type="submit"
-      disabled={isPreviewMode || isUploading}
+      disabled={disabled || isPreviewMode || isUploading}
     >
       Submit
     </button>
@@ -436,6 +461,7 @@ describe('ChatInputForm', () => {
     mockCheckRbacPermission.mockReturnValue(true);
     mockExecuteWithTrialCheck.mockImplementation((fn: () => void) => fn());
     mockMaxCharacterSize = '2000';
+    mockShareableToken = null;
   });
 
   const renderWithRedux = (
@@ -1632,6 +1658,110 @@ describe('ChatInputForm', () => {
 
       // uploadFiles should NOT be called
       expect(mockUploadFiles).not.toHaveBeenCalled();
+    });
+
+    it('should bypass the RBAC gate when a shareable-link token is present', () => {
+      mockMentorSettings = {
+        data: {
+          mentorVisibility: 'PRIVATE',
+          disclaimer: null,
+          mentorDbId: 42,
+        },
+      } as any;
+      // RBAC would otherwise deny chat...
+      mockCheckRbacPermission.mockReturnValue(false);
+      // ...but the user arrived via a shareable link (?token=...).
+      mockShareableToken = 'share-abc123';
+
+      renderWithRedux(<ChatInputForm {...defaultProps} />, {
+        rbac: { rbacPermissions: { '/mentors/42/': {} } },
+      });
+
+      const textarea = screen.getByTestId('auto-resize-textarea');
+      // Chat input is enabled and does NOT show the RBAC denial placeholder.
+      // defaultProps.sessionId is truthy ('session-123'), i.e. the backend
+      // accepted the token and created a session — the bypass condition.
+      expect(textarea).not.toBeDisabled();
+      expect(textarea).not.toHaveAttribute(
+        'placeholder',
+        "Sorry about that! You don't have permission to chat.",
+      );
+      // Submit button remains enabled (only disabled by preview/uploading).
+      expect(screen.getByTestId('submit-button')).not.toBeDisabled();
+    });
+
+    it('should keep chat gated (and hide the RBAC denial) when a token is present but no session has been created yet', () => {
+      mockMentorSettings = {
+        data: {
+          mentorVisibility: 'PRIVATE',
+          disclaimer: null,
+          mentorDbId: 42,
+        },
+      } as any;
+      // RBAC denies, and although a token is present the backend has not yet
+      // returned a sessionId (invalid/expired token, or pre-create window).
+      mockCheckRbacPermission.mockReturnValue(false);
+      mockShareableToken = 'share-abc123';
+
+      renderWithRedux(<ChatInputForm {...defaultProps} sessionId="" />, {
+        rbac: { rbacPermissions: { '/mentors/42/': {} } },
+      });
+
+      const textarea = screen.getByTestId('auto-resize-textarea');
+      // Without a created session the token cannot open the input...
+      expect(textarea).toBeDisabled();
+      expect(screen.getByTestId('submit-button')).toBeDisabled();
+      // ...but a share-link visitor must never see the RBAC denial message,
+      // so the placeholder is the normal one, not the denial text.
+      expect(textarea).not.toHaveAttribute(
+        'placeholder',
+        "Sorry about that! You don't have permission to chat.",
+      );
+    });
+
+    it('should allow submission when a shareable-link token bypasses RBAC', () => {
+      mockMentorSettings = {
+        data: {
+          mentorVisibility: 'PRIVATE',
+          disclaimer: null,
+          mentorDbId: 42,
+        },
+      } as any;
+      mockCheckRbacPermission.mockReturnValue(false);
+      mockShareableToken = 'share-abc123';
+
+      renderWithRedux(<ChatInputForm {...defaultProps} />, {
+        chatInput: { textareaInput: 'Hello via shareable link!' },
+        rbac: { rbacPermissions: { '/mentors/42/': {} } },
+      });
+
+      const form = screen.getByTestId('auto-resize-textarea').closest('form');
+      fireEvent.submit(form!);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith('Hello via shareable link!');
+    });
+
+    it('should keep chat enabled when a token is present and RBAC also grants permission', () => {
+      mockMentorSettings = {
+        data: {
+          mentorVisibility: 'PRIVATE',
+          disclaimer: null,
+          mentorDbId: 42,
+        },
+      } as any;
+      mockCheckRbacPermission.mockReturnValue(true);
+      mockShareableToken = 'share-abc123';
+
+      renderWithRedux(<ChatInputForm {...defaultProps} />, {
+        rbac: { rbacPermissions: { '/mentors/42/': {} } },
+      });
+
+      const textarea = screen.getByTestId('auto-resize-textarea');
+      expect(textarea).not.toBeDisabled();
+      expect(textarea).not.toHaveAttribute(
+        'placeholder',
+        "Sorry about that! You don't have permission to chat.",
+      );
     });
   });
 

--- a/components/chat-input-form.tsx
+++ b/components/chat-input-form.tsx
@@ -3,7 +3,7 @@
 import type React from 'react';
 
 import { useState, useRef, ChangeEvent } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { format } from 'date-fns';
 import { useMediaQuery } from 'react-responsive';
 import { FileText } from 'lucide-react';
@@ -152,6 +152,8 @@ export function ChatInputForm({
   const persistentChatInputLabel =
     tenantMetadata?.persistent_chat_input_label === true;
 
+  const hasShareableToken = !!useSearchParams().get('token');
+
   // Check if user has chat permission via RBAC
   const mentorDbId = mentorSettings?.data?.mentorDbId;
   const mentorRbacKey = mentorDbId ? `/mentors/${mentorDbId}/` : null;
@@ -159,10 +161,12 @@ export function ChatInputForm({
     ? mentorRbacKey in rbacPermissions
     : false;
   const hasChatPermission =
-    mentorDbId && hasMentorRbacData
+    (hasShareableToken && !!sessionId) ||
+    (mentorDbId && hasMentorRbacData
       ? checkRbacPermission(rbacPermissions, `/mentors/${mentorDbId}/#chat`)
-      : true; // Default to true if mentor ID not available or RBAC data not loaded
+      : true); // Default to true if mentor ID not available or RBAC data not loaded
   const isChatDisabledByRbac = !hasChatPermission;
+  const isSendDisabled = isChatDisabledByRbac || !sessionId;
 
   const {
     FreeTrialDialog,
@@ -238,7 +242,7 @@ export function ChatInputForm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // Prevent submission when chat is disabled, files are uploading, or session not ready
-    if (isChatDisabledByRbac || hasUploadingFiles || !sessionId) return;
+    if (isSendDisabled || hasUploadingFiles) return;
     onSubmit(inputValue);
     setInputValue('');
     setFileAddedNotification(null);
@@ -422,7 +426,7 @@ export function ChatInputForm({
               isPreviewMode={isPreviewMode}
               textAreaRows={textAreaRows}
               placeholder={
-                isChatDisabledByRbac
+                isChatDisabledByRbac && !hasShareableToken
                   ? "Sorry about that! You don't have permission to chat."
                   : textAreaPlaceholder()
               }
@@ -444,7 +448,7 @@ export function ChatInputForm({
                   onCameraTrigger={() =>
                     executeWithTrialCheck(handleCameraClick)
                   }
-                  disabled={isChatDisabledByRbac || !sessionId}
+                  disabled={isSendDisabled}
                 />
               )}
 
@@ -505,7 +509,7 @@ export function ChatInputForm({
                     isPreviewMode={isPreviewMode}
                     allowAnonymousAccess={isMentorViewableByAnyone}
                     isUploading={hasUploadingFiles}
-                    disabled={isChatDisabledByRbac || !sessionId}
+                    disabled={isSendDisabled}
                     isConnecting={isConnecting}
                   />
                 )}
@@ -524,7 +528,7 @@ export function ChatInputForm({
                 : MENTOR_CHAT_DOCUMENTS_EXTENSIONS.join(',')
             }
             multiple
-            disabled={isChatDisabledByRbac || !sessionId}
+            disabled={isSendDisabled}
           />
 
           <input
@@ -534,7 +538,7 @@ export function ChatInputForm({
             onChange={handleFileInputChange}
             accept="image/*"
             capture="environment"
-            disabled={isChatDisabledByRbac || !sessionId}
+            disabled={isSendDisabled}
           />
         </div>
 

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-07-21 | 566 checkpoints (539 covered, 7 pending/fixme, 8 not-reproducible in default env, 12 deprecated) | 64 journeys (63 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-07-23 | 586 checkpoints (559 covered, 7 pending/fixme, 8 not-reproducible in default env, 12 deprecated) | 66 journeys (65 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -1175,3 +1175,31 @@ Covers the `ChatSearchDialog` (issue #2053) opened from the sidebar's "Search ch
 - [x] csd-06: Collapsing the sidebar and clicking the "Search chats" rail icon opens the same dialog
 
 ---
+
+## Journey 64: Shareable Link RBAC Bypass (3 checkpoints) — `journeys/64-shareable-link-rbac-bypass.spec.ts`
+
+**Source files:** `components/chat-input-form.tsx`
+
+Issue #2155 — a shareable-link `?token=` must bypass the RBAC `#chat` gate once the
+backend has accepted it and returned a session (`hasChatPermission =
+(hasShareableToken && !!sessionId) || <rbac check>`), without regressing the
+no-token denial or letting token _presence alone_ grant free access. Each test
+provisions its own Administrators-only / Authenticated-Users-chat mentor live
+against the running backend (Journey 14's isolation pattern), configured through
+the Embed tab's real "Who Can View? / Who Can Chat?" selects and a real "Generate
+Shareable Link" token — no `page.route` mocking. All three checkpoints were run
+and verified passing against a live `pnpm build && pnpm start` server.
+
+There is deliberately no anonymous-visitor checkpoint: `@iblai/web-utils`'s
+`MentorProvider` only loads the `rbacPermissions` Redux data (what
+`chat-input-form.tsx` reads) when the visitor `isLoggedIn`. For a never-
+authenticated visitor `rbacPermissions` is always `{}`, so the RBAC gate this fix
+touches structurally never applies — verified empirically: an anonymous visitor on
+an Administrators-only mentor got full enabled chat access with **no token at
+all**. An anonymous "token bypass" case would pass identically pre-fix and prove
+nothing about #2155; Journey 14 already covers the anonymous/public-access happy
+path.
+
+- [x] shl-01: Non-admin user denied RBAC #chat permission opens the mentor chat with a VALID shareable-link token — the textarea is enabled (no RBAC denial placeholder), and the user can send a message and receive a response
+- [x] shl-02: Safety-boundary guard — the same non-admin user opens the same mentor chat with an INVALID/never-issued shareable-link token — the backend never creates a session, so the textarea stays disabled exactly as with no token (token presence alone must not unlock chat)
+- [x] shl-03: Regression guard — the same non-admin user opens the same mentor chat with NO token — the textarea stays disabled and the RBAC denial placeholder ("Sorry about that! You don't have permission to chat.") is shown

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "lastUpdated": "2026-07-21",
+  "lastUpdated": "2026-07-23",
   "summary": {
-    "totalCheckpoints": 566,
-    "coveredCheckpoints": 539,
+    "totalCheckpoints": 586,
+    "coveredCheckpoints": 559,
     "deprecatedCheckpoints": 12,
     "notReproducibleCheckpoints": 8,
     "pendingCheckpoints": 7,
     "percent": 100,
-    "totalJourneys": 64,
-    "activeJourneys": 63
+    "totalJourneys": 66,
+    "activeJourneys": 65
   },
   "journeys": [
     {
@@ -3726,6 +3726,29 @@
         {
           "id": "csd-06",
           "description": "Collapsing the sidebar and clicking the Search chats rail icon opens the same dialog",
+          "status": "covered"
+        }
+      ]
+    },
+    {
+      "id": "shareable-link-rbac-bypass",
+      "name": "Shareable Link RBAC Bypass",
+      "spec": "64-shareable-link-rbac-bypass.spec.ts",
+      "sourceFiles": ["components/chat-input-form.tsx"],
+      "checkpoints": [
+        {
+          "id": "shl-01",
+          "description": "Non-admin user denied RBAC #chat permission on an Administrators-only, Authenticated-Users-chat mentor opens the chat with a VALID shareable-link token — the textarea is enabled (no RBAC denial placeholder), and the user can send a message and receive a response (issue #2155)",
+          "status": "covered"
+        },
+        {
+          "id": "shl-02",
+          "description": "Safety-boundary guard: the same non-admin user opens the same mentor chat with an INVALID/never-issued shareable-link token — the backend never creates a session, so the textarea stays disabled exactly as with no token at all (token presence alone must not unlock chat)",
+          "status": "covered"
+        },
+        {
+          "id": "shl-03",
+          "description": "Regression guard: the same non-admin user opens the same mentor chat with NO token — the textarea stays disabled and the RBAC denial placeholder (\"Sorry about that! You don't have permission to chat.\") is shown",
           "status": "covered"
         }
       ]

--- a/e2e/journeys/64-shareable-link-rbac-bypass.spec.ts
+++ b/e2e/journeys/64-shareable-link-rbac-bypass.spec.ts
@@ -1,0 +1,374 @@
+import { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/mentor-test';
+import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import { parsePlatformUrl, safeWaitForURL } from '../utils/navigation';
+import { waitForPageReady } from '../utils/resilient';
+import { MENTOR_NEXTJS_HOST } from '../fixtures/test-data';
+import { CreateMentorPage } from '../page-objects/create-mentor.page';
+import { EditMentorPage } from '../page-objects/edit-mentor/edit-mentor.page';
+import { MentorTracker } from '../utils/mentor-cleanup';
+import { logger } from '@iblai/iblai-js/playwright';
+
+/**
+ * Journey 64: Shareable Link RBAC Bypass (issue #2155)
+ *
+ * `components/chat-input-form.tsx` disables the chat send controls while
+ * `isChatDisabledByRbac || !sessionId`, and additionally disables the
+ * textarea itself while `isChatDisabledByRbac`. A shareable-link `?token=`
+ * only clears `isChatDisabledByRbac` once the backend has ACCEPTED the token
+ * and a chat `sessionId` has actually been created
+ * (`hasChatPermission = (hasShareableToken && !!sessionId) || <rbac check>`)
+ * — the token query param's mere *presence* is not enough. That's the load-
+ * bearing design point this journey proves: the backend stays the authority,
+ * the frontend never trusts the token by itself.
+ *
+ * This journey proves that end-to-end against a LIVE backend using real
+ * access restrictions configured through the Embed tab's "Who Can View?" /
+ * "Who Can Chat?" selects (no `page.route` mocking of RBAC — see the note
+ * below on why an anonymous-visitor scenario can't be built this way). Each
+ * test provisions its OWN fresh mentor rather than sharing one fixture
+ * mentor across cases, so a failure or leftover state in one case can never
+ * bleed into another.
+ *
+ * Cleanup: every provisioned mentor id is registered with `MentorTracker`
+ * (`e2e/utils/mentor-cleanup.ts`) and batch-deleted via its fast API-based
+ * `deleteAll()` in a single `afterAll` — the same pattern journeys 22, 42,
+ * 44, 47 and 52 use, and strictly better than a per-test UI delete (no
+ * Edit-Agent-modal navigation/flakiness, one DELETE request per mentor).
+ * Mentor names are prefixed "E2E " with a trailing 13-digit timestamp so
+ * `mentor-sweeper.ts`'s `globalTeardown` can also reap them as a backstop if
+ * a run crashes before `afterAll` runs.
+ *
+ * Why no anonymous-visitor case: `@iblai/web-utils`'s `MentorProvider` only
+ * calls `loadMentorsPermissions` (the mutation that populates the
+ * `rbacPermissions` Redux slice `chat-input-form.tsx` reads) when
+ * `isLoggedIn` is true. For a never-authenticated visitor, `rbacPermissions`
+ * is always `{}`, so `hasMentorRbacData` is always `false` and
+ * `hasChatPermission` always defaults to `true` — the RBAC gate this fix
+ * touches structurally never applies to anonymous users, with or without a
+ * token, with or without this fix. This was verified empirically against the
+ * live server: an anonymous visitor on a "Who Can View: Administrators, Who
+ * Can Chat: Anyone" mentor gets a fully enabled chat textarea with NO token
+ * at all. An anonymous-visitor "token bypass" test would therefore pass
+ * identically on unpatched `main` and prove nothing about issue #2155 —
+ * Journey 14 already covers the anonymous/public-access happy path.
+ *
+ * This file must run single-worker/serial: every test provisions and tears
+ * down a mentor through the same admin session, and concurrent provisioning
+ * against the shared backend has been a source of flakiness in other
+ * mentor-lifecycle journeys (see Journey 14).
+ */
+
+const RBAC_DENIAL_PLACEHOLDER =
+  "Sorry about that! You don't have permission to chat.";
+
+interface ProvisionedMentor {
+  mentorId: string;
+  platformKey: string;
+  shareableToken: string;
+}
+
+function mentorUrl(platformKey: string, mentorId: string): string {
+  return `${MENTOR_NEXTJS_HOST}/platform/${platformKey}/${mentorId}`;
+}
+
+/**
+ * Creates a fresh mentor via the admin `page`, locks down its "Who Can
+ * View?" / "Who Can Chat?" Embed settings, mints a shareable link, and
+ * VERIFIES all three actually persisted (by re-opening a clean Embed tab
+ * view and re-reading the selects/toggle) before handing control back to
+ * the test. This guards against silently proceeding to the RBAC assertions
+ * on a mentor whose settings never actually saved.
+ */
+async function provisionMentor(
+  page: Page,
+  createMentorPage: CreateMentorPage,
+  editMentorPage: EditMentorPage,
+  tracker: MentorTracker,
+  opts: { namePrefix: string; whoCanView: string; whoCanChat: string },
+): Promise<ProvisionedMentor> {
+  // "E2E " prefix + trailing 13-digit timestamp matches `E2E_MENTOR_RE` in
+  // `mentor-sweeper.ts`, so a crashed run still gets swept as a backstop.
+  const mentorName = await createMentorPage.openAndCreate(
+    `E2E ${opts.namePrefix} ${Date.now()}`,
+  );
+  logger.info(`Journey 64: created mentor "${mentorName}"`);
+
+  const { platformKey, mentorId } = parsePlatformUrl(page.url());
+  expect(
+    mentorId,
+    'mentor creation must produce a mentorId in the URL',
+  ).toBeTruthy();
+  expect(
+    platformKey,
+    'mentor creation must produce a platformKey in the URL',
+  ).toBeTruthy();
+
+  // Register immediately so the mentor is cleaned up in afterAll even if a
+  // later assertion in this test throws.
+  tracker.add(mentorId);
+
+  await editMentorPage.open('Embed');
+  await waitForPageReady(page);
+
+  await editMentorPage.embed.setWhoCanView(opts.whoCanView);
+  await editMentorPage.embed.setWhoCanChat(opts.whoCanChat);
+  if (opts.whoCanChat === 'Authenticated Users') {
+    // "Who Can Chat? = Authenticated Users" reveals the Website URL field
+    // (allow_anonymous=false) — syncEmbedSettings() requires a valid URL to
+    // persist mentor_visibility/allow_anonymous at all; without it "Create
+    // Embed" silently no-ops on the visibility/chat fields. "Anyone" does
+    // not render this field.
+    await editMentorPage.embed.fillWebsiteUrl('https://example.com');
+  }
+  await editMentorPage.embed.submit();
+
+  await editMentorPage.embed.enableShareableLink();
+  const shareableToken = await editMentorPage.embed.getShareableLinkToken();
+  expect(
+    shareableToken.length,
+    'a shareable link token must be minted',
+  ).toBeGreaterThan(0);
+  await editMentorPage.close();
+
+  // Verify the mentor is actually working as configured: re-open a clean
+  // Embed tab view (not the one we just submitted from) and confirm the
+  // Who Can View / Who Can Chat selections and the shareable link toggle
+  // all reflect what we just set, i.e. they really persisted server-side.
+  await editMentorPage.open('Embed');
+  await waitForPageReady(page);
+  await expect(editMentorPage.embed.whoCanViewSelect).toContainText(
+    new RegExp(opts.whoCanView, 'i'),
+    { timeout: 15_000 },
+  );
+  await expect(editMentorPage.embed.whoCanChatSelect).toContainText(
+    new RegExp(opts.whoCanChat, 'i'),
+    { timeout: 15_000 },
+  );
+  await expect(editMentorPage.embed.shareableLinkToggle).toHaveAttribute(
+    'aria-checked',
+    'true',
+    { timeout: 15_000 },
+  );
+  await editMentorPage.close();
+
+  logger.info(
+    `Journey 64: mentor ${mentorId} verified — view="${opts.whoCanView}" ` +
+      `chat="${opts.whoCanChat}" token length ${shareableToken.length}`,
+  );
+
+  return { mentorId, platformKey, shareableToken };
+}
+
+/**
+ * Navigates `nonadminPage` to a freshly-provisioned mentor's chat URL and
+ * waits generously for the URL to settle on the intended mentor, returning
+ * `false` only if it never does.
+ *
+ * Empirically (via direct network tracing), a mentor that is only seconds
+ * old can trip a transient backend race in the SDK's `MentorProvider` — it
+ * can briefly bounce through /error/403 or the Explore page before landing
+ * on the intended mentor. This is the exact class of flakiness Journey 59
+ * documents for a reload ("Reload can transiently bounce through
+ * /error/403 → / → back to the platform URL — wait generously on the
+ * [target] rather than asserting the URL immediately") and Journey 32
+ * handles with `safeWaitForURL` + a URL predicate rather than a fixed
+ * sleep. We follow the same pattern here: `safeWaitForURL` polls
+ * (web-first, no blind `waitForTimeout`) until the URL settles on the
+ * expected mentor or the generous timeout elapses. A flow that never
+ * settles is a genuine failure, not something to paper over — callers must
+ * hard-assert the returned boolean (see shl-01/02/03) rather than treat
+ * `false` as an alternate pass condition.
+ */
+async function gotoMentorAsNonAdmin(
+  nonadminPage: Page,
+  url: string,
+  expectedMentorId: string,
+): Promise<boolean> {
+  await nonadminPage.goto(url, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+
+  try {
+    await safeWaitForURL(
+      nonadminPage,
+      (u) => u.href.includes(expectedMentorId),
+      { timeout: 60_000 },
+    );
+  } catch {
+    logger.info(
+      `Journey 64: non-admin never settled on mentor ${expectedMentorId} ` +
+        `— stuck at ${nonadminPage.url()}`,
+    );
+    return false;
+  }
+
+  await waitForPageReady(nonadminPage);
+  // Defensive re-check: safeWaitForURL resolves on the FIRST match, so
+  // guard against a later bounce away from the mentor in the brief window
+  // before waitForPageReady settles.
+  return nonadminPage.url().includes(expectedMentorId);
+}
+
+// Every test in this file provisions its own mentor through the same admin
+// session against a shared live backend — force single-worker, in-order
+// execution so provisioning never overlaps across cases.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Journey 64: Shareable Link RBAC Bypass', () => {
+  const tracker = new MentorTracker();
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(240_000);
+    await navigateToMentorApp(page);
+    const isAdmin = await checkAdminStatus(page);
+    test.skip(
+      !isAdmin,
+      'Requires admin access to provision the shareable-link fixture mentors',
+    );
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker.deleteAll(browser, testInfo);
+  });
+
+  // shl-01: a logged-in non-admin, who is denied RBAC #chat permission on
+  // this Administrators-only / Authenticated-Users-chat mentor, bypasses
+  // that denial with a valid shareable-link token and can chat.
+  test('non-admin user opens the admin-only mentor chat with a valid shareable-link token and can chat', async ({
+    page,
+    createMentorPage,
+    editMentorPage,
+    nonadminPage,
+    nonadminChatPage,
+  }) => {
+    const mentor = await provisionMentor(
+      page,
+      createMentorPage,
+      editMentorPage,
+      tracker,
+      {
+        namePrefix: 'RBAC Bypass (valid token)',
+        whoCanView: 'Administrators',
+        whoCanChat: 'Authenticated Users',
+      },
+    );
+
+    const landed = await gotoMentorAsNonAdmin(
+      nonadminPage,
+      `${mentorUrl(mentor.platformKey, mentor.mentorId)}?token=${mentor.shareableToken}`,
+      mentor.mentorId,
+    );
+    expect(
+      landed,
+      `non-admin never landed on mentor ${mentor.mentorId} — stuck at ${nonadminPage.url()}`,
+    ).toBe(true);
+
+    const chatInput = nonadminChatPage.chatInput;
+    await expect(chatInput).toBeVisible({ timeout: 45_000 });
+    await expect(chatInput).toBeEnabled({ timeout: 30_000 });
+    const placeholder = await chatInput.getAttribute('placeholder');
+    expect(placeholder).not.toBe(RBAC_DENIAL_PLACEHOLDER);
+
+    await nonadminChatPage.sendMessage(
+      'Hello from the shareable-link RBAC bypass test (valid token)',
+    );
+    await nonadminChatPage.waitForAIResponse(120_000);
+  });
+
+  // shl-02: safety-boundary guard — token *presence* alone must not unlock
+  // chat. A non-admin visits with a syntactically-plausible but never-issued
+  // token. The backend never accepts it, so no sessionId is ever created;
+  // `hasChatPermission`'s `hasShareableToken && !!sessionId` clause stays
+  // false and the RBAC denial (`checkRbacPermission`) still applies — the
+  // chat textarea must stay disabled exactly as it does with no token at
+  // all. (The RBAC *placeholder text* is suppressed whenever a `token` param
+  // is present at all, valid or not — `isChatDisabledByRbac &&
+  // !hasShareableToken` — so this case is distinguished from shl-03 only by
+  // the disabled textarea, not by the placeholder copy.)
+  test('non-admin user opens the admin-only mentor chat with an invalid shareable-link token and still cannot chat', async ({
+    page,
+    createMentorPage,
+    editMentorPage,
+    nonadminPage,
+    nonadminChatPage,
+  }) => {
+    const mentor = await provisionMentor(
+      page,
+      createMentorPage,
+      editMentorPage,
+      tracker,
+      {
+        namePrefix: 'RBAC Bypass (invalid token)',
+        whoCanView: 'Administrators',
+        whoCanChat: 'Authenticated Users',
+      },
+    );
+
+    const landed = await gotoMentorAsNonAdmin(
+      nonadminPage,
+      `${mentorUrl(mentor.platformKey, mentor.mentorId)}?token=invalid-garbage-token-does-not-exist-12345`,
+      mentor.mentorId,
+    );
+    expect(
+      landed,
+      `non-admin never landed on mentor ${mentor.mentorId} — stuck at ${nonadminPage.url()}`,
+    ).toBe(true);
+
+    const chatInput = nonadminChatPage.chatInput;
+    await expect(chatInput).toBeVisible({ timeout: 45_000 });
+    logger.info(
+      'shl-02: chat textarea rendered with an invalid token — asserting it stays disabled.',
+    );
+    await expect(chatInput).toBeDisabled({ timeout: 15_000 });
+  });
+
+  // shl-03: regression guard — a non-admin user, no token at all. The one
+  // deterministic outcome for this combination (Administrators-only view,
+  // Authenticated-Users chat, no token) is that the chat surface renders
+  // but stays disabled with the RBAC denial placeholder — see
+  // chat-input-form.tsx's `isChatDisabledByRbac && !hasShareableToken`
+  // branch. There is no separate "access-denied page" for a logged-in
+  // non-admin here (view-restriction does not gate page-level access in
+  // this app; only the chat capability is RBAC-gated) — so unlike an
+  // earlier draft of this test, we do NOT treat "landed somewhere else" or
+  // "chat never rendered" as alternate pass conditions. A flow that never
+  // reaches that one real, disabled state is a genuine test failure, full
+  // stop — no early `return` before the deterministic assertions below.
+  test('non-admin user opens the admin-only mentor with no token and cannot chat', async ({
+    page,
+    createMentorPage,
+    editMentorPage,
+    nonadminPage,
+    nonadminChatPage,
+  }) => {
+    const mentor = await provisionMentor(
+      page,
+      createMentorPage,
+      editMentorPage,
+      tracker,
+      {
+        namePrefix: 'RBAC Bypass (no token)',
+        whoCanView: 'Administrators',
+        whoCanChat: 'Authenticated Users',
+      },
+    );
+
+    const landed = await gotoMentorAsNonAdmin(
+      nonadminPage,
+      mentorUrl(mentor.platformKey, mentor.mentorId),
+      mentor.mentorId,
+    );
+    expect(
+      landed,
+      `non-admin never landed on mentor ${mentor.mentorId} — stuck at ${nonadminPage.url()}`,
+    ).toBe(true);
+
+    const chatInput = nonadminChatPage.chatInput;
+    await expect(chatInput).toBeVisible({ timeout: 60_000 });
+    await expect(chatInput).toBeDisabled({ timeout: 15_000 });
+    const placeholder = await chatInput.getAttribute('placeholder');
+    expect(placeholder).toBe(RBAC_DENIAL_PLACEHOLDER);
+  });
+});

--- a/e2e/page-objects/edit-mentor/embed.tab.ts
+++ b/e2e/page-objects/edit-mentor/embed.tab.ts
@@ -17,6 +17,9 @@ export class EmbedTab {
   readonly regenerateShareableLinkButton: Locator;
   readonly submitButton: Locator;
   readonly embedCodeDialog: Locator;
+  readonly shareableLinkUrlBlock: Locator;
+  readonly whoCanViewSelect: Locator;
+  readonly whoCanChatSelect: Locator;
 
   constructor(page: Page, dialog: Locator) {
     this.page = page;
@@ -70,6 +73,23 @@ export class EmbedTab {
     // The regenerate control is an icon-only RefreshCw with no accessible
     // name; fall back to its lucide CSS class.
     this.regenerateShareableLinkButton = dialog.locator('.lucide-refresh-cw');
+    // The generated URL (`{origin}/platform/{tenantKey}/{mentorId}?token=...`)
+    // renders in a CopyCodeBlock <pre>. The tab has other <pre> blocks (main
+    // embed snippet, SSO redirect token), so filter on the querystring shape
+    // rather than relying on DOM order.
+    this.shareableLinkUrlBlock = dialog.locator('pre').filter({
+      hasText: '?token=',
+    });
+    // "Who Can View?" — bound to `mentor_visibility` (tabsEmbedTab.
+    // selectWhoCanViewAriaLabel = "Select who can view").
+    this.whoCanViewSelect = dialog.getByRole('combobox', {
+      name: /select who can view/i,
+    });
+    // "Who Can Chat?" — bound to `allow_anonymous` (tabsEmbedTab.
+    // selectWhoCanChatAriaLabel = "Select who can chat").
+    this.whoCanChatSelect = dialog.getByRole('combobox', {
+      name: /select who can chat/i,
+    });
   }
 
   /**
@@ -235,5 +255,75 @@ export class EmbedTab {
     }
 
     await expect(this.embedCodeDialog).toBeHidden({ timeout: 5_000 });
+  }
+
+  /**
+   * Enables the shareable link if not already on, then waits for the generated
+   * URL block to render. Reuses main-side getShareableLinkState/toggleShareableLink.
+   */
+  async enableShareableLink(): Promise<void> {
+    if (await this.getShareableLinkState()) return;
+    await this.toggleShareableLink();
+    await expect(this.shareableLinkToggle).toHaveAttribute(
+      'aria-checked',
+      'true',
+      { timeout: 20_000 },
+    );
+    await expect(this.shareableLinkUrlBlock).toBeVisible({ timeout: 15_000 });
+  }
+
+  /** Returns the full generated shareable-link URL text. */
+  async getShareableLinkUrl(): Promise<string> {
+    await expect(this.shareableLinkUrlBlock).toBeVisible({ timeout: 15_000 });
+    return (await this.shareableLinkUrlBlock.textContent())?.trim() ?? '';
+  }
+
+  /** Extracts just the `token` query-param value from the generated shareable-link URL. */
+  async getShareableLinkToken(): Promise<string> {
+    const url = await this.getShareableLinkUrl();
+    const match = url.match(/[?&]token=([^&\s]+)/);
+    if (!match) {
+      throw new Error(
+        `Shareable link URL did not contain a token query param: ${url}`,
+      );
+    }
+    return match[1];
+  }
+
+  /** Selects an option in the "Who Can View?" Radix Select (mentor_visibility). */
+  async setWhoCanView(label: string): Promise<void> {
+    await expect(this.whoCanViewSelect).toBeVisible({ timeout: 10_000 });
+    await this.whoCanViewSelect.click();
+    await this.selectRadixOption(label);
+  }
+
+  /** Selects an option in the "Who Can Chat?" Radix Select (allow_anonymous). */
+  async setWhoCanChat(label: string): Promise<void> {
+    await expect(this.whoCanChatSelect).toBeVisible({ timeout: 10_000 });
+    await this.whoCanChatSelect.click();
+    await this.selectRadixOption(label);
+  }
+
+  /** Clicks the open Radix Select popup's option matching `label`. */
+  private async selectRadixOption(label: string): Promise<void> {
+    const opt = this.page.locator('div[role="option"]').filter({
+      hasText: new RegExp(`^${label}$`, 'i'),
+    });
+    let radixVisible = false;
+    try {
+      await opt.first().waitFor({ state: 'visible', timeout: 3_000 });
+      radixVisible = true;
+    } catch {
+      radixVisible = false;
+    }
+    if (radixVisible) {
+      await opt.first().click();
+    } else {
+      const fallback = this.page.getByRole('option', {
+        name: new RegExp(label, 'i'),
+      });
+      await expect(fallback.first()).toBeVisible({ timeout: 5_000 });
+      await fallback.first().click();
+    }
   }
 }


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Allow a user who has a shareable token to chat without checking RBAC permissions. When an admin shares an admin-only agent with a shareable token. The application does not check for the RBAC permission, allowing the user to chat.
- Closes https://github.com/iblai/iblai-platform/issues/2155

## Screenshots
https://github.com/user-attachments/assets/eca2e7cf-9cf3-4d17-96d3-257412ddabce