### PR TITLE
Fix/2109 inline math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### CI
 
-* **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
+- **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
 
 ## [0.95.11](https://github.com/iblai/os/compare/v0.95.10...v0.95.11) (2026-07-15)
 
 ### Bug Fixes
 
-* chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
-* **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
-* upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
-* upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
+- chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
+- **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
+- upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
+- upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
 
 ### Chores
 
-* bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
-* **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
+- bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
+- **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
 
 ## [0.95.10](https://github.com/iblai/os/compare/v0.95.9...v0.95.10) (2026-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* **auth:** require a valid edx_jwt_token for a non-expired session ([53e961f](https://github.com/iblai/os/commit/53e961f7781167148ffb6c8acf963448c3da3ddd))
+- **auth:** require a valid edx_jwt_token for a non-expired session ([53e961f](https://github.com/iblai/os/commit/53e961f7781167148ffb6c8acf963448c3da3ddd))
 
 ## [0.95.7](https://github.com/iblai/os/compare/v0.95.6...v0.95.7) (2026-07-13)
 

--- a/components/__tests__/markdown.test.tsx
+++ b/components/__tests__/markdown.test.tsx
@@ -355,6 +355,43 @@ Show me your steps — write out each one just like I did above. 😊`;
     });
 
     /**
+     * Ambiguous delimiters must never reach KaTeX as a parse error.
+     *
+     * remark-math pairs `$` in runs of equal length, so `$a$$b$` is one span
+     * whose content is `a$$b` -- invalid TeX, rendered as a red error box. We
+     * decline to claim spans whose delimiters touch another `$`, so the run
+     * stays literal text instead of turning red.
+     */
+    it('should never render a red KaTeX error for ambiguous delimiters', () => {
+      const ambiguous = [
+        'Consecutive math: $a$$b$ and $x$ $y$',
+        'Double dollar inline: price is $$5 here.',
+        'Triple: $$$5',
+        'Only a dollar sign: $',
+        'Dollar then letter: $abc and $xyz',
+      ];
+      for (const md of ambiguous) {
+        const { container } = render(<Markdown>{md}</Markdown>);
+        expect(container.querySelectorAll('.katex-error')).toHaveLength(0);
+      }
+    });
+
+    /**
+     * The ambiguous run stays literal, while unambiguous neighbours on the
+     * same line still render as math.
+     */
+    it('should keep an ambiguous run literal without harming its neighbours', () => {
+      const { container } = render(
+        <Markdown>{'Consecutive math: $a$$b$ and $x$ $y$'}</Markdown>,
+      );
+      const tex = [...container.querySelectorAll('.katex annotation')].map(
+        (a) => a.textContent,
+      );
+      expect(tex).toEqual(['x', 'y']);
+      expect(container.textContent).toContain('$a$$b$');
+    });
+
+    /**
      * Test currency dollar sign handling
      * Verifies that dollar signs before digits are escaped and rendered as literal $
      */

--- a/components/__tests__/markdown.test.tsx
+++ b/components/__tests__/markdown.test.tsx
@@ -1,7 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import Markdown from '@/components/markdown';
 import { preprocessLaTeX } from '@/lib/utils';
+
+// A fenced block with a language renders the copy button, which reads route
+// params. Without this the syntax-highlighted branch cannot be tested at all.
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ tenantKey: 'test-tenant' }),
+  usePathname: () => '/platform/test-tenant/agent',
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 /**
  * Test suite for the Markdown component
@@ -115,9 +124,50 @@ describe('Markdown Component', () => {
     it('should render code blocks', () => {
       const markdown = '```javascript\nconst x = 10;\n```';
       const { container } = render(<Markdown>{markdown}</Markdown>);
-      // Check for code element
-      const code = container.querySelector('code');
-      expect(code).toBeTruthy();
+      // The whole block must survive as one unit. It used to be shredded into
+      // an inline span by the `` -> " quote rule, which collapsed the newlines
+      // and injected stray quote characters.
+      expect(container.textContent).toContain('const x = 10;');
+      expect(container.textContent).not.toContain('"javascript');
+      expect(container.textContent).not.toContain('```');
+    });
+
+    /**
+     * Fenced code is literal: no LaTeX/currency preprocessing may reach inside
+     * it. A `$5` in a code sample must not pick up an escaping backslash.
+     */
+    it('should not preprocess the contents of a fenced code block', () => {
+      const markdown = '```js\nconst price = "$5";\nconst total = "$10";\n```';
+      const { container } = render(<Markdown>{markdown}</Markdown>);
+      expect(container.textContent).toContain('"$5"');
+      expect(container.textContent).toContain('"$10"');
+      expect(container.textContent).not.toContain('\\$');
+    });
+
+    /**
+     * A plain fence (no language) takes the <pre><code> path.
+     */
+    it('should render a plain fence as a real pre/code block', () => {
+      const { container } = render(
+        <Markdown>{'```\nplain line one\nplain line two\n```'}</Markdown>,
+      );
+      const pre = container.querySelector('pre');
+      expect(pre).toBeTruthy();
+      expect(pre?.querySelector('code')).toBeTruthy();
+      expect(pre?.textContent).toContain('plain line one');
+      expect(pre?.textContent).toContain('plain line two');
+    });
+
+    /**
+     * Inline code is literal too -- `$5` must not gain a backslash.
+     */
+    it('should not preprocess the contents of inline code', () => {
+      const { container } = render(
+        <Markdown>{'Money in code: `$5` and `$x$` stay literal.'}</Markdown>,
+      );
+      expect(container.textContent).toContain('$5');
+      expect(container.textContent).not.toContain('\\$');
+      expect(container.querySelectorAll('code').length).toBe(2);
     });
 
     /**

--- a/components/__tests__/markdown.test.tsx
+++ b/components/__tests__/markdown.test.tsx
@@ -291,6 +291,54 @@ describe('Markdown Component', () => {
     });
 
     /**
+     * Regression test for issue #2109
+     * Backslash-free inline arithmetic like $3x + 5$ (and block $$...$$) must
+     * render as KaTeX rather than leaking raw $ / $$ delimiters as plain text.
+     */
+    it('should render backslash-free inline and block math from the issue repro', () => {
+      const repro = `No worries at all — that's exactly why we warm up before diving into something new! Let me walk you through it.
+
+In Lesson 1.1.3 you learned that when you *evaluate* an expression, you replace the variable with a number. The expression $3x + 5$ has two parts: the term $3x$ and the constant $5$. When we substitute $x = 4$, we replace the $x$ with $4$.
+
+Here's how it works step by step:
+
+$$3x + 5$$
+
+Replace $x$ with $4$:
+
+$$3(4) + 5$$
+
+Multiply first (multiplication comes before addition):
+
+$$12 + 5$$
+
+Then add:
+
+$$17$$
+
+So $3x + 5 = 17$ when $x = 4$.
+
+The key move is always the same: swap the variable out for the number, then simplify using the order of operations — multiply and divide before you add and subtract.
+
+Now let's make sure that landed. Try this one on your own:
+
+If $x = 3$, what is the value of $2x + 6$?
+
+Show me your steps — write out each one just like I did above. 😊`;
+
+      const { container } = render(<Markdown>{repro}</Markdown>);
+
+      // Inline math ($3x + 5$, $3x$, $5$, ...) and block math ($$...$$, $$17$$)
+      // both produce KaTeX output. The repro has many math spans, so a healthy
+      // count confirms both inline and single-token block math ($$17$$) render.
+      expect(container.querySelector('.katex')).toBeTruthy();
+      expect(container.querySelectorAll('.katex').length).toBeGreaterThan(10);
+      // No raw math delimiters should leak into the visible text.
+      expect(container.textContent).not.toContain('$$');
+      expect(container.textContent).not.toContain('$');
+    });
+
+    /**
      * Test currency dollar sign handling
      * Verifies that dollar signs before digits are escaped and rendered as literal $
      */

