### PR TITLE
feat(ci): self-signed Windows build pipeline (x64 + arm64)

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,35 @@
+name: Release Windows
+
+# Builds self-signed NSIS installers (Intel x64 + ARM64) and attaches them to
+# the app-v<X> Release. Triggered by the same `app-v*` tag that
+# tauri-autoversion.yml pushes when a src-tauri change bumps the tauri version
+# (the macOS DMG build runs off the same tag, in its own pipeline). The
+# build/sign logic lives in the reusable workflow; this file is just the trigger
+# + inputs.
+#
+# Manual "Run workflow" produces build-only installer artifacts (no Release),
+# named by short SHA.
+on:
+  push:
+    tags:
+      - 'app-v*'
+  workflow_dispatch:
+
+concurrency:
+  group: release-windows-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # attach the installers to the Release
+
+jobs:
+  release:
+    uses: ./.github/workflows/reusable-release-windows.yml
+    with:
+      allow_in_app_purchase: true
+      # Tag push -> attach the installers to that app-v<X> Release.
+      # Manual dispatch -> build-only artifacts (no Release), named by short SHA.
+      release_tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+      release_name: ${{ github.ref_type == 'tag' && format('ibl.ai {0} (Windows)', github.ref_name) || '' }}
+      artifact_prefix: ${{ github.ref_type == 'tag' && format('ibl-ai-windows-{0}', github.ref_name) || format('ibl-ai-windows-{0}', github.sha) }}
+    secrets: inherit

