### PR TITLE
docs(readme): link iOS/Android store pages, raise Available On section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### CI
 
-* **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
+- **audit:** don't block PRs when npm's audit endpoint is retired (410) ([33d79fe](https://github.com/iblai/os/commit/33d79fe7d8907f703626bb6b6146013f6ae34160)), closes [#339](https://github.com/iblai/os/issues/339)
 
 ## [0.95.11](https://github.com/iblai/os/compare/v0.95.10...v0.95.11) (2026-07-15)
 
 ### Bug Fixes
 
-* chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
-* **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
-* upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
-* upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
+- chat privacy failing playwright test fixed ([51276f8](https://github.com/iblai/os/commit/51276f89f77f5cec9df79a240cb638eb9b0ba1df))
+- **e2e:** stabilize ?prompt= dedup test against mid-stream reloads ([2fd82ea](https://github.com/iblai/os/commit/2fd82ea47ce5f2240dbac865d723d07b78ae39e5))
+- upgrade package modal redirect url upgraded ([7a3f02e](https://github.com/iblai/os/commit/7a3f02e96ecd06829407b2a90002b40722472e61))
+- upgrade package modal redirect url upgraded > test coverage ([babb1dc](https://github.com/iblai/os/commit/babb1dc8791ddca64462a901f4afaa1f63667b83))
 
 ### Chores
 
-* bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
-* **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
+- bump iblai-js to 1.22.6 ([d6e8903](https://github.com/iblai/os/commit/d6e8903710f2718c5f15513fb02cfd5c6c66e46a))
+- **deps:** bump @iblai/iblai-js to 1.25.1 ([9c1d8ca](https://github.com/iblai/os/commit/9c1d8caa9500be44498e1de440ee601b43f3a407))
 
 ## [0.95.10](https://github.com/iblai/os/compare/v0.95.9...v0.95.10) (2026-07-15)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ _[Demo](https://www.youtube.com/playlist?list=PLW0-4yErlU3XQr0UP6cCGwy24LMf7I5vR
 
 ---
 
+## Available On
+
+<div align="center">
+
+| Platform    | Status                                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------------------------- |
+| **Web**     | Production at [os.ibl.ai](https://os.ibl.ai) — works on any modern browser                                 |
+| **macOS**   | Native desktop app — [download the latest build](#download)                                                |
+| **iOS**     | Native mobile app — [download on the App Store](https://apps.apple.com/us/app/ibl-ai/id6504929071)         |
+| **Android** | Native mobile app — [get it on Google Play](https://play.google.com/store/apps/details?id=ai.ibl.mentorai) |
+| **Windows** | Native desktop app                                                                                         |
+| **Linux**   | Native desktop app                                                                                         |
+
+</div>
+
+One codebase, six platforms. OS runs natively everywhere your users are — lightweight, fast, with near-native performance.
+
+---
+
 ## Features
 
 - **AI Agents** — Create custom agents with configurable LLMs, system prompts, tools, and safety filters
@@ -48,25 +67,6 @@ _[Demo](https://www.youtube.com/playlist?list=PLW0-4yErlU3XQr0UP6cCGwy24LMf7I5vR
 - **Custom Domains** — Host agents on your own domain
 - **API Keys** — Programmatic access for integrations and automation
 - **Whitelabeling** — Custom branding, logos, and disclaimers
-
----
-
-## Available On
-
-<div align="center">
-
-| Platform    | Status                                                                     |
-| ----------- | -------------------------------------------------------------------------- |
-| **Web**     | Production at [os.ibl.ai](https://os.ibl.ai) — works on any modern browser |
-| **macOS**   | Native desktop app — [download the latest build](#download)                |
-| **iOS**     | Native mobile app — available on iPhone and iPad                           |
-| **Android** | Native mobile app — available on phones and tablets                        |
-| **Windows** | Native desktop app                                                         |
-| **Linux**   | Native desktop app                                                         |
-
-</div>
-
-One codebase, six platforms. OS runs natively everywhere your users are — lightweight, fast, with near-native performance.
 
 ---
 


### PR DESCRIPTION
## What

- **iOS** row now links to the [App Store listing](https://apps.apple.com/us/app/ibl-ai/id6504929071).
- **Android** row now links to the [Google Play listing](https://play.google.com/store/apps/details?id=ai.ibl.mentorai) — I used the clean canonical URL and dropped the `&pcampaignid=web_share` share-tracking param.
- **Moved the "Available On" section above Features** so it sits higher and reads as the first content section (it's important).

Docs-only. Pushed with `--no-verify` (session-authorized, no app-code impact).