--- a/components/__tests__/markdown.test.tsx
+++ b/components/__tests__/markdown.test.tsx
@@ -93,6 +93,22 @@ describe('Markdown Component', () => {
     });
 
     /**
+     * A list item that is itself a scroll container clips its own marker, so
+     * every bullet and number disappears. The overflow has to live on a
+     * wrapper inside the <li>, never on the <li>.
+     */
+    it('should not make list items scroll containers (markers stay visible)', () => {
+      const { container } = render(
+        <Markdown>{'1. First item\n2. Second item'}</Markdown>,
+      );
+      for (const li of container.querySelectorAll('li')) {
+        expect(li.className ?? '').not.toMatch(/overflow/);
+        // wide content still gets a scroll container, just inside the li
+        expect(li.querySelector('.overflow-x-auto')).toBeTruthy();
+      }
+    });
+
+    /**
      * Test code block rendering
      * Verifies that code blocks are properly rendered with syntax highlighting
      */

--- a/components/markdown/__tests__/markdown-components.test.tsx
+++ b/components/markdown/__tests__/markdown-components.test.tsx
@@ -325,7 +325,7 @@ describe('Markdown Components', () => {
   describe('li component', () => {
     const Li = components.li!;
 
-    it('should render li with styling', () => {
+    it('should render li with the scroll container inside it', () => {
       const { container } = render(
         <ul>
           <Li node={{} as any}>List item</Li>
@@ -333,7 +333,13 @@ describe('Markdown Components', () => {
       );
       const li = container.querySelector('li');
       expect(li).toBeTruthy();
-      expect(li?.className).toContain('overflow-x-auto');
+      expect(li?.textContent).toBe('List item');
+      // The li must not be a scroll container itself: that clips its own
+      // marker and hides every bullet and number. Wide content still scrolls,
+      // via a wrapper inside the li.
+      expect(li?.className ?? '').not.toContain('overflow');
+      const wrapper = li?.querySelector(':scope > div');
+      expect(wrapper?.className).toContain('overflow-x-auto');
     });
   });
 

--- a/components/markdown/markdown-components.tsx
+++ b/components/markdown/markdown-components.tsx
@@ -114,7 +114,14 @@ export const components: Components = {
     <ol {...props} className="my-6 ml-6 list-decimal [&>li]:mt-2" />
   ),
 
-  li: ({ node, ...props }) => <li {...props} className="overflow-x-auto" />,
+  // The scroll container has to be inside the <li>: a list item that is itself
+  // a scroll container clips its own marker, which hides every bullet and
+  // number. Wide content (long equations) still scrolls via the wrapper.
+  li: ({ node, children, ...props }) => (
+    <li {...props}>
+      <div className="overflow-x-auto">{children}</div>
+    </li>
+  ),
 
   code: ({ node, ...props }) => {
     const match = /language-(\w+)/.exec(props.className || '');

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-07-08 | 545 checkpoints (519 covered, 7 pending/fixme, 7 not-reproducible in default env, 12 deprecated) | 62 journeys (61 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-07-14 | 550 checkpoints (524 covered, 7 pending/fixme, 7 not-reproducible in default env, 12 deprecated) | 63 journeys (62 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -1095,5 +1095,23 @@ Sub-resource tests (Links / Keys / Tools) still require `is_lti_accessible=true`
 ### SDK-pending (lti-sdk-01)
 
 - [ ] lti-sdk-01: PENDING (SDK dependency) — When an admin creates the first LTI link, `is_lti_accessible` is auto-enabled via the API without requiring the "Enable LTI launches" toggle to be turned on manually. Not yet implemented: `AgentLtiTab` exposes no post-create callback hook and there are no public LTI data-layer hooks in `@iblai/iblai-js`.
+
+---
+
+## Journey 61: LaTeX / Math Rendering (5 checkpoints) — `journeys/61-latex-math-rendering.spec.ts`
+
+**Source files:** `lib/utils.ts`, `components/markdown.tsx`
+
+Covers the fix for GitHub issue #2109 ("Improve latex compatibility for rendering chat messages and artifacts"). `preprocessLaTeX` (`lib/utils.ts`) escapes a `$` immediately followed by a digit into `\$` so currency amounts render literally — but that same escape corrupted backslash-free / digit-leading inline math like `$3x + 5$` and `$x = 4$`, and a leading currency amount could swallow the opening `$` of a real math span later on the same line. The fix adds an `isInlineMath` predicate (a `$...$` span is math when it has a backslash command OR no 2+ letter prose word inside it) and a rewind scan (a non-math span only consumes its opening `$`, leaving the closing `$` free to open a later real math span).
+
+**Deterministic seam:** live chat streams over a raw WebSocket (`useChat` in `@iblai/web-utils`), which has no practical Playwright route-mocking seam without reimplementing the wire protocol. Instead this journey drives the public "shared chat" page (`app/share/chat/[sessionId]/[tenantKey]/[mentorId]/page.tsx`), which fetches message history over a plain REST GET (`.../sessions/{sessionId}/shared/`) and renders it through the exact same `ChatMessages` → `AIMessageBubble` → `MessagePreview` → `<Markdown>` component tree as live chat. `ChatPage.mockSharedChatSession` intercepts that GET with `page.route` and injects a FIXED assistant markdown message, so every assertion is against real KaTeX/react-markdown rendering of known-in-advance content — no LLM in the loop, no flakiness from varying model output.
+
+Note: `remark-math` only classifies a `$$...$$` span as block/display math when its delimiters each sit alone on their own line (confirmed by direct probing against this build) — a single-line `$$3x + 5$$` renders as inline `.katex` inside a `<p>`. The block-math checkpoint (latex-02) uses the "own-line fence" form, which is also how LLMs naturally emit standalone equations.
+
+- [x] latex-01: Inline LaTeX math (`$3x + 5$`, `$x = 4$`, `$2x + 6$`, `$3(4) + 5$`) renders as KaTeX with no raw dollar signs or escape backslashes leaking into the visible text
+- [x] latex-02: Block LaTeX math (`$$...$$` on its own fenced lines) renders as KaTeX display blocks (`.katex-display`), including a `\text{}`/`\frac{}` expression
+- [x] latex-03: Currency amounts ("I have $5 and $10, it costs $5, and the total is $3.50.") stay literal text with no KaTeX rendering and no visible escape backslash
+- [x] latex-04: Money then math on the same line ("the kit costs $12, and the formula $3x + 5$ gives the price.") keeps `$12` literal while `$3x + 5$` renders as KaTeX
+- [x] latex-05: Math then money on the same line ("since $2x = 8$, each unit is $8 and the pair is $16.") renders `$2x = 8$`as KaTeX while`$8`and`$16` stay literal
 
 ---

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "lastUpdated": "2026-07-08",
+  "lastUpdated": "2026-07-14",
   "summary": {
-    "totalCheckpoints": 545,
-    "coveredCheckpoints": 519,
+    "totalCheckpoints": 550,
+    "coveredCheckpoints": 524,
     "deprecatedCheckpoints": 12,
     "notReproducibleCheckpoints": 7,
     "pendingCheckpoints": 7,
     "percent": 100,
-    "totalJourneys": 62,
-    "activeJourneys": 61
+    "totalJourneys": 63,
+    "activeJourneys": 62
   },
   "journeys": [
     {
@@ -3505,6 +3505,39 @@
           "id": "lti-sdk-01",
           "description": "PENDING (SDK dependency): When an admin creates the first LTI link, is_lti_accessible is auto-enabled via the API — not yet implemented; AgentLtiTab exposes no post-create callback hook",
           "status": "pending"
+        }
+      ]
+    },
+    {
+      "id": "latex-math-rendering",
+      "name": "LaTeX / Math Rendering",
+      "spec": "61-latex-math-rendering.spec.ts",
+      "sourceFiles": ["lib/utils.ts", "components/markdown.tsx"],
+      "checkpoints": [
+        {
+          "id": "latex-01",
+          "description": "Inline LaTeX math (e.g. $3x + 5$, $x = 4$, $2x + 6$, $3(4) + 5$) renders as KaTeX with no raw dollar signs or escape backslashes leaking into the visible text",
+          "status": "covered"
+        },
+        {
+          "id": "latex-02",
+          "description": "Block LaTeX math ($$...$$ on its own fenced lines) renders as KaTeX display blocks (.katex-display), including a \\text{}/\\frac{} expression",
+          "status": "covered"
+        },
+        {
+          "id": "latex-03",
+          "description": "Currency amounts (e.g. \"I have $5 and $10, it costs $5, and the total is $3.50.\") stay literal text with no KaTeX rendering and no visible escape backslash",
+          "status": "covered"
+        },
+        {
+          "id": "latex-04",
+          "description": "Money then math on the same line (\"the kit costs $12, and the formula $3x + 5$ gives the price.\") keeps $12 literal while $3x + 5$ renders as KaTeX",
+          "status": "covered"
+        },
+        {
+          "id": "latex-05",
+          "description": "Math then money on the same line (\"since $2x = 8$, each unit is $8 and the pair is $16.\") renders $2x = 8$ as KaTeX while $8 and $16 stay literal",
+          "status": "covered"
         }
       ]
     }

--- a/e2e/journeys/61-latex-math-rendering.spec.ts
+++ b/e2e/journeys/61-latex-math-rendering.spec.ts
@@ -1,0 +1,268 @@
+import { test, expect } from '../fixtures/mentor-test';
+import { navigateToMentorApp, getPlatformContext } from '../utils/auth';
+import { MENTOR_NEXTJS_HOST } from '../fixtures/test-data';
+
+/**
+ * Journey 61: LaTeX / Math Rendering
+ *
+ * Covers the fix for GitHub issue #2109 ("Improve latex compatibility for
+ * rendering chat messages and artifacts"). The bug: `preprocessLaTeX`
+ * (`lib/utils.ts`) escapes a `$` immediately followed by a digit into `\$`
+ * so currency amounts render literally (e.g. "I have $5") — but that same
+ * escape was corrupting backslash-free / digit-leading inline math like
+ * `$3x + 5$` and `$x = 4$`, and a leading currency amount could swallow the
+ * opening `$` of a real math span later on the same line.
+ *
+ * The fix adds:
+ *   1. A predicate (`isInlineMath`): a `$...$` span is math when it has a
+ *      backslash command OR no 2+ letter prose word inside it.
+ *   2. A rewind scan: when a span is judged NOT math, only the opening `$`
+ *      is consumed, so a following real math span's delimiter survives.
+ *
+ * Deterministic seam: live chat streams over a raw WebSocket
+ * (`useChat` in `@iblai/web-utils`), which has no practical Playwright
+ * route-mocking seam without reimplementing the wire protocol. Instead this
+ * journey drives the public "shared chat" page
+ * (`app/share/chat/[sessionId]/[tenantKey]/[mentorId]/page.tsx`), which
+ * fetches message history over a plain REST GET
+ * (`.../sessions/{sessionId}/shared/`) and renders it through the exact same
+ * `ChatMessages` -> `AIMessageBubble` -> `MessagePreview` -> `<Markdown>`
+ * component tree as live chat. `ChatPage.mockSharedChatSession` intercepts
+ * that GET with `page.route` and injects a FIXED assistant markdown message,
+ * so every assertion below is against real KaTeX/react-markdown rendering of
+ * known-in-advance content — no LLM in the loop, no flakiness from varying
+ * model output.
+ */
+test.describe('Journey 61: LaTeX / Math Rendering', () => {
+  // Run this journey's tests serially on a single worker. Each test's setup
+  // navigates the real app with the shared admin storageState; letting the
+  // five tests race across parallel workers had them hit the backend with the
+  // same admin JWT simultaneously, which intermittently failed the app shell
+  // load (`Selected agent dropdown button` never appearing). Serial keeps a
+  // single warmed session — combined with the cached platform context below,
+  // the app login happens exactly once for the whole journey.
+  test.describe.configure({ mode: 'serial' });
+
+  let tenantKey = '';
+  let mentorId = '';
+
+  // Resolve the (constant) admin tenant + mentor once per worker rather than
+  // once per test. `navigateToMentorApp` is a full real-backend SSO login;
+  // running it in every `beforeEach` put 5+ concurrent logins on the auth
+  // service (×N under --repeat-each), which starved the local prod server and
+  // made the shared-chat bubble render race past its wait — a load-induced
+  // flake. The shared-chat page under test is fully network-mocked and auth
+  // rides on the saved storageState, so tests after the first only need the
+  // cached ids. `tenantKey`/`mentorId` persist across tests within a worker.
+  test.beforeEach(async ({ page, chatPage }) => {
+    if (!tenantKey || !mentorId) {
+      await navigateToMentorApp(page);
+      ({ tenantKey, mentorId } = await getPlatformContext(page));
+    }
+    void chatPage;
+  });
+
+  test('admin views a shared chat message with inline math and it renders as KaTeX with no raw dollar signs', async ({
+    page,
+    chatPage,
+  }) => {
+    const content =
+      'Solving for x: $3x + 5$ is the expression, $x = 4$ is one solution, ' +
+      '$2x + 6$ is another form, and $3(4) + 5$ shows substitution.';
+
+    const sessionId = await chatPage.mockSharedChatSession(
+      tenantKey,
+      mentorId,
+      content,
+    );
+    await chatPage.gotoSharedChat(
+      MENTOR_NEXTJS_HOST,
+      sessionId,
+      tenantKey,
+      mentorId,
+    );
+
+    const aiMessage = await chatPage.waitForAiMessageWithText('Solving for x:');
+
+    const math = chatPage.getRenderedMath(aiMessage);
+    await expect(math).toHaveCount(4, { timeout: 15_000 });
+
+    // The raw, undelimited-by-KaTeX source must not leak through as plain
+    // text — that's exactly the bug: `$3x` mangled into `\$3x`.
+    const bubbleText = await aiMessage.innerText();
+    expect(bubbleText).not.toContain('$3x + 5$');
+    expect(bubbleText).not.toContain('$x = 4$');
+    expect(bubbleText).not.toContain('$2x + 6$');
+    expect(bubbleText).not.toContain('$3(4) + 5$');
+    expect(bubbleText).not.toMatch(/\\\$/);
+  });
+
+  test('admin views a shared chat message with block math and it renders as KaTeX display blocks', async ({
+    page,
+    chatPage,
+  }) => {
+    // `remark-math` only classifies a `$$...$$` span as BLOCK (display) math
+    // when the delimiters each sit alone on their own line — confirmed by
+    // probing this exact build: a single-line `$$3x + 5$$` renders as
+    // inline `.katex` inside a `<p>` (no `.katex-display`), while the
+    // "own-line fence" form below renders `<span class="katex-display">`
+    // with `display="block"` in the MathML. This is also the form LLMs
+    // naturally emit for standalone equations, so it's the realistic case
+    // for the "block math" checkpoint.
+    const content = [
+      '$$',
+      '3x + 5',
+      '$$',
+      '',
+      '$$',
+      '17',
+      '$$',
+      '',
+      '$$',
+      '0.075 \\text{ L} \\times \\frac{1000 \\text{ mL}}{1 \\text{ L}} = 75 \\text{ mL}',
+      '$$',
+    ].join('\n');
+
+    const sessionId = await chatPage.mockSharedChatSession(
+      tenantKey,
+      mentorId,
+      content,
+    );
+    await chatPage.gotoSharedChat(
+      MENTOR_NEXTJS_HOST,
+      sessionId,
+      tenantKey,
+      mentorId,
+    );
+
+    // '17' is a unique rendered marker across the three equations (does not
+    // appear as a substring of "0.075", "1000", or "3x + 5").
+    const aiMessage = await chatPage.waitForAiMessageWithText('17');
+
+    const blockMath = chatPage.getRenderedBlockMath(aiMessage);
+    await expect(blockMath).toHaveCount(3, { timeout: 15_000 });
+
+    const mathSource = await chatPage
+      .getRenderedMathSource(aiMessage)
+      .allTextContents();
+    expect(mathSource.some((s) => s.replace(/\s+/g, '') === '3x+5')).toBe(true);
+    expect(mathSource.some((s) => s.replace(/\s+/g, '') === '17')).toBe(true);
+    expect(mathSource.some((s) => s.includes('75') && s.includes('mL'))).toBe(
+      true,
+    );
+
+    const bubbleText = await aiMessage.innerText();
+    expect(bubbleText).not.toContain('$$3x + 5$$');
+    expect(bubbleText).not.toContain('$$17$$');
+    expect(bubbleText).not.toMatch(/\\\$/);
+  });
+
+  test('admin views a shared chat message with currency amounts and they stay literal text, not KaTeX', async ({
+    page,
+    chatPage,
+  }) => {
+    const content = 'I have $5 and $10, it costs $5, and the total is $3.50.';
+
+    const sessionId = await chatPage.mockSharedChatSession(
+      tenantKey,
+      mentorId,
+      content,
+    );
+    await chatPage.gotoSharedChat(
+      MENTOR_NEXTJS_HOST,
+      sessionId,
+      tenantKey,
+      mentorId,
+    );
+
+    const aiMessage = await chatPage.waitForAiMessageWithText('$3.50');
+
+    // No math should have been detected at all.
+    await expect(chatPage.getRenderedMath(aiMessage)).toHaveCount(0, {
+      timeout: 15_000,
+    });
+
+    const bubbleText = await aiMessage.innerText();
+    expect(bubbleText).toContain('$5');
+    expect(bubbleText).toContain('$10');
+    expect(bubbleText).toContain('$3.50');
+    // The escape backslash itself must never be visible to the user.
+    expect(bubbleText).not.toMatch(/\\\$/);
+  });
+
+  test('admin views a shared chat message mixing currency and math on the same line — money first, then math', async ({
+    page,
+    chatPage,
+  }) => {
+    const content =
+      'the kit costs $12, and the formula $3x + 5$ gives the price.';
+
+    const sessionId = await chatPage.mockSharedChatSession(
+      tenantKey,
+      mentorId,
+      content,
+    );
+    await chatPage.gotoSharedChat(
+      MENTOR_NEXTJS_HOST,
+      sessionId,
+      tenantKey,
+      mentorId,
+    );
+
+    const aiMessage = await chatPage.waitForAiMessageWithText('$12');
+
+    // Exactly one math expression ($3x + 5$); $12 stays literal.
+    await expect(chatPage.getRenderedMath(aiMessage)).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    const mathSource = await chatPage
+      .getRenderedMathSource(aiMessage)
+      .allTextContents();
+    expect(mathSource.some((s) => s.replace(/\s+/g, '') === '3x+5')).toBe(true);
+
+    const bubbleText = await aiMessage.innerText();
+    expect(bubbleText).toContain('$12');
+    expect(bubbleText).not.toContain('$3x + 5$');
+    expect(bubbleText).not.toMatch(/\\\$/);
+  });
+
+  test('admin views a shared chat message mixing currency and math on the same line — math first, then money', async ({
+    page,
+    chatPage,
+  }) => {
+    const content = 'since $2x = 8$, each unit is $8 and the pair is $16.';
+
+    const sessionId = await chatPage.mockSharedChatSession(
+      tenantKey,
+      mentorId,
+      content,
+    );
+    await chatPage.gotoSharedChat(
+      MENTOR_NEXTJS_HOST,
+      sessionId,
+      tenantKey,
+      mentorId,
+    );
+
+    // '$16' is a unique literal marker (unlike '$8', which is a substring of
+    // neither other amount but is worth avoiding for clarity of intent).
+    const aiMessage = await chatPage.waitForAiMessageWithText('$16');
+
+    // Exactly one math expression ($2x = 8$); $8 and $16 stay literal.
+    await expect(chatPage.getRenderedMath(aiMessage)).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    const mathSource = await chatPage
+      .getRenderedMathSource(aiMessage)
+      .allTextContents();
+    expect(mathSource.some((s) => s.replace(/\s+/g, '') === '2x=8')).toBe(true);
+
+    const bubbleText = await aiMessage.innerText();
+    expect(bubbleText).toContain('$8');
+    expect(bubbleText).toContain('$16');
+    expect(bubbleText).not.toContain('$2x = 8$');
+    expect(bubbleText).not.toMatch(/\\\$/);
+  });
+});

--- a/e2e/page-objects/chat.page.ts
+++ b/e2e/page-objects/chat.page.ts
@@ -211,6 +211,133 @@ export class ChatPage {
     }, mentorId);
   }
 
+  // ── Deterministic message rendering via the shared-chat REST seam ──────────
+  //
+  // Journey 61 (LaTeX/math rendering) needs a FIXED assistant markdown
+  // response to assert on, without depending on a real (non-deterministic)
+  // LLM reply. Live chat is delivered over a raw WebSocket
+  // (`useChat({ wsUrl, ... })` in `@iblai/web-utils`), which Playwright can
+  // only intercept via `page.routeWebSocket()` — impractical here because it
+  // would require re-implementing the app's whole streaming/artifact wire
+  // protocol.
+  //
+  // Instead we use the public "shared chat" page
+  // (`app/share/chat/[sessionId]/[tenantKey]/[mentorId]/page.tsx`), which
+  // fetches message history over a plain REST GET
+  // (`useGetChatMessagesForSessionQuery` ->
+  // `GET /api/ai-mentor/orgs/{org}/users/{user_id}/sessions/{session_id}/shared/`)
+  // and renders it through `ChatMessages` -> `AIMessageBubble` ->
+  // `MessagePreview` -> `<Markdown>` — the EXACT same component tree (and
+  // `.chat-ai-message-response` / `.chat-user-message-query` classes) as live
+  // chat. Mocking that one GET with `page.route` gives byte-for-byte control
+  // over the rendered markdown while exercising the real renderer.
+  //
+  // Raw message shape (see `hooks/use-shared-chat-messages.ts` ->
+  // `transformChatMessage`): `type: 'human'` becomes role `user`, anything
+  // else (e.g. `'ai'`) becomes role `assistant`. The `content` field is
+  // passed straight through to `<Markdown>`.
+
+  /**
+   * Intercepts the shared-chat-history GET for a synthetic `sessionId` and
+   * fulfills it with a single fixed assistant message containing `content`.
+   * Returns the generated `sessionId` to use with `gotoSharedChat`.
+   */
+  async mockSharedChatSession(
+    tenantKey: string,
+    mentorId: string,
+    content: string,
+  ): Promise<string> {
+    const sessionId = `e2e-latex-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await this.page.route(
+      `**/api/ai-mentor/orgs/*/users/*/sessions/${sessionId}/shared/**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            count: 1,
+            title: 'E2E LaTeX rendering test',
+            is_shared: true,
+            proactive_prompt: '',
+            mentor_unique_id: mentorId,
+            platform_key: tenantKey,
+            previous: null,
+            next: null,
+            results: [
+              {
+                id: `e2e-msg-${Date.now()}`,
+                type: 'ai',
+                content,
+                timestamp: new Date().toISOString(),
+              },
+            ],
+          }),
+        });
+      },
+    );
+    return sessionId;
+  }
+
+  /**
+   * Navigates to the shared-chat page for `sessionId`/`tenantKey`/`mentorId`.
+   * Pair with `mockSharedChatSession` — the route must be registered first.
+   */
+  async gotoSharedChat(
+    host: string,
+    sessionId: string,
+    tenantKey: string,
+    mentorId: string,
+  ): Promise<void> {
+    await this.page.goto(
+      `${host}/share/chat/${sessionId}/${tenantKey}/${mentorId}`,
+      { waitUntil: 'domcontentloaded', timeout: 60_000 },
+    );
+  }
+
+  /** Returns the most recently rendered AI message bubble. */
+  getLastAiMessage(): Locator {
+    return this.aiMessages.last();
+  }
+
+  /**
+   * Returns the AI message bubble containing `text`, and waits for it to be
+   * visible. Prefer this over `getLastAiMessage()` + a bare visibility check
+   * when the bubble's content is known in advance (e.g. an injected mock
+   * message) — asserting on distinctive rendered text is a stronger,
+   * web-first signal that the real content has mounted than asserting
+   * visibility of a `.chat-ai-message-response` container alone, which
+   * could in principle match a transient/placeholder render first.
+   */
+  async waitForAiMessageWithText(
+    text: string,
+    timeout = 30_000,
+  ): Promise<Locator> {
+    const message = this.aiMessages.filter({ hasText: text });
+    await expect(message).toBeVisible({ timeout });
+    return message;
+  }
+
+  /** Returns all rendered KaTeX nodes (inline + block) within `scope`. */
+  getRenderedMath(scope?: Locator): Locator {
+    return (scope ?? this.page).locator('.katex');
+  }
+
+  /** Returns all rendered KaTeX *block* (display-mode) nodes within `scope`. */
+  getRenderedBlockMath(scope?: Locator): Locator {
+    return (scope ?? this.page).locator('.katex-display');
+  }
+
+  /**
+   * Returns the raw TeX source annotations KaTeX embeds for each rendered
+   * expression (`<annotation encoding="application/x-tex">`) — useful for
+   * asserting *which* expression rendered, not just that something did.
+   */
+  getRenderedMathSource(scope?: Locator): Locator {
+    return (scope ?? this.page).locator(
+      '.katex annotation[encoding="application/x-tex"]',
+    );
+  }
+
   /** Deletes the nth prompt (0-indexed) from the Prompt Gallery. */
   async deletePromptFromGallery(index = 0): Promise<void> {
     const deleteButton = this.getPromptGalleryDeleteButtons().nth(index);

--- a/hooks/__tests__/use-shared-chat-messages.test.ts
+++ b/hooks/__tests__/use-shared-chat-messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import {
+  normalizeMessageContent,
   transformArtifactVersions,
   transformChatMessage,
   transformChatResults,
@@ -126,6 +127,87 @@ describe('transformArtifactVersions', () => {
       current_version_number: undefined,
       version_count: undefined,
     });
+  });
+});
+
+describe('normalizeMessageContent', () => {
+  it('passes a plain string through unchanged', () => {
+    expect(normalizeMessageContent('I have $5 and $10.')).toBe(
+      'I have $5 and $10.',
+    );
+  });
+
+  it('flattens the array of content blocks the API sends for assistant replies', () => {
+    // Real shape from the shared-session endpoint.
+    expect(
+      normalizeMessageContent([
+        { index: 0, type: 'text', text: 'Evaluate $3x + 5$ at $x = 4$.' },
+      ]),
+    ).toBe('Evaluate $3x + 5$ at $x = 4$.');
+  });
+
+  it('joins multiple text blocks', () => {
+    expect(
+      normalizeMessageContent([
+        { index: 0, type: 'text', text: 'First part.' },
+        { index: 1, type: 'text', text: 'Second part.' },
+      ]),
+    ).toBe('First part.\n\nSecond part.');
+  });
+
+  it('drops non-text blocks from a reply that used tools', () => {
+    // A tool-using reply interleaves tool plumbing between the prose blocks;
+    // none of it has a `text` field and none of it should render.
+    expect(
+      normalizeMessageContent([
+        { index: 0, type: 'text', text: 'Let me draw that.' },
+        {
+          index: 1,
+          type: 'server_tool_use',
+          id: 'srvtoolu_1',
+          name: 'bash_code_execution',
+          input: {},
+          partial_json: '{"command": "python3 plot.py"}',
+        },
+        {
+          index: 2,
+          type: 'bash_code_execution_tool_result',
+          tool_use_id: 'srvtoolu_1',
+          content: { stdout: 'Saved.\n', return_code: 0 },
+        },
+        { index: 3, type: 'text', text: 'There is the picture.' },
+      ]),
+    ).toBe('Let me draw that.\n\nThere is the picture.');
+  });
+
+  it('returns an empty string for missing or unexpected content', () => {
+    expect(normalizeMessageContent(undefined)).toBe('');
+    expect(normalizeMessageContent(null)).toBe('');
+    expect(normalizeMessageContent([])).toBe('');
+    expect(normalizeMessageContent(42)).toBe('');
+    expect(normalizeMessageContent([null, { type: 'text' }])).toBe('');
+  });
+});
+
+describe('transformChatMessage', () => {
+  it('normalizes array content so downstream .trim() cannot throw', () => {
+    // The shared endpoint returns assistant content as blocks. Consumers call
+    // `(message.content ?? '').trim()`, which throws on an array and takes the
+    // whole shared chat down with it.
+    const message = transformChatMessage({
+      type: 'ai',
+      content: [{ index: 0, type: 'text', text: 'Evaluate $3x + 5$.' }],
+    });
+    expect(message.content).toBe('Evaluate $3x + 5$.');
+    expect(() => (message.content ?? '').trim()).not.toThrow();
+  });
+
+  it('leaves human string content alone', () => {
+    const message = transformChatMessage({
+      type: 'human',
+      content: 'What is $3x + 5$ at $x = 4$?',
+    });
+    expect(message.content).toBe('What is $3x + 5$ at $x = 4$?');
   });
 });
 

--- a/hooks/use-shared-chat-messages.ts
+++ b/hooks/use-shared-chat-messages.ts
@@ -9,6 +9,8 @@ type TransformedMessage = {
   id?: string;
   type?: string;
   role: 'user' | 'assistant';
+  // Always a string once transformed, whatever shape the API sent.
+  content: string;
   visible: boolean;
   artifactVersions?: TransformedArtifactVersion[];
   [key: string]: unknown;
@@ -87,11 +89,42 @@ export function transformArtifactVersions(
   }));
 }
 
+/**
+ * Flattens a message's `content` to the text it actually says.
+ *
+ * Human messages arrive as a plain string, but assistant messages arrive as an
+ * array of content blocks — `[{ type: 'text', text: '…' }]` — and a reply that
+ * used tools carries non-text blocks (`server_tool_use`, tool results) between
+ * the text ones. Everything downstream assumes a string: the Markdown renderer
+ * returns '' for a non-string, and the `content.trim()` checks that gate the
+ * typing indicator throw outright, which takes down the whole shared chat.
+ *
+ * Blocks without text are dropped: they carry tool-call plumbing, not prose.
+ */
+export function normalizeMessageContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((block) =>
+      block && typeof block === 'object' && typeof block.text === 'string'
+        ? block.text
+        : '',
+    )
+    .filter(Boolean)
+    .join('\n\n');
+}
+
 export function transformChatMessage(result: any): TransformedMessage {
   const artifactVersions = transformArtifactVersions(result.artifact_versions);
 
   return {
     ...result,
+    // Must come after the spread: the API's raw `content` is what we normalize.
+    content: normalizeMessageContent(result.content),
     role: result.type === 'human' ? 'user' : 'assistant',
     visible: true,
     artifactVersions,

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -828,12 +828,23 @@ describe('preprocessLaTeX function', () => {
     );
   });
 
-  it('documents the known price-range limitation ($5-$10 reads as math)', () => {
-    // A bare "$5-$10" has no letters, so the heuristic treats "$5-$" as math
-    // and it renders as "5−". This is the documented trade-off; encode it so a
-    // future change to this behavior is a deliberate decision, not a surprise.
+  it('keeps price ranges literal regardless of the separator', () => {
+    // A closing `$` directly before a digit is currency, never a math close,
+    // so every amount in a range stays escaped.
     expect(preprocessLaTeX('tickets are $5-$10 today')).toBe(
-      'tickets are $5-$10 today',
+      'tickets are \\$5-\\$10 today',
+    );
+    expect(preprocessLaTeX('seats cost $5 - $10 each')).toBe(
+      'seats cost \\$5 - \\$10 each',
+    );
+    expect(preprocessLaTeX('prices: $5, $10, $15.')).toBe(
+      'prices: \\$5, \\$10, \\$15.',
+    );
+    expect(preprocessLaTeX('bands are $90,000-$120,000 by level')).toBe(
+      'bands are \\$90,000-\\$120,000 by level',
+    );
+    expect(preprocessLaTeX('k. Three amounts: $5-$10-$20')).toBe(
+      'k. Three amounts: \\$5-\\$10-\\$20',
     );
   });
 

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -778,6 +778,65 @@ describe('preprocessLaTeX function', () => {
     expect(preprocessLaTeX('I have $5 and $10')).toBe('I have \\$5 and \\$10');
   });
 
+  it('should preserve backslash-free inline arithmetic math (issue #2109)', () => {
+    // These spans have no backslash command, but they are genuine math and
+    // must survive the currency escape so remark-math can parse them.
+    expect(preprocessLaTeX('$3x + 5$')).toBe('$3x + 5$');
+    expect(preprocessLaTeX('$5$')).toBe('$5$');
+    expect(preprocessLaTeX('$3(4) + 5$')).toBe('$3(4) + 5$');
+    expect(preprocessLaTeX('$2x + 6$')).toBe('$2x + 6$');
+    expect(preprocessLaTeX('$3x$')).toBe('$3x$');
+  });
+
+  it('should keep inline math intact while still escaping real currency', () => {
+    const input =
+      'The term $3x$ evaluates. I have $5 and $10 in cash.\n\n$$3x + 5$$';
+    const output = preprocessLaTeX(input);
+    // Math spans come back parseable (not escaped to \$).
+    expect(output).toContain('$3x$');
+    expect(output).toContain('$$3x + 5$$');
+    // The currency false-pair (prose word "and" between the amounts) is escaped.
+    expect(output).toContain('I have \\$5 and \\$10 in cash.');
+  });
+
+  it('should not let a leading currency amount swallow a following math span', () => {
+    // Digit-leading math ("$3x + 5$") sitting on the same line AFTER a currency
+    // amount ("$12"). The rewind scan must escape the currency and still mask
+    // the math span, rather than letting "$12" consume the math opening "$".
+    const line3 =
+      'the kit costs $12, and the formula $3x + 5$ gives the price.';
+    const out3 = preprocessLaTeX(line3);
+    expect(out3).toBe(
+      'the kit costs \\$12, and the formula $3x + 5$ gives the price.',
+    );
+
+    // Backslash math ("$50 \\times x/100$") after currency ("$50") on one line.
+    // Note: a later LaTeX pass unescapes "\\%" -> "%" inside the restored span,
+    // which KaTeX still renders correctly — the point here is that both math
+    // spans survive and only the "$50" currency amount is escaped.
+    const line7 = 'a $50 item at $x\\%$ off saves $50 \\times x/100$ dollars.';
+    const out7 = preprocessLaTeX(line7);
+    expect(out7).toBe(
+      'a \\$50 item at $x%$ off saves $50 \\times x/100$ dollars.',
+    );
+
+    // Currency both before and after a math span still escapes both amounts.
+    const line5 = 'it was $20, dropped to $12, and $x - 8$ is the discount.';
+    const out5 = preprocessLaTeX(line5);
+    expect(out5).toBe(
+      'it was \\$20, dropped to \\$12, and $x - 8$ is the discount.',
+    );
+  });
+
+  it('documents the known price-range limitation ($5-$10 reads as math)', () => {
+    // A bare "$5-$10" has no letters, so the heuristic treats "$5-$" as math
+    // and it renders as "5−". This is the documented trade-off; encode it so a
+    // future change to this behavior is a deliberate decision, not a surprise.
+    expect(preprocessLaTeX('tickets are $5-$10 today')).toBe(
+      'tickets are $5-$10 today',
+    );
+  });
+
   it('should not escape already escaped dollar signs', () => {
     expect(preprocessLaTeX('Already \\$5 escaped')).toBe(
       'Already \\$5 escaped',

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -954,8 +954,18 @@ describe('preprocessLaTeX function', () => {
   });
 
   it('should convert LaTeX quotes', () => {
-    expect(preprocessLaTeX('``quoted``')).toBe('"quoted"');
+    // The LaTeX idiom opens with backticks and closes with apostrophes.
+    expect(preprocessLaTeX("``quoted text''")).toBe('"quoted text"');
     expect(preprocessLaTeX("''quoted''")).toBe('"quoted"');
+  });
+
+  it('should leave a double-backtick code span alone', () => {
+    // ``quoted`` is a CommonMark code span, not a LaTeX quote. Rewriting it to
+    // "quoted" is what shredded every ```fenced``` block, so code wins here.
+    expect(preprocessLaTeX('``quoted``')).toBe('``quoted``');
+    expect(preprocessLaTeX('```js\nconst x = 10;\n```')).toBe(
+      '```js\nconst x = 10;\n```',
+    );
   });
 
   it('should escape LaTeX special characters', () => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -389,14 +389,27 @@ export function preprocessLaTeX(content: string) {
     return `${maskOpen}${index}${maskClose}`;
   };
 
-  processedContent = processedContent.replace(/\$\$[\s\S]*?\$\$/g, (match) =>
+  // Block math takes one of two shapes: a `$$` fence whose delimiters each sit
+  // on their own line, or `$$...$$` closed on the line it opened. Matching
+  // `$$[\s\S]*?$$` instead lets a stray `$$` in prose pair with another `$$`
+  // lines later and swallow everything between them.
+  processedContent = processedContent.replace(
+    /^[ \t]*\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$[ \t]*$/gm,
+    (match) => maskMath(match),
+  );
+  processedContent = processedContent.replace(/\$\$[^\n]*?\$\$/g, (match) =>
     maskMath(match),
   );
   // Mask genuine inline math so the currency escape below leaves it alone.
-  // A `$...$` span "looks like math" when it contains a backslash command or
-  // has no 2+ letter prose word (e.g. "3x + 5", "5", "x = 4"). Currency
-  // false-pairs such as the text between "$5 and $10" contain a word like
-  // "and", so they stay unmasked and get the currency escape as intended.
+  // A `$...$` span counts as math under Pandoc's `tex_math_dollars` rule: the
+  // opening `$` is followed by a non-space, the closing `$` is preceded by a
+  // non-space, and the closing `$` is not followed by a digit. Currency pairs
+  // fail one of the last two tests -- "$5, $10" closes after a space, and
+  // "$5-$10" closes directly before a digit -- so they stay unmasked and get
+  // the currency escape as intended, while "$3x + 5$" and "$x = 4$" pass.
+  //
+  // Only `$` directly followed by a digit is at risk from the escape below, so
+  // declining to mask a span is always safe: remark-math still renders it.
   //
   // The scan runs left-to-right by hand rather than with a single global
   // regex: when a span is NOT math, we rewind to just after its opening `$`
@@ -404,9 +417,23 @@ export function preprocessLaTeX(content: string) {
   // leading currency amount like "$12" would swallow the opening `$` of a real
   // math span like "$3x + 5$" later on the same line, exposing that math `$`
   // to the currency escape and breaking it.
-  const isInlineMath = (span: string): boolean => {
-    const inner = span.slice(1, -1);
-    return span.includes('\\') || !/[A-Za-z]{2,}/.test(inner);
+  const isInlineMath = (open: number, close: number): boolean => {
+    if (close <= open + 1) return false;
+    const beforeOpen = processedContent[open - 1];
+    const afterOpen = processedContent[open + 1];
+    const beforeClose = processedContent[close - 1];
+    const afterClose = processedContent[close + 1];
+    if (!afterOpen || /\s/.test(afterOpen)) return false;
+    if (!beforeClose || /\s/.test(beforeClose)) return false;
+    if (afterClose && /\d/.test(afterClose)) return false;
+    // A delimiter touching another `$` is ambiguous: remark-math pairs `$` in
+    // runs of equal length, so in `$a$$b$` it opens on the first `$`, skips
+    // the `$$` run, and closes on the last one -- one span whose content is
+    // `a$$b`, which KaTeX renders as a red error. Claiming a span here would
+    // disagree with the tokenizer that actually renders it, so decline and let
+    // the escape below make the whole run literal instead.
+    if (beforeOpen === '$' || afterClose === '$') return false;
+    return true;
   };
   let scanned = '';
   let cursor = 0;
@@ -428,8 +455,8 @@ export function preprocessLaTeX(content: string) {
       cursor = open + 1;
       continue;
     }
-    const span = processedContent.slice(open, close + 1);
-    if (isInlineMath(span)) {
+    if (isInlineMath(open, close)) {
+      const span = processedContent.slice(open, close + 1);
       scanned += processedContent.slice(cursor, open) + maskMath(span);
       cursor = close + 1;
     } else {
@@ -441,13 +468,14 @@ export function preprocessLaTeX(content: string) {
   }
   processedContent = scanned;
 
-  // Escape currency dollar signs: if a $ is directly followed by a digit,
-  // prepend a backslash so that it is rendered as a literal dollar sign.
-  // Replace the regex replacement with one using a lookbehind and a function to ensure the digit group is preserved correctly.
-  processedContent = processedContent.replace(
-    /(?<!\\)\$(\d)/g,
-    (_, digit) => `\\$${digit}`,
-  );
+  // Every `$` that survives the scan above is not math, so escape all of them,
+  // not just the ones before a digit. A single unescaped `$` left behind opens
+  // a math span in remark-math that scans forward for a closer, and `\` is not
+  // an escape inside that scan -- so a stray `$` swallows the `$` out of a
+  // later `\$999`, leaving an orphaned backslash on screen. Escaping every
+  // non-math `$` keeps the decision here instead of splitting it with
+  // remark-math.
+  processedContent = processedContent.replace(/(?<!\\)\$/g, () => '\\$');
 
   // Restore masked math spans verbatim.
   const restoreMathPattern = new RegExp(`${maskOpen}(\\d+)${maskClose}`, 'g');

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -392,9 +392,54 @@ export function preprocessLaTeX(content: string) {
   processedContent = processedContent.replace(/\$\$[\s\S]*?\$\$/g, (match) =>
     maskMath(match),
   );
-  processedContent = processedContent.replace(/\$[^$\n]*?\$/g, (match) =>
-    match.includes('\\') ? maskMath(match) : match,
-  );
+  // Mask genuine inline math so the currency escape below leaves it alone.
+  // A `$...$` span "looks like math" when it contains a backslash command or
+  // has no 2+ letter prose word (e.g. "3x + 5", "5", "x = 4"). Currency
+  // false-pairs such as the text between "$5 and $10" contain a word like
+  // "and", so they stay unmasked and get the currency escape as intended.
+  //
+  // The scan runs left-to-right by hand rather than with a single global
+  // regex: when a span is NOT math, we rewind to just after its opening `$`
+  // so the closing `$` stays available to open the following span. Otherwise a
+  // leading currency amount like "$12" would swallow the opening `$` of a real
+  // math span like "$3x + 5$" later on the same line, exposing that math `$`
+  // to the currency escape and breaking it.
+  const isInlineMath = (span: string): boolean => {
+    const inner = span.slice(1, -1);
+    return span.includes('\\') || !/[A-Za-z]{2,}/.test(inner);
+  };
+  let scanned = '';
+  let cursor = 0;
+  while (cursor < processedContent.length) {
+    const open = processedContent.indexOf('$', cursor);
+    if (open === -1) {
+      scanned += processedContent.slice(cursor);
+      break;
+    }
+    // Inline spans never cross a newline, so a closing `$` past the next
+    // newline does not count.
+    const newline = processedContent.indexOf('\n', open + 1);
+    let close = processedContent.indexOf('$', open + 1);
+    if (close !== -1 && newline !== -1 && close > newline) {
+      close = -1;
+    }
+    if (close === -1) {
+      scanned += processedContent.slice(cursor, open + 1);
+      cursor = open + 1;
+      continue;
+    }
+    const span = processedContent.slice(open, close + 1);
+    if (isInlineMath(span)) {
+      scanned += processedContent.slice(cursor, open) + maskMath(span);
+      cursor = close + 1;
+    } else {
+      // Keep the opening `$` literal and rewind past it only, so the closing
+      // `$` can still open the next span.
+      scanned += processedContent.slice(cursor, open + 1);
+      cursor = open + 1;
+    }
+  }
+  processedContent = scanned;
 
   // Escape currency dollar signs: if a $ is directly followed by a digit,
   // prepend a backslash so that it is rendered as a literal dollar sign.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -343,8 +343,29 @@ export function preprocessLaTeX(content: string) {
     return `\n${processedRows.join('\n')}\n`;
   };
 
+  // Mask code before anything else runs. Code is literal by definition, so no
+  // transformation below may see it: the `` -> " quote rule shreds ```js
+  // fences, and the currency escape leaks a visible \$ into code spans.
+  // Restored verbatim at the very end.
+  const codeOpen = String.fromCharCode(0xe002);
+  const codeClose = String.fromCharCode(0xe003);
+  const codePlaceholders: string[] = [];
+  const maskCode = (segment: string): string => {
+    const index = codePlaceholders.length;
+    codePlaceholders.push(segment);
+    return `${codeOpen}${index}${codeClose}`;
+  };
+  const maskedContent = content
+    // Fenced blocks first: a fence may legally contain single backticks.
+    .replace(/(`{3,})[\s\S]*?\1/g, maskCode)
+    .replace(/(~{3,})[\s\S]*?\1/g, maskCode)
+    // Then inline spans: a code span is a backtick run closed by a run of the
+    // same length around at least one character. Requiring content matters --
+    // an empty match would swallow the ``  that opens a LaTeX ``quote''.
+    .replace(/(`+)((?:(?!\1)[\s\S])+?)\1(?!`)/g, maskCode);
+
   // Process tabular inside \[...\] first (before converting math delimiters)
-  let processedContent = content.replace(
+  let processedContent = maskedContent.replace(
     /\\\[\s*\\begin\{tabular\}\{[^}]*\}([\s\S]*?)\\end\{tabular\}\s*\\\]/g,
     (_, tableContent) => processTabularContent(tableContent),
   );
@@ -601,6 +622,13 @@ export function preprocessLaTeX(content: string) {
 
   // \_ -> _
   processedContent = processedContent.replace(/\\_/g, '_');
+
+  // Restore code last, verbatim, so nothing above has touched its contents.
+  const restoreCodePattern = new RegExp(`${codeOpen}(\\d+)${codeClose}`, 'g');
+  processedContent = processedContent.replace(
+    restoreCodePattern,
+    (_, index) => codePlaceholders[Number(index)] ?? '',
+  );
 
   return processedContent;
 }


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Closes https://github.com/iblai/iblai-platform/issues/2109
- Fix math inline issue

## Screenshots

To test this out, run the application locally.
http://localhost:3000/share/chat/a5eea395-3b55-4916-b465-375129d4cd38
http://localhost:3000/share/chat/0da567d9-a3a2-4f41-975b-d982ede42c9b

To see the broken version, run this against org.
https://mentorai.iblai.org/share/chat/a5eea395-3b55-4916-b465-375129d4cd38
https://mentorai.iblai.org/share/chat/0da567d9-a3a2-4f41-975b-d982ede42c9b