### PR TITLE
ci(e2e): prune docker images on stg deploy (fix 'no space left on device')

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -128,6 +128,7 @@ jobs:
         cd /ibl/app/ibl-spa/mentor &&
         sed -i 's|image: .*|image: ${{ needs.build-app-image.outputs.image-uri }}|' docker-compose.yml &&
         docker compose down &&
+        docker image prune -af &&
         docker compose up -d
 
   # ============================================================


### PR DESCRIPTION
The E2E `ec2-commands` deploy pulls a fresh per-PR image (`iblai-mentor-spa-pro:pr-XXX`) onto the stg box (98.82.66.78) every run via `docker compose down && up -d`, but **never prunes**. Old images accumulate until `/var/lib/docker` fills and the next `docker compose up -d` dies extracting layers with `failed to register layer: … no space left on device` (run 29754029545, job step "Run commands on EC2"). The job runs on `iblai-stg-runner`, but the full disk is on the **deploy box**, not the runner.

**Fix:** add `docker image prune -af` between `compose down` and `up -d`. With mentor stopped, this clears the accumulated old `pr-XXX` images + dangling layers (running services keep their images) and frees space before the new pull — so the deploy is self-cleaning and the box never accumulates.

Companion PR on lms (same deploy pattern for `skills` on the same box). Also recommend a box-side `docker system prune` cron + disk alert as belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)