### PR TITLE
test(e2e): fixme journey-60 LTI key/tool tests blocked on a backend issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Documentation
 
-* **e2e-agent:** require MentorTracker cleanup for mentor-creating tests ([87e5166](https://github.com/iblai/os/commit/87e5166a89d970b7fbc60c87332c426c4f017ae9))
+- **e2e-agent:** require MentorTracker cleanup for mentor-creating tests ([87e5166](https://github.com/iblai/os/commit/87e5166a89d970b7fbc60c87332c426c4f017ae9))
 
 ### Tests
 
-* **e2e:** clean up agents created during tests to stop DB accumulation ([b29c8e8](https://github.com/iblai/os/commit/b29c8e87e7fcdd5f05607bff8d715c8fab7c1a37))
+- **e2e:** clean up agents created during tests to stop DB accumulation ([b29c8e8](https://github.com/iblai/os/commit/b29c8e87e7fcdd5f05607bff8d715c8fab7c1a37))
 
 ## [0.95.8](https://github.com/iblai/os/compare/v0.95.7...v0.95.8) (2026-07-14)
 

--- a/e2e/journeys/60-mentor-lti-tab.spec.ts
+++ b/e2e/journeys/60-mentor-lti-tab.spec.ts
@@ -463,84 +463,85 @@ test.describe('Journey 60 — LTI tab sub-resource tests', () => {
   // ── lti-10..lti-12: Keys sub-tab ──────────────────────────────────────────
 
   // lti-10: Create a key; detail shows non-empty public key + JWK.
-  test('admin creates an LTI key and the key detail shows non-empty public key and JWK', async ({
-    page,
-    editMentorPage,
-    ltiMentorUrl,
-  }) => {
-    test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
-    await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
-    await editMentorPage.lti.switchToSubTab('keys');
+  // FIXME: blocked on a backend issue (LTI keys/tools API) — re-enable once fixed.
+  test.fixme(
+    'admin creates an LTI key and the key detail shows non-empty public key and JWK',
+    async ({ page, editMentorPage, ltiMentorUrl }) => {
+      test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
+      await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
+      await editMentorPage.lti.switchToSubTab('keys');
 
-    const keyName = LtiTab.uniqueName('e2e-key');
-    try {
-      await editMentorPage.lti.createKey(keyName);
-      await editMentorPage.lti.expectKeyInList(keyName);
-      await editMentorPage.lti.openKeyDetail(keyName);
-      expect(
-        (await editMentorPage.lti.readKeyPublicKey()).trim().length,
-      ).toBeGreaterThan(0);
-      expect(
-        (await editMentorPage.lti.readKeyPublicJwk()).trim().length,
-      ).toBeGreaterThan(0);
-      await editMentorPage.page.keyboard.press('Escape');
-    } finally {
-      await editMentorPage.lti.deleteKey(keyName).catch(() => {});
-    }
+      const keyName = LtiTab.uniqueName('e2e-key');
+      try {
+        await editMentorPage.lti.createKey(keyName);
+        await editMentorPage.lti.expectKeyInList(keyName);
+        await editMentorPage.lti.openKeyDetail(keyName);
+        expect(
+          (await editMentorPage.lti.readKeyPublicKey()).trim().length,
+        ).toBeGreaterThan(0);
+        expect(
+          (await editMentorPage.lti.readKeyPublicJwk()).trim().length,
+        ).toBeGreaterThan(0);
+        await editMentorPage.page.keyboard.press('Escape');
+      } finally {
+        await editMentorPage.lti.deleteKey(keyName).catch(() => {});
+      }
 
-    await editMentorPage.close();
-  });
+      await editMentorPage.close();
+    },
+  );
 
   // lti-11: Rename a key.
-  test('admin renames an LTI key and the new name appears in the list', async ({
-    page,
-    editMentorPage,
-    ltiMentorUrl,
-  }) => {
-    test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
-    await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
-    await editMentorPage.lti.switchToSubTab('keys');
+  // FIXME: blocked on a backend issue (LTI keys/tools API) — re-enable once fixed.
+  test.fixme(
+    'admin renames an LTI key and the new name appears in the list',
+    async ({ page, editMentorPage, ltiMentorUrl }) => {
+      test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
+      await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
+      await editMentorPage.lti.switchToSubTab('keys');
 
-    const name = LtiTab.uniqueName('e2e-key-orig');
-    const renamed = LtiTab.uniqueName('e2e-key-renamed');
-    try {
-      await editMentorPage.lti.createKey(name);
-      await editMentorPage.lti.expectKeyInList(name);
-      await editMentorPage.lti.renameKey(name, renamed);
-      await editMentorPage.lti.expectKeyInList(renamed);
-      await editMentorPage.lti.expectKeyNotInList(name);
-    } finally {
-      await editMentorPage.lti.deleteKey(renamed).catch(() => {});
-    }
+      const name = LtiTab.uniqueName('e2e-key-orig');
+      const renamed = LtiTab.uniqueName('e2e-key-renamed');
+      try {
+        await editMentorPage.lti.createKey(name);
+        await editMentorPage.lti.expectKeyInList(name);
+        await editMentorPage.lti.renameKey(name, renamed);
+        await editMentorPage.lti.expectKeyInList(renamed);
+        await editMentorPage.lti.expectKeyNotInList(name);
+      } finally {
+        await editMentorPage.lti.deleteKey(renamed).catch(() => {});
+      }
 
-    await editMentorPage.close();
-  });
+      await editMentorPage.close();
+    },
+  );
 
   // lti-12: Delete a key.
-  test('admin deletes an LTI key and the key is no longer in the list', async ({
-    page,
-    editMentorPage,
-    ltiMentorUrl,
-  }) => {
-    test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
-    await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
-    await editMentorPage.lti.switchToSubTab('keys');
+  // FIXME: blocked on a backend issue (LTI keys/tools API) — re-enable once fixed.
+  test.fixme(
+    'admin deletes an LTI key and the key is no longer in the list',
+    async ({ page, editMentorPage, ltiMentorUrl }) => {
+      test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
+      await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
+      await editMentorPage.lti.switchToSubTab('keys');
 
-    const keyName = LtiTab.uniqueName('e2e-key-delete');
-    let present = false;
-    try {
-      await editMentorPage.lti.createKey(keyName);
-      present = true;
-      await editMentorPage.lti.expectKeyInList(keyName);
-      await editMentorPage.lti.deleteKey(keyName);
-      present = false;
-      await editMentorPage.lti.expectKeyNotInList(keyName);
-    } finally {
-      if (present) await editMentorPage.lti.deleteKey(keyName).catch(() => {});
-    }
+      const keyName = LtiTab.uniqueName('e2e-key-delete');
+      let present = false;
+      try {
+        await editMentorPage.lti.createKey(keyName);
+        present = true;
+        await editMentorPage.lti.expectKeyInList(keyName);
+        await editMentorPage.lti.deleteKey(keyName);
+        present = false;
+        await editMentorPage.lti.expectKeyNotInList(keyName);
+      } finally {
+        if (present)
+          await editMentorPage.lti.deleteKey(keyName).catch(() => {});
+      }
 
-    await editMentorPage.close();
-  });
+      await editMentorPage.close();
+    },
+  );
 
   // ── lti-13..lti-14: Tools sub-tab ─────────────────────────────────────────
 
@@ -579,43 +580,43 @@ test.describe('Journey 60 — LTI tab sub-resource tests', () => {
   });
 
   // lti-14: Create a tool with a JWKS URL signing config.
-  test('admin creates an LTI tool with a JWKS URL signing config and it appears in the tools list', async ({
-    page,
-    editMentorPage,
-    ltiMentorUrl,
-  }) => {
-    test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
-    await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
+  // FIXME: blocked on a backend issue (LTI keys/tools API) — re-enable once fixed.
+  test.fixme(
+    'admin creates an LTI tool with a JWKS URL signing config and it appears in the tools list',
+    async ({ page, editMentorPage, ltiMentorUrl }) => {
+      test.skip(!ltiMentorUrl, 'LTI mentor unavailable on this worker');
+      await openLtiTabOnSharedMentor(page, editMentorPage, ltiMentorUrl!);
 
-    const keyName = LtiTab.uniqueName('e2e-tool-key-url');
-    const toolTitle = LtiTab.uniqueName('e2e-tool-url');
-    try {
-      await editMentorPage.lti.switchToSubTab('keys');
-      await editMentorPage.lti.createKey(keyName);
-      await editMentorPage.lti.expectKeyInList(keyName);
+      const keyName = LtiTab.uniqueName('e2e-tool-key-url');
+      const toolTitle = LtiTab.uniqueName('e2e-tool-url');
+      try {
+        await editMentorPage.lti.switchToSubTab('keys');
+        await editMentorPage.lti.createKey(keyName);
+        await editMentorPage.lti.expectKeyInList(keyName);
 
-      await editMentorPage.lti.switchToSubTab('tools');
-      await editMentorPage.lti.createTool({
-        title: toolTitle,
-        issuer: 'https://lms.example.com',
-        clientId: `client-${toolTitle}`,
-        authLoginUrl: 'https://lms.example.com/lti/auth',
-        authTokenUrl: 'https://lms.example.com/lti/token',
-        keySetMode: 'url',
-        jwksUrl: 'https://lms.example.com/.well-known/jwks.json',
-        signingKeyName: keyName,
-      });
-      await editMentorPage.lti.expectToolInList(toolTitle);
-    } finally {
-      // No in-test cleanup is possible: tools and keys are PLATFORM-wide
-      // (they do NOT die with the worker mentor), the SDK exposes no
-      // delete-tool UI, and the key cannot be deleted while the tool
-      // references it. Both are uniquely named and reaped by
-      // `reapStaleLtiResidue` in the worker fixture once they are >2h old.
-    }
+        await editMentorPage.lti.switchToSubTab('tools');
+        await editMentorPage.lti.createTool({
+          title: toolTitle,
+          issuer: 'https://lms.example.com',
+          clientId: `client-${toolTitle}`,
+          authLoginUrl: 'https://lms.example.com/lti/auth',
+          authTokenUrl: 'https://lms.example.com/lti/token',
+          keySetMode: 'url',
+          jwksUrl: 'https://lms.example.com/.well-known/jwks.json',
+          signingKeyName: keyName,
+        });
+        await editMentorPage.lti.expectToolInList(toolTitle);
+      } finally {
+        // No in-test cleanup is possible: tools and keys are PLATFORM-wide
+        // (they do NOT die with the worker mentor), the SDK exposes no
+        // delete-tool UI, and the key cannot be deleted while the tool
+        // references it. Both are uniquely named and reaped by
+        // `reapStaleLtiResidue` in the worker fixture once they are >2h old.
+      }
 
-    await editMentorPage.close();
-  });
+      await editMentorPage.close();
+    },
+  );
 
   // NOTE: the raw-JWKS-JSON tool variant (formerly lti-15) is intentionally
   // not covered for now. The SDK's ToolModal submitted `key_set` as a parsed


### PR DESCRIPTION
## Why

Four LTI sub-resource tests in `e2e/journeys/60-mentor-lti-tab.spec.ts` are failing due to a **backend issue**, not a defect in the tests:

- `admin creates an LTI key and the key detail shows non-empty public key and JWK` (was L466)
- `admin renames an LTI key and the new name appears in the list` (L495)
- `admin deletes an LTI key and the key is no longer in the list` (L520)
- `admin creates an LTI tool with a JWKS URL signing config and it appears in the tools list` (L582)

## What

Marked all four as **`test.fixme`** (with a `// FIXME: blocked on a backend issue` comment), rather than `test.skip`.

**Why `fixme` over `skip`:** `test.skip` is for tests that don't *apply* in a context (env/role-gated). These tests are valid and should pass — they're temporarily broken by an external backend problem. `test.fixme` correctly signals "known-broken, re-enable once fixed," matches the project convention (the e2e engineer skill documents `fixme` for known-broken tests, and journey 51 already uses `describe.fixme`), and keeps them visible as tech-debt to revert.

## Notes

- Only the four affected tests are disabled; the rest of journey 60 (and its LTI mentor fixture/cleanup) is untouched.
- **`coverage.json` intentionally not changed** — these checkpoints are temporarily blocked, not permanently removed; they'll be re-enabled when the LTI API is fixed. Flag if you'd prefer them marked pending in coverage.
- Pushed with `--no-verify` (author-authorized) due to the recurring SIGPIPE-after-pass push flake.

**Action item:** revert the `test.fixme` markers once the LTI keys/tools backend issue is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)