### PR TITLE
test(e2e): track & clean up agents created during tests

### DIFF
--- a/.claude/agents/playwright-e2e-engineer.md
+++ b/.claude/agents/playwright-e2e-engineer.md
@@ -175,6 +175,58 @@ import { logger } from '@iblai/iblai-js/playwright';
 logger.info('TC20: Search value after reopen: ...');
 ```
 
+### Mentor Creation — Always Track & Clean Up (Critical Rule)
+
+**Any test that creates a mentor/agent MUST track it and delete it afterwards.**
+Created mentors are persisted server-side; without cleanup they accumulate in
+the DB on every run (a full 4-browser run can leak hundreds). When you write or
+modify a spec that calls `createMentorPage.openAndCreate()` /
+`CreateMentorPage.createWithName()` (or any other mentor-creation flow), wire in
+cleanup via `MentorTracker` from `e2e/utils/mentor-cleanup.ts`:
+
+```typescript
+import { MentorTracker } from '../utils/mentor-cleanup';
+
+test.describe('...', () => {
+  const tracker = new MentorTracker();
+
+  test.beforeEach(async ({ page, createMentorPage }) => {
+    await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    tracker.add(mentorId); // register every mentor this suite creates
+  });
+
+  // Delete in afterAll (best-effort, via the DM API), NEVER afterEach —
+  // see the shared-mentor note below.
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker.deleteAll(browser, testInfo);
+  });
+});
+```
+
+Rules that keep cleanup from breaking other tests:
+
+- **Track by id/url and delete only what the suite created.** Never delete by a
+  broad name sweep in a spec. `MentorTracker.deleteAll` only removes the exact
+  ids you registered, so seed/default mentors are never touched.
+- **Use `afterAll`, not `afterEach`.** Many suites create one mentor in
+  `beforeAll`/a worker fixture and share it across tests (e.g. journeys 14, 51, 60) — an `afterEach` delete would break siblings mid-suite. `afterAll` (or
+  worker-fixture teardown) is the safe scope. Only use per-test deletion when
+  each test genuinely creates and owns its own mentor.
+- **Never reduce the tenant to zero mentors.** `navigateToMentorApp` depends on
+  a default mentor existing; deleting the last one cascades failures across the
+  whole run. Only ever remove test-created mentors.
+- **Cleanup is best-effort.** `deleteAll` swallows errors so a failed delete
+  never fails the run.
+- **Unique, timestamped names.** Use `generateMentorName()` (`E2E Mentor {ts}`)
+  rather than fixed names, so the global sweeper can reap orphans by age and
+  parallel browsers don't collide.
+
+A `globalTeardown` sweeper (`e2e/utils/mentor-sweeper.ts`) reaps stale
+timestamped `E2E …` mentors (older than 2h) as a safety net for crashed tests —
+but that is a backstop, **not a substitute** for per-suite `afterAll` cleanup.
+Model new specs on journeys 14, 60, and the `afterAll` blocks in journeys 22/42/44/47/52.
+
 ### Cross-Browser Resilience
 
 The test suite runs on Chrome, Firefox, Safari (WebKit), and Edge. Browser-specific handling is built into the utilities — **always use them instead of raw Playwright APIs for navigation and waiting**:
@@ -241,6 +293,7 @@ When investigating flaky tests:
 - Every test should have a clear assertion — no tests that only navigate without verifying outcomes
 - Tests should be independent and can run in any order
 - Clean up any test data created during the journey
+- **Any spec that creates a mentor MUST track it with `MentorTracker` and delete it in `afterAll`** (see "Mentor Creation — Always Track & Clean Up"). Before finishing, confirm every `openAndCreate()`/`createWithName()` call has a corresponding `tracker.add(...)` and the suite drains via `tracker.deleteAll(...)`.
 - Use meaningful error messages in custom assertions
 - Avoid test interdependencies — each spec file should be self-contained
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* **auth:** require a valid edx_jwt_token for a non-expired session ([53e961f](https://github.com/iblai/os/commit/53e961f7781167148ffb6c8acf963448c3da3ddd))
+- **auth:** require a valid edx_jwt_token for a non-expired session ([53e961f](https://github.com/iblai/os/commit/53e961f7781167148ffb6c8acf963448c3da3ddd))
 
 ## [0.95.7](https://github.com/iblai/os/compare/v0.95.6...v0.95.7) (2026-07-13)
 

--- a/e2e/journeys/22-disclaimers-and-user-agreement.spec.ts
+++ b/e2e/journeys/22-disclaimers-and-user-agreement.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '../fixtures/mentor-test';
-import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import {
+  navigateToMentorApp,
+  checkAdminStatus,
+  getPlatformContext,
+} from '../utils/auth';
 import { waitForPageReady, waitForDialogReady } from '../utils/resilient';
 import { safeWaitForURL } from '../utils/navigation';
+import { MentorTracker } from '../utils/mentor-cleanup';
 
 // ─── Journey 22: Disclaimers & User Agreement ─────────────────────────────────
 //
@@ -18,6 +23,8 @@ import { safeWaitForURL } from '../utils/navigation';
 // ─── A. Admin — User Agreement Toggle ────────────────────────────────────────
 
 test.describe('Journey 22-A: Admin — User Agreement Toggle', () => {
+  const trackerA = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage, editMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -26,6 +33,8 @@ test.describe('Journey 22-A: Admin — User Agreement Toggle', () => {
       return;
     }
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    trackerA.add(mentorId);
     await editMentorPage.open('Disclaimers');
     await waitForPageReady(page);
   });
@@ -72,11 +81,17 @@ test.describe('Journey 22-A: Admin — User Agreement Toggle', () => {
 
     await editMentorPage.close();
   });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await trackerA.deleteAll(browser, testInfo);
+  });
 });
 
 // ─── B. Admin — Edit Content ──────────────────────────────────────────────────
 
 test.describe('Journey 22-B: Admin — Edit Content', () => {
+  const trackerB = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage, editMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -85,6 +100,8 @@ test.describe('Journey 22-B: Admin — Edit Content', () => {
       return;
     }
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    trackerB.add(mentorId);
     await editMentorPage.open('Disclaimers');
     await waitForPageReady(page);
   });
@@ -265,11 +282,17 @@ test.describe('Journey 22-B: Admin — Edit Content', () => {
 
     await editMentorPage.close();
   });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await trackerB.deleteAll(browser, testInfo);
+  });
 });
 
 // ─── C. Admin — Copy Content ──────────────────────────────────────────────────
 
 test.describe('Journey 22-C: Admin — Copy Content', () => {
+  const trackerC = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage, editMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -278,6 +301,8 @@ test.describe('Journey 22-C: Admin — Copy Content', () => {
       return;
     }
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    trackerC.add(mentorId);
     await editMentorPage.open('Disclaimers');
     await waitForPageReady(page);
   });
@@ -347,11 +372,16 @@ test.describe('Journey 22-C: Admin — Copy Content', () => {
 
     await editMentorPage.close();
   });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await trackerC.deleteAll(browser, testInfo);
+  });
 });
 
 // ─── D. Non-Admin — Agreement Enforcement ────────────────────────────────────
 
 test.describe('Journey 22-D: Non-Admin — Agreement Enforcement', () => {
+  const trackerD = new MentorTracker();
   // disc-01 / disc-07 / disc-08: The critical E2E enforcement journey.
   // Admin creates a mentor, enables User Agreement + sets visibility to Anyone,
   // then a non-admin navigates directly to the mentor and must accept before chatting.
@@ -371,6 +401,7 @@ test.describe('Journey 22-D: Non-Admin — Agreement Enforcement', () => {
     }
 
     await createMentorPage.openAndCreate();
+    trackerD.add((await getPlatformContext(page)).mentorId);
 
     // Step 2: Enable user agreement
     await editMentorPage.open('Disclaimers');
@@ -481,6 +512,7 @@ test.describe('Journey 22-D: Non-Admin — Agreement Enforcement', () => {
     }
 
     await createMentorPage.openAndCreate();
+    trackerD.add((await getPlatformContext(page)).mentorId);
 
     // Verify user agreement is disabled on the new mentor
     await editMentorPage.open('Disclaimers');
@@ -546,6 +578,7 @@ test.describe('Journey 22-D: Non-Admin — Agreement Enforcement', () => {
     }
 
     await createMentorPage.openAndCreate();
+    trackerD.add((await getPlatformContext(page)).mentorId);
 
     await editMentorPage.open('Disclaimers');
     await waitForPageReady(page);
@@ -635,11 +668,17 @@ test.describe('Journey 22-D: Non-Admin — Agreement Enforcement', () => {
       expect(firstModalVisible || firstErrorVisible).toBe(true);
     }
   });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await trackerD.deleteAll(browser, testInfo);
+  });
 });
 
 // ─── E. Tab Layout ────────────────────────────────────────────────────────────
 
 test.describe('Journey 22-E: Tab Layout', () => {
+  const trackerE = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage, editMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -648,6 +687,8 @@ test.describe('Journey 22-E: Tab Layout', () => {
       return;
     }
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    trackerE.add(mentorId);
     await editMentorPage.open('Disclaimers');
     await waitForPageReady(page);
   });
@@ -748,5 +789,9 @@ test.describe('Journey 22-E: Tab Layout', () => {
     await expect(uaDialog).toBeHidden({ timeout: 5_000 });
 
     await editMentorPage.close();
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await trackerE.deleteAll(browser, testInfo);
   });
 });

--- a/e2e/journeys/42-suggested-prompts.spec.ts
+++ b/e2e/journeys/42-suggested-prompts.spec.ts
@@ -1,9 +1,16 @@
 import { test, expect } from '../fixtures/mentor-test';
-import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import {
+  navigateToMentorApp,
+  checkAdminStatus,
+  getPlatformContext,
+} from '../utils/auth';
 import { waitForPageReady } from '../utils/resilient';
+import { MentorTracker } from '../utils/mentor-cleanup';
 
 test.describe('Journey 42: Suggested Prompts', () => {
   test.setTimeout(200_000);
+
+  const tracker = new MentorTracker();
 
   test.beforeEach(async ({ page, createMentorPage }) => {
     await navigateToMentorApp(page);
@@ -16,6 +23,8 @@ test.describe('Journey 42: Suggested Prompts', () => {
     // Create a fresh mentor for each test so the suggested prompts list
     // starts empty (avoids pagination/page-size pollution from prior runs).
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    tracker.add(mentorId);
   });
 
   // --------------------------------------------------------------------------
@@ -486,5 +495,9 @@ test.describe('Journey 42: Suggested Prompts', () => {
         timeout: 10_000,
       });
     });
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker.deleteAll(browser, testInfo);
   });
 });

--- a/e2e/journeys/44-claw-advanced-sandbox.spec.ts
+++ b/e2e/journeys/44-claw-advanced-sandbox.spec.ts
@@ -31,8 +31,13 @@
  */
 
 import { test, expect } from '../fixtures/mentor-test';
-import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import {
+  navigateToMentorApp,
+  checkAdminStatus,
+  getPlatformContext,
+} from '../utils/auth';
 import { waitForPageReady } from '../utils/resilient';
+import { MentorTracker } from '../utils/mentor-cleanup';
 import { SandboxTab } from '../page-objects/edit-mentor/sandbox.tab';
 import { SkillsTab } from '../page-objects/edit-mentor/skills.tab';
 import type { Locator } from '@playwright/test';
@@ -92,6 +97,8 @@ async function expectTabHidden(
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Journey 44: CLAW Advanced Sandbox', () => {
+  const tracker44A = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -104,6 +111,8 @@ test.describe('Journey 44: CLAW Advanced Sandbox', () => {
     // against a clean mentor (independent of whatever claw state a prior
     // run or the default mentor was left in).
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    tracker44A.add(mentorId);
   });
 
   // ── TC01: Toggle is present in Settings tab ───────────────────────────────
@@ -474,6 +483,10 @@ test.describe('Journey 44: CLAW Advanced Sandbox', () => {
       await editMentorPage.close();
     }
   });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker44A.deleteAll(browser, testInfo);
+  });
 });
 
 // ── TC09: Toggle on/off lifecycle in a single session ────────────────────────
@@ -482,6 +495,8 @@ test.describe('Journey 44: CLAW Advanced Sandbox', () => {
 // Sandbox disappear — all within the same modal session (no reopen).
 
 test.describe('Journey 44: CLAW Advanced Sandbox — deeper lifecycle', () => {
+  const tracker44B = new MentorTracker();
+
   test.beforeEach(async ({ page, createMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -494,6 +509,8 @@ test.describe('Journey 44: CLAW Advanced Sandbox — deeper lifecycle', () => {
     // against a clean mentor (independent of whatever claw state a prior
     // run or the default mentor was left in).
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    tracker44B.add(mentorId);
   });
 
   test('admin toggles Sandbox ON then OFF and Sandbox tab appears then disappears in the same session', async ({
@@ -1159,6 +1176,10 @@ test.describe('Journey 44: CLAW Advanced Sandbox — deeper lifecycle', () => {
       }
       await editMentorPage.close();
     }
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker44B.deleteAll(browser, testInfo);
   });
 });
 

--- a/e2e/journeys/47-mentor-voice-tab.spec.ts
+++ b/e2e/journeys/47-mentor-voice-tab.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../fixtures/mentor-test';
-import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import {
+  navigateToMentorApp,
+  checkAdminStatus,
+  getPlatformContext,
+} from '../utils/auth';
 import { waitForPageReady } from '../utils/resilient';
+import { MentorTracker } from '../utils/mentor-cleanup';
 
 /**
  * Journey 47 — Mentor Voice Tab.
@@ -35,6 +40,8 @@ import { waitForPageReady } from '../utils/resilient';
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Journey 47: Mentor Voice Tab', () => {
+  const tracker47 = new MentorTracker();
+
   test.beforeEach(async ({ page, editMentorPage, createMentorPage }) => {
     await navigateToMentorApp(page);
     const isAdmin = await checkAdminStatus(page);
@@ -51,6 +58,8 @@ test.describe('Journey 47: Mentor Voice Tab', () => {
     // is present from the start; the defensive fallback below still covers the
     // edge case where it is not. See the file-level serial note above.
     await createMentorPage.openAndCreate();
+    const { mentorId } = await getPlatformContext(page);
+    tracker47.add(mentorId);
 
     // Open the Edit Agent modal to the Settings tab first, not directly to
     // Voice. The Voice tab is admin-gated by the segments hook (userTypes:
@@ -294,5 +303,9 @@ test.describe('Journey 47: Mentor Voice Tab', () => {
     await expect(editMentorPage.voice.tabLink).toBeVisible({ timeout: 15_000 });
 
     await editMentorPage.close();
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker47.deleteAll(browser, testInfo);
   });
 });

--- a/e2e/journeys/52-tool-call-indicator-and-reasoning.spec.ts
+++ b/e2e/journeys/52-tool-call-indicator-and-reasoning.spec.ts
@@ -1,12 +1,15 @@
 // spec: e2e/test-plans/tool-call-indicator-and-reasoning-section.md
 
 import { test, expect } from '../fixtures/mentor-test';
-import { navigateToMentorApp } from '../utils/auth';
+import { navigateToMentorApp, getPlatformContext } from '../utils/auth';
+import { MentorTracker } from '../utils/mentor-cleanup';
 
 // Generous timeout for LLM streaming responses
 const STREAMING_TIMEOUT = 120_000;
 
 test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
+  const tracker52 = new MentorTracker();
+
   test.beforeEach(async ({ page }) => {
     await navigateToMentorApp(page);
   });
@@ -20,7 +23,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Tool Call Test Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Tool Call Test Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable Web Search via Tools tab
     // Enable verbose reasoning gates the tool-call indicator — enable it first.
@@ -102,7 +108,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Tool Call Expand Test Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Tool Call Expand Test Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning gates the tool-call indicator — enable it first.
     await editMentorPage.open('Settings');
@@ -183,7 +192,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Unique Tool Count Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Unique Tool Count Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning gates the tool-call indicator — enable it first.
     await editMentorPage.open('Settings');
@@ -244,7 +256,8 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E No-Tools Mentor');
+    await createMentorPage.openAndCreate(`E2E No-Tools Mentor ${Date.now()}`);
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // No Web Search button should be visible
     try {
@@ -286,7 +299,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Web Search Not Activated Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Web Search Not Activated Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning gates the tool-call indicator — enable it first.
     await editMentorPage.open('Settings');
@@ -336,7 +352,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Reasoning Test Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Reasoning Test Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning gates the reasoning section — enable it, then set the
     // LLM to gpt-5 via the LLM tab page object.
@@ -441,7 +460,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Non-Reasoning Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Non-Reasoning Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning so this test verifies the model produces no
     // reasoning tokens, rather than the section being hidden by the toggle.
@@ -492,7 +514,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Combined Features Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Combined Features Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Enable verbose reasoning gates both the reasoning section and the tool-call
     // indicator — enable it first.
@@ -581,7 +606,10 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     editMentorPage,
     chatPage,
   }) => {
-    await createMentorPage.openAndCreate('E2E Verbose Reasoning Off Mentor');
+    await createMentorPage.openAndCreate(
+      `E2E Verbose Reasoning Off Mentor ${Date.now()}`,
+    );
+    tracker52.add((await getPlatformContext(page)).mentorId);
 
     // Explicitly turn enable verbose reasoning OFF (new mentors default it ON), then
     // enable Web Search — the tool genuinely runs yet its indicator must stay
@@ -624,5 +652,9 @@ test.describe('Journey 52: Tool Call Indicator and Reasoning Section', () => {
     } catch {
       // Expected: indicator is gated off by the enable verbose reasoning toggle
     }
+  });
+
+  test.afterAll(async ({ browser }, testInfo) => {
+    await tracker52.deleteAll(browser, testInfo);
   });
 });

--- a/e2e/journeys/cleanup.spec.ts
+++ b/e2e/journeys/cleanup.spec.ts
@@ -1,11 +1,16 @@
 import { test, expect } from '../fixtures/mentor-test';
 import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
 import { waitForPageReady } from '../utils/resilient';
+import { E2E_MENTOR_RE } from '../utils/mentor-sweeper';
 
 /**
  * Post-suite cleanup: deletes test mentors created during the test run.
  * This is NOT a user journey — it is infrastructure cleanup.
  * Original: cleanup.mentornextjs.cleanup.ts
+ *
+ * SAFETY: Only deletes the currently-loaded mentor if its name matches the
+ * timestamped E2E pattern (e.g. "E2E Mentor 1720000000000"). This prevents
+ * accidentally removing seed/default mentors that don't carry a timestamp.
  */
 test.describe('Cleanup: Delete test mentors', () => {
   test('admin goes to mentor settings and deletes test mentors created during the test run', async ({
@@ -18,11 +23,38 @@ test.describe('Cleanup: Delete test mentors', () => {
 
     await editMentorPage.open('Settings');
     await waitForPageReady(page);
+
+    // Navigate to the Basic sub-tab to read the mentor's name from the name
+    // input field — this is the authoritative source of the currently loaded
+    // mentor's identity.
+    await editMentorPage.settings.selectSubTab('Basic');
+    const nameInput = editMentorPage.dialog.getByRole('textbox', {
+      name: /name/i,
+    });
+    let mentorName = '';
+    try {
+      await nameInput.waitFor({ state: 'visible', timeout: 10_000 });
+      mentorName = (await nameInput.inputValue()) ?? '';
+    } catch {
+      // Name input not visible — cannot determine mentor identity; skip deletion.
+      return;
+    }
+
+    // SAFETY GUARD: only delete if the name matches the E2E timestamped pattern.
+    if (!E2E_MENTOR_RE.test(mentorName)) {
+      return;
+    }
+
     const deleteBtn = editMentorPage.settings.deleteButton;
-    const visible = await deleteBtn
-      .isVisible({ timeout: 5_000 })
-      .catch(() => false);
-    if (!visible) return;
+    let deleteBtnVisible = false;
+    try {
+      await deleteBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      deleteBtnVisible = true;
+    } catch {
+      deleteBtnVisible = false;
+    }
+    if (!deleteBtnVisible) return;
+
     await editMentorPage.settings.deleteMentor();
     await expect(page).toHaveURL(/\/platform\//, { timeout: 15_000 });
   });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,6 +20,7 @@ const testRetries = process.env.TEST_RETRIES
 
 const config = defineConfig({
   testDir: './journeys',
+  globalTeardown: './utils/mentor-sweeper',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: testRetries,

--- a/e2e/utils/mentor-cleanup.ts
+++ b/e2e/utils/mentor-cleanup.ts
@@ -1,0 +1,202 @@
+/**
+ * Mentor cleanup utilities for E2E tests.
+ *
+ * Provides two tools:
+ *
+ * 1. `deleteMentorById(page, mentorId)` — API-based best-effort delete of a
+ *    single mentor by its unique_id (the slug in the platform URL). Reads
+ *    dm_token, username, and tenantKey from localStorage so no extra
+ *    credentials are needed. Falls back silently on any error.
+ *
+ * 2. `MentorTracker` — a simple accumulator a spec can use to register
+ *    created mentor ids and then wipe them all in `afterAll`. Example:
+ *
+ *    ```ts
+ *    const tracker = new MentorTracker();
+ *
+ *    test.beforeEach(async ({ page, createMentorPage }) => {
+ *      await createMentorPage.openAndCreate();
+ *      const { mentorId } = await getPlatformContext(page);
+ *      tracker.add(mentorId);
+ *    });
+ *
+ *    test.afterAll(async ({ browser }, testInfo) => {
+ *      await tracker.deleteAll(browser, testInfo);
+ *    });
+ *    ```
+ *
+ * API endpoint used:
+ *   DELETE {NEXT_PUBLIC_API_BASE_URL}/dm/api/ai-mentor/orgs/{tenantKey}/users/{username}/{mentorId}/
+ *   Authorization: Token {dm_token}
+ *
+ * The NEXT_PUBLIC_API_BASE_URL env var is already set in the app's .env.local
+ * and is available to Playwright via the dotenv load in playwright.config.ts.
+ *
+ * WHY API rather than UI:
+ *   The UI path (`editMentorPage.settings.deleteMentor()`) requires the page
+ *   to be navigated to the mentor's URL, the Edit Agent modal to be opened,
+ *   and the confirmation dialog to be accepted. This is 3-5 network round
+ *   trips + DOM interactions. A single DELETE request is faster, more robust
+ *   (no UI flakiness), and does not depend on the page being in any
+ *   particular state. The UI path is still used in journey 60's worker
+ *   fixture where the page is already on the mentor URL — we keep parity
+ *   with that approach where the API is not available.
+ *
+ * SAFETY CONSTRAINTS (enforced here):
+ *   - Never deletes unless the mentorId is a known test-created id
+ *     (callers are responsible; the API simply performs what is asked).
+ *   - Everything is best-effort: any error is caught and logged, not thrown.
+ *   - Use in `afterAll` (not `afterEach`) for suites that share one mentor
+ *     across tests; use per-test `finally` blocks for self-contained tests.
+ */
+
+import type { Browser, TestInfo } from '@playwright/test';
+import { logger } from '@iblai/iblai-js/playwright';
+import path from 'path';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+
+/**
+ * Reads auth context from localStorage of an already-navigated page and
+ * issues a DELETE request for the given mentorId (unique_id / slug).
+ *
+ * @param page  A Playwright Page that has already loaded the mentor app and
+ *              has dm_token + userData + current_tenant in localStorage.
+ * @param mentorId  The unique_id segment from the mentor's platform URL
+ *                  (e.g. "my-mentor-1234").
+ */
+export async function deleteMentorById(
+  page: import('@playwright/test').Page,
+  mentorId: string,
+): Promise<void> {
+  try {
+    if (!API_BASE) {
+      logger.warn(
+        '[mentor-cleanup] NEXT_PUBLIC_API_BASE_URL is not set — skipping API delete',
+      );
+      return;
+    }
+
+    const { dmToken, username, tenantKey } = await page.evaluate(() => {
+      const dmToken = localStorage.getItem('dm_token');
+
+      // userData.user_nicename is what the app uses as userId in API calls
+      let username: string | null = null;
+      try {
+        const raw = localStorage.getItem('userData');
+        if (raw) username = JSON.parse(raw)?.user_nicename ?? null;
+      } catch {
+        // ignore
+      }
+
+      // current_tenant — either an object with .key or a bare string
+      let tenantKey: string | null = null;
+      try {
+        const raw = localStorage.getItem('current_tenant');
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          tenantKey =
+            typeof parsed === 'string' ? parsed : (parsed?.key ?? null);
+        }
+      } catch {
+        // ignore
+      }
+
+      return { dmToken, username, tenantKey };
+    });
+
+    if (!dmToken || !username || !tenantKey) {
+      logger.warn(
+        `[mentor-cleanup] Missing auth context (dmToken=${!!dmToken}, username=${!!username}, tenantKey=${!!tenantKey}) — skipping API delete for mentor ${mentorId}`,
+      );
+      return;
+    }
+
+    // DM API lives under the `/dm` path on the API base (see config.dmUrl()).
+    const url = `${API_BASE}/dm/api/ai-mentor/orgs/${encodeURIComponent(tenantKey)}/users/${encodeURIComponent(username)}/${encodeURIComponent(mentorId)}/`;
+
+    const res = await page.request.delete(url, {
+      headers: { Authorization: `Token ${dmToken}` },
+      timeout: 20_000,
+    });
+
+    if (res.ok() || res.status() === 404) {
+      logger.info(
+        `[mentor-cleanup] Deleted mentor ${mentorId} (status ${res.status()})`,
+      );
+    } else {
+      logger.warn(
+        `[mentor-cleanup] DELETE ${url} → ${res.status()} — mentor ${mentorId} may not have been deleted`,
+      );
+    }
+  } catch (err) {
+    // Best-effort — a cleanup failure must never fail the test run.
+    logger.warn(`[mentor-cleanup] Failed to delete mentor ${mentorId}: ${err}`);
+  }
+}
+
+/**
+ * Accumulates mentor ids created during a describe block and batch-deletes
+ * them in `afterAll`. Thread-safe within a single worker (tests inside one
+ * describe run sequentially). Each spec file should create its own instance.
+ */
+export class MentorTracker {
+  private readonly ids: Set<string> = new Set();
+
+  /** Register a mentorId so it is cleaned up in deleteAll(). */
+  add(mentorId: string): void {
+    if (mentorId) this.ids.add(mentorId);
+  }
+
+  /** Best-effort delete of all tracked mentors using a fresh browser context
+   *  authenticated via the project's storageState. */
+  async deleteAll(browser: Browser, testInfo: TestInfo): Promise<void> {
+    if (this.ids.size === 0) return;
+
+    // Derive the browser storageState from the project name, matching how
+    // journeys 14 and 60 do it.
+    const browserKey = testInfo.project.name
+      .replace('mentor-desktop-', '')
+      .toLowerCase();
+    const authFile = path.join(
+      __dirname,
+      `../../playwright/.auth/user-${browserKey}.json`,
+    );
+
+    const ctx = await browser.newContext({ storageState: authFile });
+    try {
+      const page = await ctx.newPage();
+
+      const mentorNextjsHost = process.env.MENTOR_NEXTJS_HOST || '';
+      if (mentorNextjsHost) {
+        // Navigate to the app to hydrate localStorage with dm_token etc.
+        try {
+          await page.goto(mentorNextjsHost, {
+            waitUntil: 'domcontentloaded',
+            timeout: 60_000,
+          });
+          // Wait until dm_token is available in localStorage (set by AuthProvider).
+          await page
+            .waitForFunction(() => !!window.localStorage.getItem('dm_token'), {
+              timeout: 30_000,
+            })
+            .catch(() => {
+              /* best-effort — proceed even if dm_token never shows up */
+            });
+        } catch {
+          // Navigation failure — proceed anyway, deleteMentorById will
+          // detect missing tokens and bail out gracefully.
+        }
+      }
+
+      for (const mentorId of this.ids) {
+        await deleteMentorById(page, mentorId);
+      }
+      this.ids.clear();
+    } catch (err) {
+      logger.warn(`[MentorTracker] deleteAll failed: ${err}`);
+    } finally {
+      await ctx.close().catch(() => {});
+    }
+  }
+}

--- a/e2e/utils/mentor-sweeper.ts
+++ b/e2e/utils/mentor-sweeper.ts
@@ -1,0 +1,307 @@
+/**
+ * Stale test-mentor sweeper — runs as Playwright `globalTeardown`.
+ *
+ * After every full test run this sweeper lists all mentors owned by the admin
+ * user and deletes any that:
+ *   1. Have a name matching the E2E test-created pattern (starts with "E2E "
+ *      and ends with a 13-digit Unix-millisecond timestamp), AND
+ *   2. Were created more than STALE_AFTER_MS ago (2 hours).
+ *
+ * The age gate guarantees that a concurrent/just-started run's mentors are
+ * never reaped — a freshly created mentor is at most a few seconds old, far
+ * below the 2-hour floor.
+ *
+ * SAFETY guarantees (mirrors lti-residue.ts):
+ *   • Only names matching E2E_MENTOR_RE are considered. Any seed mentor or
+ *     manually created mentor never matches.
+ *   • Only stale (> 2h) matches are deleted. A parallel run's live mentors
+ *     are never touched.
+ *   • The tenant always keeps ≥1 mentor: the default/seed mentor doesn't
+ *     match the regex, so it is never a candidate.
+ *   • Everything is best-effort: a failed delete is logged and skipped.
+ *     A sweep failure NEVER causes the Playwright process to exit non-zero.
+ *
+ * Auth: reads dm_token, username (user_nicename), and tenantKey (key) directly
+ * from the saved storageState JSON (`playwright/.auth/user-chrome.json`) so no
+ * live browser context is needed and globalTeardown stays fast.
+ *
+ * API used:
+ *   GET  {API_BASE}/dm/api/ai-mentor/orgs/{org}/users/{username}/?page=N
+ *   DELETE {API_BASE}/dm/api/ai-mentor/orgs/{org}/users/{username}/{mentorUniqueId}/
+ *   Authorization: Token {dm_token}
+ *
+ * Name pattern produced by `generateMentorName()` in test-data.ts:
+ *   "E2E Mentor 1720000000000"
+ * Name pattern used by journey 52 (after this fix):
+ *   "E2E Tool Call Test Mentor 1720000000000"
+ * Both match: /^E2E .+\b(\d{13})\b/
+ */
+
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import http from 'http';
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const STALE_AFTER_MS = 2 * 60 * 60 * 1000; // 2 hours
+const MAX_PAGES = 50; // cap page-walk to avoid runaway loops
+
+/**
+ * Matches test-created mentor names that embed a 13-digit timestamp.
+ * Examples:
+ *   "E2E Mentor 1720000000000"
+ *   "E2E Tool Call Test Mentor 1720000000000"
+ *   "E2E No-Tools Mentor 1720000000000"
+ * The captured group 1 is the timestamp string.
+ */
+export const E2E_MENTOR_RE = /^E2E .+\b(\d{13})\b/;
+
+// ── Auth extraction ───────────────────────────────────────────────────────────
+
+interface StorageEntry {
+  name: string;
+  value: string;
+}
+
+interface AuthContext {
+  dmToken: string;
+  username: string;
+  tenantKey: string;
+}
+
+function readAuthFromStorageState(
+  storageStatePath: string,
+): AuthContext | null {
+  try {
+    const raw = fs.readFileSync(storageStatePath, 'utf8');
+    const state: { origins?: Array<{ localStorage?: StorageEntry[] }> } =
+      JSON.parse(raw);
+    const allEntries: StorageEntry[] = (state.origins ?? []).flatMap(
+      (o) => o.localStorage ?? [],
+    );
+
+    const get = (key: string) =>
+      allEntries.find((e) => e.name === key)?.value ?? '';
+
+    const dmToken = get('dm_token');
+    if (!dmToken) return null;
+
+    let username = '';
+    try {
+      const ud = JSON.parse(get('userData'));
+      username = ud?.user_nicename ?? '';
+    } catch {
+      /* ignore */
+    }
+    if (!username) return null;
+
+    let tenantKey = '';
+    try {
+      const ct = JSON.parse(get('current_tenant'));
+      tenantKey = typeof ct === 'string' ? ct : (ct?.key ?? '');
+    } catch {
+      /* ignore */
+    }
+    if (!tenantKey) return null;
+
+    return { dmToken, username, tenantKey };
+  } catch {
+    return null;
+  }
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+function httpRequest(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const mod = parsed.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method,
+        headers,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+      },
+    );
+    req.on('error', reject);
+    req.setTimeout(20_000, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+    req.end();
+  });
+}
+
+// ── Mentor list type ──────────────────────────────────────────────────────────
+
+interface MentorListItem {
+  unique_id?: string;
+  name?: string;
+}
+
+interface MentorListResponse {
+  results?: MentorListItem[];
+  num_pages?: number;
+}
+
+// ── Sweeper logic ─────────────────────────────────────────────────────────────
+
+function isStale(name: string | undefined): boolean {
+  if (!name) return false;
+  const m = name.match(E2E_MENTOR_RE);
+  if (!m) return false;
+  return Date.now() - Number(m[1]) > STALE_AFTER_MS;
+}
+
+async function sweepStaleMentors(
+  apiBase: string,
+  auth: AuthContext,
+): Promise<void> {
+  const { dmToken, username, tenantKey } = auth;
+  const headers = {
+    Authorization: `Token ${dmToken}`,
+    Accept: 'application/json',
+  };
+
+  // DM API lives under the `/dm` path on the API base (see config.dmUrl()).
+  const baseListUrl = `${apiBase}/dm/api/ai-mentor/orgs/${encodeURIComponent(tenantKey)}/users/${encodeURIComponent(username)}/`;
+
+  let reaped = 0;
+  let skipped = 0;
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const listUrl = `${baseListUrl}?page=${page}&page_size=100`;
+    let res: { status: number; body: string };
+    try {
+      res = await httpRequest(listUrl, 'GET', headers);
+    } catch (err) {
+      console.warn(`[mentor-sweeper] GET page ${page} failed: ${err}`);
+      break;
+    }
+
+    if (res.status !== 200) {
+      if (res.status !== 404)
+        console.warn(
+          `[mentor-sweeper] GET page ${page} → ${res.status} — stopping`,
+        );
+      break;
+    }
+
+    let data: MentorListResponse | MentorListItem[];
+    try {
+      data = JSON.parse(res.body) as MentorListResponse | MentorListItem[];
+    } catch {
+      console.warn(`[mentor-sweeper] Failed to parse page ${page} response`);
+      break;
+    }
+
+    const items: MentorListItem[] = Array.isArray(data)
+      ? data
+      : (data.results ?? []);
+    const numPages: number = Array.isArray(data) ? 1 : (data.num_pages ?? 1);
+
+    for (const item of items) {
+      const name = item.name;
+      const uniqueId = item.unique_id;
+      if (!uniqueId) continue;
+
+      if (!isStale(name)) {
+        skipped++;
+        continue;
+      }
+
+      const deleteUrl = `${baseListUrl}${encodeURIComponent(uniqueId)}/`;
+      try {
+        const delRes = await httpRequest(deleteUrl, 'DELETE', headers);
+        if (
+          delRes.status === 204 ||
+          delRes.status === 200 ||
+          delRes.status === 404
+        ) {
+          console.log(
+            `[mentor-sweeper] Reaped mentor "${name}" (${uniqueId}) → ${delRes.status}`,
+          );
+          reaped++;
+        } else {
+          console.warn(
+            `[mentor-sweeper] DELETE ${uniqueId} → ${delRes.status} — skipping`,
+          );
+          skipped++;
+        }
+      } catch (err) {
+        console.warn(
+          `[mentor-sweeper] DELETE ${uniqueId} failed: ${err} — skipping`,
+        );
+        skipped++;
+      }
+    }
+
+    if (page >= numPages || items.length === 0) break;
+  }
+
+  console.log(
+    `[mentor-sweeper] Done — reaped ${reaped}, skipped/failed ${skipped}`,
+  );
+}
+
+// ── Playwright globalTeardown entry point ─────────────────────────────────────
+
+export default async function globalTeardown(): Promise<void> {
+  try {
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!apiBase) {
+      console.log(
+        '[mentor-sweeper] NEXT_PUBLIC_API_BASE_URL not set — skipping sweep',
+      );
+      return;
+    }
+
+    // Use the chrome admin storageState — always available after the admin
+    // setup project runs. Fall back to any available browser's auth file.
+    const authDir = path.join(__dirname, '../../playwright/.auth');
+    const candidates = [
+      'user-chrome.json',
+      'user-firefox.json',
+      'user-edge.json',
+      'user-safari.json',
+    ];
+    let auth: AuthContext | null = null;
+    for (const candidate of candidates) {
+      const filePath = path.join(authDir, candidate);
+      if (fs.existsSync(filePath)) {
+        auth = readAuthFromStorageState(filePath);
+        if (auth) {
+          console.log(
+            `[mentor-sweeper] Using auth from ${candidate} (user: ${auth.username}, tenant: ${auth.tenantKey})`,
+          );
+          break;
+        }
+      }
+    }
+
+    if (!auth) {
+      console.log(
+        '[mentor-sweeper] No valid admin auth found in storageState files — skipping sweep',
+      );
+      return;
+    }
+
+    await sweepStaleMentors(apiBase, auth);
+  } catch (err) {
+    // Best-effort — never let teardown failure affect the exit code.
+    console.warn(`[mentor-sweeper] Unexpected error: ${err}`);
+  }
+}


### PR DESCRIPTION
## Problem

E2E journeys create mentors/agents but mostly never delete them — ~400+ leak into the DB per full 4-browser run (journeys creating in `beforeEach` multiply by test count; journey 52 used fixed names that duplicate every run). Only journeys 14/60 (and partially 51) cleaned up.

## What this adds

**Cleanup that can only ever remove test-created mentors** — seed/default mentors and the tenant's last mentor are never touched.

- **`e2e/utils/mentor-cleanup.ts`** — `MentorTracker` + `deleteMentorById()` via the DM API (`DELETE {apiBase}/dm/api/ai-mentor/orgs/{org}/users/{username}/{id}/`, auth `Token {dm_token}`), best-effort; mirrors the existing `lti-residue.ts` reaper.
- **Per-suite `afterAll` cleanup** for journeys **22, 42, 44, 47, 52** — tracks each created mentor's id and deletes them at suite end. Deliberately **`afterAll`, not `afterEach`**, so shared-mentor suites (14/51/60) are untouched.
- **Journey 52** fixed names now carry a timestamp → unique per run and reapable by the sweeper.
- **`e2e/utils/mentor-sweeper.ts`** — `globalTeardown` that reaps **only stale** (`E2E … {13-digit ts}`, older than 2h) mentors, catching orphans from crashed tests without endangering seed or in-flight mentors. Wired via `playwright.config.ts`.
- **`cleanup.spec.ts`** hardened — only deletes the loaded mentor if its name matches the test-mentor pattern (can't nuke a seed).
- **`.claude/agents/playwright-e2e-engineer.md`** — new "Mentor Creation — Always Track & Clean Up" rule + a Quality-Checks gate, so future generated tests must use `MentorTracker`.

## Safety design (why it won't break other tests)

- Deletes only tracked ids — never a broad name sweep in a spec.
- `afterAll`/worker-teardown scope preserves shared-mentor suites.
- Never reduces the tenant to zero (which `navigateToMentorApp` depends on).
- All deletes best-effort (a failed cleanup never fails the run).

## ⚠️ Needs live validation

The DM mentor-delete **endpoint path** is validated against app usage (`hooks/use-speech.ts` uses the same `/dm/api/ai-mentor/orgs/{org}/users/{userId}/…` base), and I fixed a bug where the helpers were missing the `/dm` prefix (would have silently 404'd). But the **`DELETE` verb** couldn't be exercised against a real backend here — **the first CI/live run should confirm agents are actually deleted** (check the `[mentor-cleanup]`/`[mentor-sweeper]` logs). Best-effort means a wrong verb won't fail tests, just silently skip deletion.

## Scope

Covers the 4 worst offenders + sweeper + journey 52. The remaining ~11 leaking journeys can adopt the same `afterAll` pattern in a follow-up.

Pushed with `--no-verify` (author-authorized): pre-push suite passed (10,571 tests) but `git push` hit the recurring SIGPIPE-after-pass transport flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)