### PR TITLE
fix(auth): require a valid edx_jwt_token for a non-expired session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### CI
 
-* **pr-gate:** run vitest unit tests in the Required PR workflow ([dbea82a](https://github.com/iblai/os/commit/dbea82a2bf35529c6195fb8ab1b631d2b2b09ce4))
+- **pr-gate:** run vitest unit tests in the Required PR workflow ([dbea82a](https://github.com/iblai/os/commit/dbea82a2bf35529c6195fb8ab1b631d2b2b09ce4))
 
 ## [0.95.6](https://github.com/iblai/os/compare/v0.95.5...v0.95.6) (2026-07-13)
 
 ### Documentation
 
-* **readme:** link the macOS row to the latest build download ([238bc6d](https://github.com/iblai/os/commit/238bc6d16346989f0fc1f4a52542918f8c8bbab3)), closes [#download](https://github.com/iblai/os/issues/download)
+- **readme:** link the macOS row to the latest build download ([238bc6d](https://github.com/iblai/os/commit/238bc6d16346989f0fc1f4a52542918f8c8bbab3)), closes [#download](https://github.com/iblai/os/issues/download)
 
 ## [0.95.5](https://github.com/iblai/os/compare/v0.95.4...v0.95.5) (2026-07-13)
 

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   cn,
   hasNonExpiredAuthToken,
+  isJwtExpired,
   redirectToAuthSpa,
   getPlatformKey,
   getAuthSpaJoinUrl,
@@ -124,6 +125,16 @@ const localStorageMock = (() => {
   };
 })();
 
+// Builds a minimal (unsigned) JWT with the given `exp` claim (seconds since
+// epoch). Omit `exp` for a token with no expiry claim.
+function makeJwt(exp?: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify(exp === undefined ? {} : { exp }));
+  return `${header}.${payload}.signature`;
+}
+
+const validEdxJwt = () => makeJwt(Math.floor(Date.now() / 1000) + 3600);
+
 describe('cn function', () => {
   it('should combine class names correctly', () => {
     // Basic test
@@ -163,10 +174,34 @@ describe('hasNonExpiredAuthToken function', () => {
 
     // Clear localStorage before each test
     localStorageMock.clear();
+    // A valid session also requires a non-expired edx JWT; seed one so the axd
+    // token assertions below exercise the axd logic (edx tests override this).
+    localStorageMock.setItem(LOCAL_STORAGE_KEYS.EDX_TOKEN_KEY, validEdxJwt());
   });
 
   it('should return true when no token exists', () => {
+    localStorageMock.removeItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN);
     expect(hasNonExpiredAuthToken()).toBe(false);
+  });
+
+  it('should return false when edx_jwt_token is missing', () => {
+    localStorageMock.removeItem(LOCAL_STORAGE_KEYS.EDX_TOKEN_KEY);
+    localStorageMock.setItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN, 'valid-token');
+    expect(hasNonExpiredAuthToken()).toBe(false);
+  });
+
+  it('should return false when edx_jwt_token is expired', () => {
+    localStorageMock.setItem(
+      LOCAL_STORAGE_KEYS.EDX_TOKEN_KEY,
+      makeJwt(Math.floor(Date.now() / 1000) - 3600),
+    );
+    localStorageMock.setItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN, 'valid-token');
+    expect(hasNonExpiredAuthToken()).toBe(false);
+  });
+
+  it('should return true when both the axd and edx tokens are valid', () => {
+    localStorageMock.setItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN, 'valid-token');
+    expect(hasNonExpiredAuthToken()).toBe(true);
   });
 
   it('should return true when token exists but no expiry', () => {
@@ -222,6 +257,32 @@ describe('hasNonExpiredAuthToken function', () => {
 
     // Restore Date.now
     Date.now = realDateNow;
+  });
+});
+
+describe('isJwtExpired function', () => {
+  it('returns false for a token whose exp is in the future', () => {
+    expect(isJwtExpired(makeJwt(Math.floor(Date.now() / 1000) + 3600))).toBe(
+      false,
+    );
+  });
+
+  it('returns true for a token whose exp is in the past', () => {
+    expect(isJwtExpired(makeJwt(Math.floor(Date.now() / 1000) - 3600))).toBe(
+      true,
+    );
+  });
+
+  it('returns false for a token with no exp claim (non-expiring)', () => {
+    expect(isJwtExpired(makeJwt())).toBe(false);
+  });
+
+  it('returns true for a token with no payload segment', () => {
+    expect(isJwtExpired('not-a-jwt')).toBe(true);
+  });
+
+  it('returns true for a token whose payload cannot be decoded', () => {
+    expect(isJwtExpired('header.@not-base64@.sig')).toBe(true);
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -42,7 +42,49 @@ export function isSafariBrowser(): boolean {
   return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 }
 
+/**
+ * Reads a JWT's `exp` claim and reports whether it is in the past. A token that
+ * cannot be decoded (or is malformed) is treated as expired; a token with no
+ * `exp` claim is treated as non-expiring (mirrors the axd "no expiry" case).
+ */
+export function isJwtExpired(token: string): boolean {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return true;
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      '=',
+    );
+    const claims = JSON.parse(atob(padded)) as { exp?: number };
+    if (typeof claims.exp !== 'number') return false;
+    return claims.exp * 1000 <= Date.now();
+  } catch {
+    return true;
+  }
+}
+
 export function hasNonExpiredAuthToken() {
+  // The edx JWT is stored alongside the axd token at SSO login; a valid session
+  // requires it to be present and unexpired too, so re-auth is triggered when
+  // it is missing or its `exp` has passed.
+  const edxToken = window.localStorage.getItem(
+    LOCAL_STORAGE_KEYS.EDX_TOKEN_KEY,
+  );
+  if (!edxToken) {
+    console.log(
+      '################### [hasNonExpiredAuthToken] edx_jwt_token is not defined',
+      edxToken,
+    );
+    return false;
+  }
+  if (isJwtExpired(edxToken)) {
+    console.log(
+      '################### [hasNonExpiredAuthToken] edx_jwt_token is expired',
+    );
+    return false;
+  }
+
   const token = window.localStorage.getItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN);
   if (!token) {
     console.log(


### PR DESCRIPTION
## Problem

`hasNonExpiredAuthToken()` only validated the **axd** token. If the **edx JWT** (`edx_jwt_token`) was missing or expired, the session was still treated as live and re-authentication was skipped — even though the edx token is set alongside axd at SSO login and is required for a working session.

## Change

`hasNonExpiredAuthToken()` now also requires `edx_jwt_token` to be **present and unexpired** before returning `true`. The check runs first, so every success path is gated on it; when the edx token is missing or expired, the function returns `false` and the SDK's `redirectToAuthSpa` re-authenticates.

- New `isJwtExpired(token)` helper decodes the JWT's `exp` claim (base64url-safe). Malformed/undecodable → treated as expired; no `exp` claim → treated as non-expiring (mirrors the existing axd "no expiry → valid" behavior).
- Semantics are **AND**: both axd and edx must be valid.

## Tests

`lib/__tests__/utils.test.ts`: seeds a valid edx JWT in `beforeEach` (so the axd assertions still exercise axd logic), adds edx cases (missing / expired / both-valid), and a full `isJwtExpired` describe (future/past/no-exp/no-payload/undecodable). **339 passed** locally; typecheck clean.

## Note

Pushed with `--no-verify` (author-authorized): the full pre-push suite passed, but `git push` hit a repeated SIGPIPE-after-pass transport flake in the hook. The pre-existing `###################` debug `console.log`s in this function were left as-is (matched style for the new branches); happy to strip them all in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)