### PR TITLE
docs(readme): link the macOS row to the latest build download

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _[Demo](https://www.youtube.com/playlist?list=PLW0-4yErlU3XQr0UP6cCGwy24LMf7I5vR
 | Platform    | Status                                                                     |
 | ----------- | -------------------------------------------------------------------------- |
 | **Web**     | Production at [os.ibl.ai](https://os.ibl.ai) — works on any modern browser |
-| **macOS**   | Native desktop app — lightweight, fast, system-integrated                  |
+| **macOS**   | Native desktop app — [download the latest build](#download)                |
 | **iOS**     | Native mobile app — available on iPhone and iPad                           |
 | **Android** | Native mobile app — available on phones and tablets                        |
 | **Windows** | Native desktop app                                                         |


### PR DESCRIPTION
Adds a download link to the **macOS** row in the README's "Available On" table, pointing at the maintained `#download` section (which carries the auto-updated latest DMG link — so it never goes stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)