### PR TITLE
fix(routing): keep query params when redirecting to the default mentor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### CI
 
-* **pr-gate:** run vitest unit tests in the Required PR workflow ([dbea82a](https://github.com/iblai/os/commit/dbea82a2bf35529c6195fb8ab1b631d2b2b09ce4))
+- **pr-gate:** run vitest unit tests in the Required PR workflow ([dbea82a](https://github.com/iblai/os/commit/dbea82a2bf35529c6195fb8ab1b631d2b2b09ce4))
 
 ## [0.95.6](https://github.com/iblai/os/compare/v0.95.5...v0.95.6) (2026-07-13)
 
 ### Documentation
 
-* **readme:** link the macOS row to the latest build download ([238bc6d](https://github.com/iblai/os/commit/238bc6d16346989f0fc1f4a52542918f8c8bbab3)), closes [#download](https://github.com/iblai/os/issues/download)
+- **readme:** link the macOS row to the latest build download ([238bc6d](https://github.com/iblai/os/commit/238bc6d16346989f0fc1f4a52542918f8c8bbab3)), closes [#download](https://github.com/iblai/os/issues/download)
 
 ## [0.95.5](https://github.com/iblai/os/compare/v0.95.4...v0.95.5) (2026-07-13)
 

--- a/providers/__tests__/index.test.tsx
+++ b/providers/__tests__/index.test.tsx
@@ -940,6 +940,25 @@ describe('Providers', () => {
       expect(mockPush).toHaveBeenCalledWith('/platform/t1/m1');
     });
 
+    it('redirectToMentor is a no-op when already on the target mentor (keeps query params)', () => {
+      // Simulates the SDK re-invoking redirectToMentor after the initial
+      // redirect has already landed on the mentor page with its query string.
+      const locationSpy = vi.spyOn(window, 'location', 'get').mockReturnValue({
+        ...window.location,
+        pathname: '/platform/t1/m1',
+        search: '?embed=true&mode=anonymous&component=chat',
+      } as Location);
+      try {
+        renderProviders();
+        const fn = capturedMentorProviderProps.redirectToMentor as Function;
+        fn('t1', 'm1');
+        // No re-navigation — the existing URL (with its query params) is kept.
+        expect(mockPush).not.toHaveBeenCalledWith('/platform/t1/m1');
+      } finally {
+        locationSpy.mockRestore();
+      }
+    });
+
     it('redirectToAuthSpa calls the real function', () => {
       renderProviders();
       const fn = capturedMentorProviderProps.redirectToAuthSpa as Function;

--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -277,11 +277,17 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   }
 
   function redirectToMentor(tenantKey: string, mentorId: string) {
+    const targetPath = `/platform/${tenantKey}/${mentorId}`;
+    // The SDK MentorProvider re-invokes this after the initial `/` → mentor
+    // redirect settles. Bail out when we're already on the target mentor,
+    // otherwise the re-invocation re-pushes a bare URL and strips the current
+    // query string (e.g. embed/mode/component params).
+    if (window.location.pathname === targetPath) return;
     let queryParams = '';
     if (window.location.pathname === '/') {
       queryParams = window.location.search;
     }
-    router.push(`/platform/${tenantKey}/${mentorId}${queryParams}`);
+    router.push(`${targetPath}${queryParams}`);
   }
 
   function onLoadMentorsPermissions(


### PR DESCRIPTION
## Problem

Visiting `http://localhost:3001/?embed=true&mode=anonymous&extra-body-classes=iframed-externally&component=chat` produced:

1. `/?embed=…` → `/platform/<tenant>/<mentorId>?embed=…` (query **preserved** ✓)
2. → `/platform/<tenant>/<mentorId>` (query **stripped** ✗)

Expected: stay at step 1's URL with the params intact.

## Root cause

`redirectToMentor` in `providers/index.tsx` fires **twice**. It only preserved the query when `pathname === '/'`. The SDK `MentorProvider` re-invokes it after the first redirect settles — by then `pathname` is `/platform/<tenant>/<mentorId>`, so `queryParams` is `''` and it re-pushes the bare URL, stripping `embed`/`mode`/`component`/etc.

## Fix

Guard `redirectToMentor` to bail out when already on the target mentor path, so the redundant self-redirect doesn't drop the query string. All existing navigation behavior is otherwise untouched.

```ts
function redirectToMentor(tenantKey, mentorId) {
  const targetPath = `/platform/${tenantKey}/${mentorId}`;
  if (window.location.pathname === targetPath) return; // already here — don't strip
  let queryParams = '';
  if (window.location.pathname === '/') queryParams = window.location.search;
  router.push(`${targetPath}${queryParams}`);
}
```

## Tests

Added a provider unit test asserting `redirectToMentor` is a no-op (no re-push) when already on the target mentor. Full provider suite green (**117 passed**); full pre-push unit suite passed (10,564).

## Note

Pushed with `--no-verify` (author-authorized): the pre-push suite passed but `git push` hit the repeated SIGPIPE-after-pass transport flake. Worth verifying in the browser that the embed URL now stays put; if a params-stripping second redirect persists, the SDK `MentorProvider` may need a look too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)