### PR TITLE
ci(audit): don't block PRs when npm's audit endpoint is retired (410)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -53,7 +53,18 @@ jobs:
         run: |
           set +e
           pnpm audit --audit-level=high | tee audit-report.txt
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          code="${PIPESTATUS[0]}"
+          # npm has retired the legacy audit endpoint that `pnpm audit` calls, so
+          # it now exits non-zero with a 410 / ERR_PNPM_AUDIT_BAD_RESPONSE. That
+          # is an endpoint outage, not a vulnerability — do not block on it. PR
+          # advisory coverage is still enforced by dependency-review-action
+          # (fail-on-severity: moderate). Real high/critical findings, when the
+          # endpoint responds, still produce a non-zero code and block.
+          if grep -qiE "ERR_PNPM_AUDIT_BAD_RESPONSE|being retired|responded with 410" audit-report.txt; then
+            echo "::warning::pnpm audit endpoint unavailable (npm retired the legacy audit endpoint) — skipping the audit gate this run; dependency-review-action still enforces advisories on PRs."
+            code=0
+          fi
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
 
       - name: Surface report in job summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Tests
 
-* **e2e:** fixme journey-60 LTI key/tool tests blocked on a backend issue ([04b424c](https://github.com/iblai/os/commit/04b424c1ef8eed91372a325e63bd768e559272da))
+- **e2e:** fixme journey-60 LTI key/tool tests blocked on a backend issue ([04b424c](https://github.com/iblai/os/commit/04b424c1ef8eed91372a325e63bd768e559272da))
 
 ## [0.95.9](https://github.com/iblai/os/compare/v0.95.8...v0.95.9) (2026-07-14)
 


### PR DESCRIPTION
## Problem

npm has **retired the legacy audit endpoint** (`/-/npm/v1/security/audits`) that `pnpm audit` (10.11.1) calls. `pnpm audit --audit-level=high` now exits non-zero with:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint … responded with 410:
This endpoint is being retired. Use the bulk advisory endpoint instead.
```

The `audit` job's "Fail if vulnerabilities found" step keys off that exit code and **can't distinguish an endpoint outage from real findings**, so it now **blocks every PR** — e.g. #339 (a clean `@iblai/iblai-js` bump whose full pre-push suite passed) failed the audit gate purely on the 410, not a vulnerability.

## Fix

In the "Run pnpm audit" step, detect the `410` / `ERR_PNPM_AUDIT_BAD_RESPONSE` / "being retired" response and treat it as **"audit unavailable"** — emit a `::warning::` and don't fail. Real high/critical findings (when the endpoint responds, e.g. the nightly `schedule` run) still produce a non-zero code and block as before.

**PR advisory coverage is unaffected** — `dependency-review-action` (`fail-on-severity: moderate`, in `dependency-review.yml`) still gates every PR against GitHub's advisory DB, which doesn't use the retired npm endpoint.

## Follow-up options (not in this PR)

The legacy endpoint isn't coming back, so `pnpm audit` will stay "unavailable" until either pnpm moves to the bulk advisory endpoint or we switch this job to a tool that uses it (e.g. `osv-scanner`, or `pnpm dlx audit-ci` against the bulk API). Happy to do that as a follow-up if you want the full-tree nightly audit working again — for now this unblocks PRs while keeping real-advisory enforcement via dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)