--- a/.github/workflows/reusable-release-windows.yml
+++ b/.github/workflows/reusable-release-windows.yml
@@ -1,0 +1,195 @@
+# Reusable Windows build — self-signed NSIS installers for x64 + arm64.
+#
+# Mirrors reusable-release-macos-dmg.yml for Windows: builds a self-signed NSIS
+# installer per architecture (x86_64 + aarch64, arm64 cross-compiled on the x64
+# runner), uploads each as a CI artifact, and — for release builds — attaches
+# them to the app-v<X> GitHub Release. Two modes, chosen by the caller:
+#
+#   - Release build (release_tag set): attach the installers to that existing
+#     Release (the app-v<X> release the tag created).
+#   - Dev build (release_tag empty): build + upload CI artifacts only.
+#
+# Signing: uses a stored self-signed cert if WINDOWS_CERTIFICATE (base64 .pfx) +
+# WINDOWS_CERTIFICATE_PASSWORD secrets are set (stable publisher); otherwise
+# generates a fresh self-signed code-signing cert in the runner and signs with
+# that (zero setup, but the publisher/thumbprint varies per build). Either way
+# the installer is signed via signtool using the cert's thumbprint, which Tauri
+# picks up from bundle.windows.certificateThumbprint (injected as a config
+# overlay at build time).
+#
+# App-agnostic: app-specific values are inputs, defaulted to the shared IBL
+# values. Secrets flow in via `secrets: inherit`.
+
+name: Reusable Release Windows
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js version (tauri-action uses it to resolve the package manager)'
+        required: false
+        type: string
+        default: '25.3.0'
+      allow_in_app_purchase:
+        description: 'Compile-time IBL_ALLOW_IN_APP_PURCHASE flag (read via option_env! in Rust)'
+        required: false
+        type: boolean
+        default: false
+      cert_subject:
+        description: 'Subject (CN=...) used for the generated self-signed cert when no stored cert is provided'
+        required: false
+        type: string
+        default: 'CN=IBL.ai, O=IBL.ai'
+      artifact_prefix:
+        description: 'Prefix for the uploaded CI build artifacts (arch is appended)'
+        required: true
+        type: string
+      release_tag:
+        description: 'If set, attach the installers to this GitHub Release tag (release build). Empty = build-only dev build.'
+        required: false
+        type: string
+        default: ''
+      release_name:
+        description: 'Title used only if the release tag must be created as a fallback'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write # attach the installers to the Release
+
+jobs:
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            rust_target: x86_64-pc-windows-msvc
+          - arch: arm64
+            rust_target: aarch64-pc-windows-msvc
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node/pnpm are only needed so tauri-action can resolve the project's
+      # package manager; the frontend bundle is prebuilt/remote (frontendDist),
+      # so there's no `next build` here.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.arch }}
+
+      # Resolve a code-signing cert into the CurrentUser store and expose its
+      # thumbprint. Prefer a stored self-signed .pfx (stable publisher); fall
+      # back to generating one. Only the thumbprint leaves this step — the cert
+      # material stays in the runner's store.
+      - name: Prepare signing certificate
+        id: cert
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:WINDOWS_CERTIFICATE) {
+            Write-Host 'Using stored WINDOWS_CERTIFICATE (self-signed .pfx from secrets)'
+            $pfxPath = Join-Path $env:RUNNER_TEMP 'signing.pfx'
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
+            $pw = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText
+            $cert = Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $pw
+            Remove-Item $pfxPath -Force
+          } else {
+            Write-Host 'No stored certificate — generating a fresh self-signed code-signing cert'
+            $cert = New-SelfSignedCertificate `
+              -Type CodeSigningCert `
+              -Subject '${{ inputs.cert_subject }}' `
+              -CertStoreLocation Cert:\CurrentUser\My `
+              -KeyExportPolicy Exportable `
+              -KeyAlgorithm RSA -KeyLength 2048 `
+              -HashAlgorithm SHA256 `
+              -NotAfter (Get-Date).AddYears(5)
+          }
+          $thumb = $cert.Thumbprint
+          Write-Host "Signing thumbprint: $thumb"
+          "thumbprint=$thumb" >> $env:GITHUB_OUTPUT
+
+      # Tauri signs NSIS/exe via bundle.windows.certificateThumbprint. Inject the
+      # resolved thumbprint as a config overlay so the base tauri.conf.json stays
+      # unsigned by default.
+      - name: Write signing config overlay
+        id: overlay
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $overlay = Join-Path $env:RUNNER_TEMP 'tauri.windows-signing.conf.json'
+          $json = @{ bundle = @{ windows = @{ certificateThumbprint = '${{ steps.cert.outputs.thumbprint }}' } } } | ConvertTo-Json -Depth 5
+          Set-Content -Path $overlay -Value $json -Encoding utf8
+          Get-Content $overlay
+          "path=$overlay" >> $env:GITHUB_OUTPUT
+
+      # Build + sign the NSIS installer for this architecture. No tagName =>
+      # tauri-action does not create a Release; we attach the installer ourselves.
+      - name: Build & sign NSIS installer
+        id: tauri
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Enable in-app purchase for release builds when requested. Read at Rust
+          # compile time via option_env!("IBL_ALLOW_IN_APP_PURCHASE").
+          IBL_ALLOW_IN_APP_PURCHASE: ${{ inputs.allow_in_app_purchase }}
+        with:
+          args: --target ${{ matrix.rust_target }} --bundles nsis --config ${{ steps.overlay.outputs.path }}
+
+      # Always keep the installer as a CI artifact (per-arch).
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_prefix }}-${{ matrix.arch }}
+          path: src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe
+          if-no-files-found: error
+
+      # Release builds only: attach the installer to the version's Release.
+      - name: Attach installer to release
+        if: ${{ inputs.release_tag != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass inputs via env (not interpolated into the script body) to avoid
+          # shell expression injection.
+          EXE_GLOB: src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_NAME: ${{ inputs.release_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=($EXE_GLOB) # intentional glob expansion of the path pattern
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No installer found at $EXE_GLOB"; exit 1
+          fi
+          # The Release normally already exists (created by the tag/release flow);
+          # create as a fallback so a Windows-only run can still publish.
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --title "${RELEASE_NAME:-$RELEASE_TAG}" \
+              --notes "Automated, self-signed Windows build."
+          fi
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          echo "Attached ${#files[@]} installer(s) to $RELEASE_TAG"

--- a/.github/workflows/reusable-release-windows.yml
+++ b/.github/workflows/reusable-release-windows.yml
@@ -86,6 +86,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Adds the Rust std for the target. arm64 is cross-compiled from the x64
+      # runner: the GitHub-hosted windows-2022/2025 images already ship the MSVC
+      # ARM64 build tools (VC.Tools.ARM64) + Windows 11 SDK, so no extra VS
+      # component install is needed here. (A self-hosted runner would need
+      # `Microsoft.VisualStudio.Component.VC.Tools.ARM64` installed.)
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -131,19 +136,27 @@ jobs:
           Write-Host "Signing thumbprint: $thumb"
           "thumbprint=$thumb" >> $env:GITHUB_OUTPUT
 
-      # Tauri signs NSIS/exe via bundle.windows.certificateThumbprint. Inject the
-      # resolved thumbprint as a config overlay so the base tauri.conf.json stays
-      # unsigned by default.
-      - name: Write signing config overlay
-        id: overlay
+      # Tauri signs the app .exe + NSIS installer via signtool when
+      # bundle.windows.certificateThumbprint is set. Inject the resolved
+      # thumbprint into that single field of the ephemeral CI checkout's
+      # tauri.conf.json, leaving every sibling windows setting intact
+      # (digestAlgorithm: sha256, timestampUrl, webviewInstallMode, nsis). An
+      # in-place edit (vs a --config overlay) avoids any dependency on tauri's
+      # config-merge semantics dropping those sibling keys.
+      - name: Inject signing thumbprint into tauri.conf.json
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $overlay = Join-Path $env:RUNNER_TEMP 'tauri.windows-signing.conf.json'
-          $json = @{ bundle = @{ windows = @{ certificateThumbprint = '${{ steps.cert.outputs.thumbprint }}' } } } | ConvertTo-Json -Depth 5
-          Set-Content -Path $overlay -Value $json -Encoding utf8
-          Get-Content $overlay
-          "path=$overlay" >> $env:GITHUB_OUTPUT
+          $conf = 'src-tauri/tauri.conf.json'
+          $thumb = '${{ steps.cert.outputs.thumbprint }}'
+          if ([string]::IsNullOrWhiteSpace($thumb)) { throw 'empty signing thumbprint' }
+          $text = Get-Content $conf -Raw
+          if ($text -notmatch '"certificateThumbprint"\s*:\s*null') {
+            throw 'certificateThumbprint: null not found in tauri.conf.json'
+          }
+          $text = $text -replace '"certificateThumbprint"\s*:\s*null', ('"certificateThumbprint": "' + $thumb + '"')
+          Set-Content -Path $conf -Value $text -NoNewline -Encoding utf8
+          Write-Host "Injected certificateThumbprint $thumb"
 
       # Build + sign the NSIS installer for this architecture. No tagName =>
       # tauri-action does not create a Release; we attach the installer ourselves.
@@ -156,7 +169,29 @@ jobs:
           # compile time via option_env!("IBL_ALLOW_IN_APP_PURCHASE").
           IBL_ALLOW_IN_APP_PURCHASE: ${{ inputs.allow_in_app_purchase }}
         with:
-          args: --target ${{ matrix.rust_target }} --bundles nsis --config ${{ steps.overlay.outputs.path }}
+          # MSI/WiX doesn't support arm64, so restrict to NSIS (the only Tauri
+          # bundle type that builds for both x64 and arm64). tauri-action reads
+          # the --target back to resolve the per-target bundle path.
+          args: --target ${{ matrix.rust_target }} --bundles nsis
+
+      # Confirm signing actually happened. A self-signed signature is untrusted
+      # (Status won't be "Valid" without the cert in a trusted root), so we only
+      # assert that a signer certificate is present — i.e. signtool ran and
+      # embedded a signature — not that it chains to a trusted root.
+      - name: Verify installer is signed
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Get-ChildItem "src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe" | Select-Object -First 1
+          if (-not $exe) { throw 'No NSIS installer produced' }
+          $sig = Get-AuthenticodeSignature $exe.FullName
+          Write-Host "Installer: $($exe.Name)"
+          Write-Host "Signature status: $($sig.Status)"
+          Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          if ($null -eq $sig.SignerCertificate) {
+            throw "Installer is NOT signed (no signer certificate embedded)"
+          }
+          Write-Host 'OK: installer carries an Authenticode signature.'
 
       # Always keep the installer as a CI artifact (per-arch).
       - name: Upload installer artifact
@@ -185,11 +220,15 @@ jobs:
             echo "No installer found at $EXE_GLOB"; exit 1
           fi
           # The Release normally already exists (created by the tag/release flow);
-          # create as a fallback so a Windows-only run can still publish.
+          # create as a fallback so a Windows-only run can still publish. The
+          # x64 and arm64 matrix legs run this concurrently, so tolerate a lost
+          # create race (`|| true`) — whichever loses just proceeds to upload.
+          # The two legs upload distinctly-named files (_x64 / _arm64), so
+          # --clobber never pits them against each other.
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release create "$RELEASE_TAG" \
               --title "${RELEASE_NAME:-$RELEASE_TAG}" \
-              --notes "Automated, self-signed Windows build."
+              --notes "Automated, self-signed Windows build." || true
           fi
           gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
           echo "Attached ${#files[@]} installer(s) to $RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### CI
 
-* **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
+- **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
 
 ## [0.95.11](https://github.com/iblai/os/compare/v0.95.10...v0.95.11) (2026-07-15)
 
 ### Bug Fixes
 
-* chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
-* **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
-* upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
-* upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
+- chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
+- **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
+- upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
+- upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
 
 ### Chores
 
-* bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
-* **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
+- bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
+- **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
 
 ## [0.95.10](https://github.com/iblai/os/compare/v0.95.9...v0.95.10) (2026-07-15)
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ One codebase, six platforms. OS runs natively everywhere your users are — ligh
 
 **Latest macOS build:** [ibl.ai v0.95.1 (Universal .dmg)](https://github.com/iblai/os/releases/download/v0.95.1/ibl.ai_0.95.1_universal.dmg) · [all versions](docs/DOWNLOADS.md)
 
-Signed & notarized universal build (Intel + Apple Silicon). Older versions are
-listed in [docs/DOWNLOADS.md](docs/DOWNLOADS.md).
+**Latest Windows build:** _first self-signed build pending — it will appear here after the next `src-tauri` change._ · [all versions](docs/DOWNLOADS.md)
+
+Signed & notarized universal macOS build (Intel + Apple Silicon); self-signed
+Windows installers (Intel x64 + ARM64). Older versions are listed in
+[docs/DOWNLOADS.md](docs/DOWNLOADS.md).
 
 ---
 

--- a/scripts/tauri-bump.mjs
+++ b/scripts/tauri-bump.mjs
@@ -10,8 +10,10 @@
 // This script only edits files (bump + docs + README); the workflow does the
 // git commit/tag/push. It:
 //   1. bumps tauri.conf.json's version (regex, preserving the file's style),
-//   2. prepends a row to docs/DOWNLOADS.md (deterministic app-v<X> DMG link),
-//   3. updates the "Latest macOS build" line in README.md.
+//   2. prepends a row to docs/DOWNLOADS.md (deterministic app-v<X> download
+//      links: macOS DMG + Windows x64/arm64 NSIS installers),
+//   3. updates the "Latest macOS build" / "Latest Windows build" lines in
+//      README.md.
 // It prints the new version to stdout so the workflow can tag app-v<version>.
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -24,6 +26,7 @@ if (!['patch', 'minor', 'major'].includes(level)) {
 // Canonical GitHub repo that hosts the Releases (the repo moved to iblai/os).
 const RELEASES_BASE = 'https://github.com/iblai/os/releases/download';
 const README_LATEST_RE = /^\*\*Latest macOS build:\*\*.*$/m;
+const README_WINDOWS_LATEST_RE = /^\*\*Latest Windows build:\*\*.*$/m;
 
 const confUrl = new URL('../src-tauri/tauri.conf.json', import.meta.url);
 const conf = readFileSync(confUrl, 'utf8');
@@ -49,6 +52,12 @@ const productName = JSON.parse(conf).productName;
 const tag = `app-v${version}`;
 const dmg = `${productName}_${version}_universal.dmg`;
 const url = `${RELEASES_BASE}/${tag}/${encodeURIComponent(dmg)}`;
+// Windows NSIS installers, one per architecture. Tauri names them
+// `<productName>_<version>_<arch>-setup.exe` (arch = x64 | arm64).
+const winX64 = `${productName}_${version}_x64-setup.exe`;
+const winArm64 = `${productName}_${version}_arm64-setup.exe`;
+const winX64Url = `${RELEASES_BASE}/${tag}/${encodeURIComponent(winX64)}`;
+const winArm64Url = `${RELEASES_BASE}/${tag}/${encodeURIComponent(winArm64)}`;
 const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
 
 // 2) docs/DOWNLOADS.md — prepend a row under the table header (newest first).
@@ -69,7 +78,7 @@ if (headerIdx < 0 || !/^\s*\|[\s:|-]+\|\s*$/.test(lines[sepIdx] ?? '')) {
 lines.splice(
   sepIdx + 1,
   0,
-  `| ${tag} | ${date} | [macOS (Universal)](${url}) |`,
+  `| ${tag} | ${date} | [macOS (Universal)](${url}) · [Windows x64](${winX64Url}) · [Windows arm64](${winArm64Url}) |`,
 );
 writeFileSync(downloadsUrl, lines.join('\n'));
 
@@ -77,10 +86,22 @@ writeFileSync(downloadsUrl, lines.join('\n'));
 const readmeUrl = new URL('../README.md', import.meta.url);
 const readme = readFileSync(readmeUrl, 'utf8');
 const latest = `**Latest macOS build:** [ibl.ai ${tag} (Universal .dmg)](${url}) · [all versions](docs/DOWNLOADS.md)`;
+const latestWindows = `**Latest Windows build:** [ibl.ai ${tag} (x64 .exe)](${winX64Url}) · [ARM64 .exe](${winArm64Url}) · [all versions](docs/DOWNLOADS.md)`;
 if (!README_LATEST_RE.test(readme)) {
   console.error('tauri-bump: "Latest macOS build" line not found in README.md');
   process.exit(1);
 }
-writeFileSync(readmeUrl, readme.replace(README_LATEST_RE, latest));
+if (!README_WINDOWS_LATEST_RE.test(readme)) {
+  console.error(
+    'tauri-bump: "Latest Windows build" line not found in README.md',
+  );
+  process.exit(1);
+}
+writeFileSync(
+  readmeUrl,
+  readme
+    .replace(README_LATEST_RE, latest)
+    .replace(README_WINDOWS_LATEST_RE, latestWindows),
+);
 
 console.log(version);


### PR DESCRIPTION
## What

Adds a Windows build pipeline that mirrors the macOS DMG pipeline — self-signed NSIS installers for **Intel x64 and ARM64**, in their own pipeline off the **same `app-v*` tag** the mac build uses.

| Concern | macOS (existing) | Windows (this PR) |
| --- | --- | --- |
| Trigger | `app-v*` tag → `release-macos-dmg.yml` | `app-v*` tag → **`release-windows.yml`** |
| Build/sign | `reusable-release-macos-dmg.yml` (universal DMG, Developer ID + notarize) | **`reusable-release-windows.yml`** (NSIS x64 + arm64, self-signed) |
| Artifacts + Release | per-build artifact + attach to `app-v<X>` Release | same |
| Download recording | `tauri-bump.mjs` → README + `DOWNLOADS.md` | **extended** for Windows x64/arm64 links |

## Details

- **`reusable-release-windows.yml`** — matrix over `{x64: x86_64-pc-windows-msvc, arm64: aarch64-pc-windows-msvc}` on `windows-latest` (arm64 cross-compiled). Builds `--bundles nsis`, uploads a per-arch artifact, and (for tag builds) attaches the `*-setup.exe` to the `app-v<X>` Release.
- **Self-signed (as requested), generate-in-CI with stored override**: if `WINDOWS_CERTIFICATE` (base64 `.pfx`) + `WINDOWS_CERTIFICATE_PASSWORD` secrets are set, it imports and signs with that self-signed cert (stable publisher); otherwise it generates a fresh self-signed code-signing cert in the runner. Either way the installer is signed via `signtool` using the cert thumbprint, injected as a Tauri config overlay (`bundle.windows.certificateThumbprint`) so the base config stays unsigned by default.
- **`release-windows.yml`** — tag-triggered caller (+ `workflow_dispatch` for build-only artifacts), `allow_in_app_purchase: true`, `secrets: inherit`.
- **`tauri-bump.mjs`** — now records Windows x64/arm64 installer links in `DOWNLOADS.md` and a new "Latest Windows build" line in `README.md`. Verified locally: a dry `patch` run produces correct `app-v<X>` DMG + x64/arm64 URLs, then reverted.

## ⚠️ Needs a live run to validate (untestable locally)

This is a **new, untested-in-CI** pipeline (unlike the vendored mac one). First `app-v*` tag (or manual dispatch) should confirm:
1. **arm64 cross-compile** — `aarch64-pc-windows-msvc` on the x64 runner may need ARM64 MSVC build components installed; if the build fails on missing toolchain, I'll add a VS-components install step (or switch arm64 to a native `windows-11-arm` runner).
2. **NSIS filenames** — the README/DOWNLOADS links assume Tauri's `<productName>_<version>_<arch>-setup.exe` (`x64`/`arm64`); confirm the actual output names match and adjust `tauri-bump.mjs` if Tauri emits different arch labels.
3. **Signing** — that `signtool` picks up the generated cert thumbprint.

Recommend a `workflow_dispatch` build-only run first (no Release side-effects) before relying on it for a tagged release.