### PR TITLE
ci: harden tauri auto-version against release race + re-run double-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Sync to latest main
+        # Rebase onto anything that landed after this run was triggered (e.g. a
+        # racing tauri version bump from tauri-autoversion.yml) so release-it's
+        # push fast-forwards instead of failing non-fast-forward.
+        run: |
+          git fetch origin main
+          git rebase origin/main
+
       - name: Run release-it
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/tauri-autoversion.yml
+++ b/.github/workflows/tauri-autoversion.yml
@@ -47,9 +47,18 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(node scripts/tauri-bump.mjs patch)"
-          echo "tag=app-v$VERSION" >> "$GITHUB_OUTPUT"
+          TAG="app-v$VERSION"
+          # Idempotency: if this version was already released (e.g. a job re-run),
+          # stop before committing. The bump edits are discarded with the runner.
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "$TAG already exists on origin — nothing to do"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit, tag & push
+        if: steps.bump.outputs.skip != 'true'
         env:
           HUSKY: '0'
           TAG: ${{ steps.bump.outputs.tag }}


### PR DESCRIPTION
## Summary

Follow-up to the independent-tauri-versioning work (#326, now merged). Addresses the two design findings a review flagged in the two-workflow push-to-main pattern.

- **#2 (race):** `release.yml` now rebases onto the latest `main` before running release-it (`git fetch origin main && git rebase origin/main`). If `tauri-autoversion.yml` pushed a version bump first, release-it fast-forwards instead of failing non-fast-forward.
- **#3 (idempotency):** `tauri-autoversion.yml` skips the commit/tag/push if the `app-v<X>` tag already exists on origin, so a manual job re-run no-ops instead of double-bumping (the bump edits are discarded with the ephemeral runner).

## Why resilience, not a shared concurrency group

A shared concurrency group between `release.yml` (fires on **all** pushes) and `tauri-autoversion.yml` (fires on `src-tauri` pushes) is unsafe: a web-only push's release run could cancel a *pending* tauri run and drop a DMG release. Rebase-resilience avoids that.

## Residual (minor, self-healing)

A tiny window remains if a tauri bump pushes *between* release-it's rebase and its own push — the run fails but self-heals on the next push. Fully closing it would mean wrapping release-it's internal push, not worth the risk to the release workflow.

