### PR TITLE
ci(pr-gate): run vitest unit tests in the Required PR workflow

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -46,6 +46,34 @@ jobs:
       - run: echo "run-tests label detected — proceeding"
 
   # ============================================================
+  # UNIT TESTS (vitest)
+  # Runs alongside the E2E jobs so a red unit suite fails this
+  # "Required" workflow and blocks merge. Previously only the local
+  # pre-push hook ran vitest, so unit failures could reach main.
+  # ============================================================
+  unit-tests:
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test
+
+  # ============================================================
   # BUILD APP IMAGE
   # ============================================================
   build-app-image:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ### CI
 
-* harden tauri auto-version against release race + re-run double-bump ([5c135c2](https://github.com/iblai/os/commit/5c135c2060b2b03a44efc476f62f5a83a3d97f02)), closes [#2](https://github.com/iblai/os/issues/2) [#3](https://github.com/iblai/os/issues/3)
+- harden tauri auto-version against release race + re-run double-bump ([5c135c2](https://github.com/iblai/os/commit/5c135c2060b2b03a44efc476f62f5a83a3d97f02)), closes [#2](https://github.com/iblai/os/issues/2) [#3](https://github.com/iblai/os/issues/3)
 
 ## [0.95.4](https://github.com/iblai/os/compare/v0.95.3...v0.95.4) (2026-07-11)
 
 ### CI
 
-* version the macOS/tauri app independently and auto-ship DMGs ([2e79784](https://github.com/iblai/os/commit/2e79784e5e56ed5df2b126571ba3ad4386f58b63))
+- version the macOS/tauri app independently and auto-ship DMGs ([2e79784](https://github.com/iblai/os/commit/2e79784e5e56ed5df2b126571ba3ad4386f58b63))
 
 ## [0.95.3](https://github.com/iblai/os/compare/v0.95.2...v0.95.3) (2026-07-10)
 
 ### Bug Fixes
 
-* **e2e-test:** fixing privacy chat test to add wait to send next message ([7e5f820](https://github.com/iblai/os/commit/7e5f820987a030d58cd34f652ebef2a38569e29f))
+- **e2e-test:** fixing privacy chat test to add wait to send next message ([7e5f820](https://github.com/iblai/os/commit/7e5f820987a030d58cd34f652ebef2a38569e29f))
 
 ## [0.95.2](https://github.com/iblai/os/compare/v0.95.1...v0.95.2) (2026-07-10)
 
 ### Bug Fixes
 
-* update checkout ecommerce playwright test to empty browser session ([3d27eca](https://github.com/iblai/os/commit/3d27eca554fc50fb5c37f92443f9c2ea45bf6cdf))
+- update checkout ecommerce playwright test to empty browser session ([3d27eca](https://github.com/iblai/os/commit/3d27eca554fc50fb5c37f92443f9c2ea45bf6cdf))
 
 ## [0.95.1](https://github.com/iblai/os/compare/v0.95.0...v0.95.1) (2026-07-09)
 


### PR DESCRIPTION
## Why

Unit tests (vitest) currently run **only** in the local pre-push hook — they are **not** part of any CI workflow. The PR gate keys off the "PR E2E Tests (Required)" workflow, which builds Docker images and runs Playwright, but never runs `pnpm test`.

That gap let commit `97d6e4ee` merge into `main` with **73 broken unit tests** (it added `useParams()` + `useChatPrivacy()` to `ChatInputForm` without updating the test). CI stayed green; only devs' local pre-push hooks failed — so anyone had to `--no-verify` to push until it was fixed. (That red suite has since been repaired and is now green: 383 files / 10,563 tests pass.)

## What

Add a `unit-tests` job to `.github/workflows/pr-e2e-tests.yml`, gated on the same `run-tests` label as the rest of the workflow. Because the gate's "PR Validation" status derives from this workflow's overall conclusion, a failing unit suite now fails the workflow and **blocks merge**.

- `needs: gate` — runs in parallel with the Docker/Playwright jobs (no added latency on the critical path).
- `runs-on: ubuntu-latest` — no OCI/secrets needed; it's just `pnpm install --frozen-lockfile` + `pnpm test`.
- `node-version-file: package.json` — stays in sync with `engines.node`.

## Notes

- Verified locally: the full `pnpm test` suite passes (383 files, 10,563 tests, 1 skipped).
- The diff also normalizes `CHANGELOG.md` bullet style (`*`→`-`). That's **not intentional** — the repo's `pre-commit` hook runs `prettier --write .` over the whole tree and `git add -u`, so it reformats `main`'s (release-it-generated) changelog on every commit. Harmless; flagged for transparency.
- This job can only be validated once it runs in Actions on a labeled PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)