### PR TITLE
fix(e2e-test): fixing privacy chat test to add wait to send next message

### DIFF
--- a/e2e/journeys/50-chat-privacy.spec.ts
+++ b/e2e/journeys/50-chat-privacy.spec.ts
@@ -1352,6 +1352,10 @@ test.describe('Journey 50: Chat Privacy', () => {
       ).toBe(sessionIdBefore);
 
       // ── Turn 2: ask for recall ────────────────────────────────────────
+      // Give the backend a moment to persist turn 1 into session memory before
+      // asking for recall — without this gap the follow-up can race the write
+      // and the code word isn't yet retained, causing intermittent failures.
+      await page.waitForTimeout(5_000);
       await chatPage.sendMessage('What was the code word I gave you?');
       await expect(chatPage.userMessages.nth(1)).toBeVisible({
         timeout: 30_000,


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Add more time to send next message for privacy test to check AI retain message