### PR TITLE
ci: update stg1 E2E host IP → 98.82.66.78 (old box unreachable)

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -121,7 +121,7 @@ jobs:
       browsers: 'chrome'
       workers: '3'
       registry-type: 'ocir'
-      ec2-host: '32.196.111.179'
+      ec2-host: '98.82.66.78'
       runs-on: iblai-stg-runner
       ec2-user: 'ubuntu'
       ec2-commands: >-


### PR DESCRIPTION
## What
The stg1 E2E test host IP changed. `pr-e2e-tests.yml` hardcodes the old IP as `ec2-host`, so the `run-tests / ec2-ssh` step SSHes to a dead address and fails with `ssh: connect to host 32.196.111.179 port 22: Connection timed out` (e.g. os run 29535397516 / PR #346). Update to the new IP.

`32.196.111.179` → `98.82.66.78`

## Note
The same IP is hardcoded in **iblai/lms** and **iblai/iblai-web-frontend** `pr-e2e-tests.yml` (separate PRs), and in some infra/jumphost config files — those latter (access lists / docs) should be reviewed separately by infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)