### PR TITLE
fix(ci): make tauri-bump resilient so autoversion always tags a release

### DIFF
--- a/.github/workflows/tauri-autoversion.yml
+++ b/.github/workflows/tauri-autoversion.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
     paths:
       - 'src-tauri/**'
+  # Manual trigger — bump + tag + ship a release on demand, without waiting for a
+  # src-tauri change (e.g. to re-run after a failed auto-version, or to force a
+  # build off the current main).
+  workflow_dispatch:
 
 concurrency:
   group: release-tauri
@@ -20,8 +24,11 @@ permissions:
 
 jobs:
   version:
-    # Skip our own bump commits to avoid an infinite loop.
-    if: "!startsWith(github.event.head_commit.message, 'chore(tauri):')"
+    # Always run on manual dispatch; on push, skip our own bump commits to avoid
+    # an infinite loop (workflow_dispatch has no head_commit).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(tauri):')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,27 @@
 
 ### Bug Fixes
 
-* **desktop:** round the app icon corners into a native macOS squircle ([5c24c6d](https://github.com/iblai/os/commit/5c24c6d225955b6785522ae37df54b4f481fa1b7))
+- **desktop:** round the app icon corners into a native macOS squircle ([5c24c6d](https://github.com/iblai/os/commit/5c24c6d225955b6785522ae37df54b4f481fa1b7))
 
 ## [0.98.5](https://github.com/iblai/os/compare/v0.98.4...v0.98.5) (2026-07-20)
 
 ### Bug Fixes
 
-* **markdown:** unwrap LLM $…$ styling wrappers so they render as prose ([eccdd25](https://github.com/iblai/os/commit/eccdd25b2ee992666120e0bb3d20e0f945f14db8))
+- **markdown:** unwrap LLM $…$ styling wrappers so they render as prose ([eccdd25](https://github.com/iblai/os/commit/eccdd25b2ee992666120e0bb3d20e0f945f14db8))
 
 ### Refactors
 
-* **markdown:** extract preprocessLaTeX into its own module ([ae17f53](https://github.com/iblai/os/commit/ae17f53b202a1186f4c164cb25cb683b014723f4))
+- **markdown:** extract preprocessLaTeX into its own module ([ae17f53](https://github.com/iblai/os/commit/ae17f53b202a1186f4c164cb25cb683b014723f4))
 
 ### Styles
 
-* normalize CHANGELOG to prettier ([86c4b61](https://github.com/iblai/os/commit/86c4b61df55d795504ec6207cecce75fb449045e))
+- normalize CHANGELOG to prettier ([86c4b61](https://github.com/iblai/os/commit/86c4b61df55d795504ec6207cecce75fb449045e))
 
 ## [0.98.4](https://github.com/iblai/os/compare/v0.98.3...v0.98.4) (2026-07-20)
 
 ### CI
 
-* **e2e:** prune old docker images on stg deploy so the box never fills ([8982753](https://github.com/iblai/os/commit/8982753ec113224dda356a4c79102bcdf08e622b))
+- **e2e:** prune old docker images on stg deploy so the box never fills ([8982753](https://github.com/iblai/os/commit/8982753ec113224dda356a4c79102bcdf08e622b))
 
 ## [0.98.3](https://github.com/iblai/os/compare/v0.98.2...v0.98.3) (2026-07-20)
 

--- a/scripts/tauri-bump.mjs
+++ b/scripts/tauri-bump.mjs
@@ -12,8 +12,10 @@
 //   1. bumps tauri.conf.json's version (regex, preserving the file's style),
 //   2. prepends a row to docs/DOWNLOADS.md (deterministic app-v<X> download
 //      links: macOS DMG + Windows x64/arm64 NSIS installers),
-//   3. updates the "Latest macOS build" / "Latest Windows build" lines in
-//      README.md.
+//   3. repoints the macOS + Windows download links/badges in README.md to the
+//      new version.
+// Steps 2 and 3 are best-effort — they never fail the run, so the version bump
+// (and the app-v<X> tag that triggers the release pipelines) always happens.
 // It prints the new version to stdout so the workflow can tag app-v<version>.
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -25,8 +27,6 @@ if (!['patch', 'minor', 'major'].includes(level)) {
 
 // Canonical GitHub repo that hosts the Releases (the repo moved to iblai/os).
 const RELEASES_BASE = 'https://github.com/iblai/os/releases/download';
-const README_LATEST_RE = /^\*\*Latest macOS build:\*\*.*$/m;
-const README_WINDOWS_LATEST_RE = /^\*\*Latest Windows build:\*\*.*$/m;
 
 const confUrl = new URL('../src-tauri/tauri.conf.json', import.meta.url);
 const conf = readFileSync(confUrl, 'utf8');
@@ -60,48 +60,75 @@ const winX64Url = `${RELEASES_BASE}/${tag}/${encodeURIComponent(winX64)}`;
 const winArm64Url = `${RELEASES_BASE}/${tag}/${encodeURIComponent(winArm64)}`;
 const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
 
-// 2) docs/DOWNLOADS.md — prepend a row under the table header (newest first).
-const downloadsUrl = new URL('../docs/DOWNLOADS.md', import.meta.url);
-const lines = readFileSync(downloadsUrl, 'utf8').split('\n');
-const headerIdx = lines.findIndex(
-  (l) =>
-    /^\s*\|/.test(l) &&
-    /Version/.test(l) &&
-    /Date/.test(l) &&
-    /Download/.test(l),
-);
-const sepIdx = headerIdx + 1;
-if (headerIdx < 0 || !/^\s*\|[\s:|-]+\|\s*$/.test(lines[sepIdx] ?? '')) {
-  console.error('tauri-bump: Downloads table not found in docs/DOWNLOADS.md');
-  process.exit(1);
-}
-lines.splice(
-  sepIdx + 1,
-  0,
-  `| ${tag} | ${date} | [macOS (Universal)](${url}) · [Windows x64](${winX64Url}) · [Windows arm64](${winArm64Url}) |`,
-);
-writeFileSync(downloadsUrl, lines.join('\n'));
+// The doc updates below are BEST-EFFORT: they must never fail the version bump.
+// If they did, a README/DOWNLOADS redesign (as happened when the landing README
+// was rebuilt with download-button badges) would break autoversion, the
+// app-v<X> tag would never be pushed, and the release pipelines (macOS DMG +
+// Windows) would never run. On any mismatch we warn and carry on, so the tag is
+// always produced and the version is always printed.
 
-// 3) README.md — update the single "Latest macOS build" line.
-const readmeUrl = new URL('../README.md', import.meta.url);
-const readme = readFileSync(readmeUrl, 'utf8');
-const latest = `**Latest macOS build:** [ibl.ai ${tag} (Universal .dmg)](${url}) · [all versions](docs/DOWNLOADS.md)`;
-const latestWindows = `**Latest Windows build:** [ibl.ai ${tag} (x64 .exe)](${winX64Url}) · [ARM64 .exe](${winArm64Url}) · [all versions](docs/DOWNLOADS.md)`;
-if (!README_LATEST_RE.test(readme)) {
-  console.error('tauri-bump: "Latest macOS build" line not found in README.md');
-  process.exit(1);
-}
-if (!README_WINDOWS_LATEST_RE.test(readme)) {
-  console.error(
-    'tauri-bump: "Latest Windows build" line not found in README.md',
+// 2) docs/DOWNLOADS.md — prepend a row under the table header (newest first).
+try {
+  const downloadsUrl = new URL('../docs/DOWNLOADS.md', import.meta.url);
+  const lines = readFileSync(downloadsUrl, 'utf8').split('\n');
+  const headerIdx = lines.findIndex(
+    (l) =>
+      /^\s*\|/.test(l) &&
+      /Version/.test(l) &&
+      /Date/.test(l) &&
+      /Download/.test(l),
   );
-  process.exit(1);
+  const sepIdx = headerIdx + 1;
+  if (headerIdx < 0 || !/^\s*\|[\s:|-]+\|\s*$/.test(lines[sepIdx] ?? '')) {
+    console.warn(
+      'tauri-bump: Downloads table not found in docs/DOWNLOADS.md — skipping',
+    );
+  } else {
+    lines.splice(
+      sepIdx + 1,
+      0,
+      `| ${tag} | ${date} | [macOS (Universal)](${url}) · [Windows x64](${winX64Url}) · [Windows arm64](${winArm64Url}) |`,
+    );
+    writeFileSync(downloadsUrl, lines.join('\n'));
+  }
+} catch (err) {
+  console.warn(`tauri-bump: DOWNLOADS.md update skipped (${err.message})`);
 }
-writeFileSync(
-  readmeUrl,
-  readme
-    .replace(README_LATEST_RE, latest)
-    .replace(README_WINDOWS_LATEST_RE, latestWindows),
-);
+
+// 3) README.md — repoint the macOS + Windows(x64) download links at the new
+// version. Matches any `…/app-v<X>/<product>_<X>_universal.dmg` and
+// `…_x64-setup.exe` occurrence, so it works for the download-button badges AND
+// any inline links, and survives future README redesigns.
+try {
+  const readmeUrl = new URL('../README.md', import.meta.url);
+  const readme = readFileSync(readmeUrl, 'utf8');
+  const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const base = esc(RELEASES_BASE);
+  const pn = esc(productName);
+  const macRe = new RegExp(
+    `${base}/app-v\\d+\\.\\d+\\.\\d+/${pn}_\\d+\\.\\d+\\.\\d+_universal\\.dmg`,
+    'g',
+  );
+  const winRe = new RegExp(
+    `${base}/app-v\\d+\\.\\d+\\.\\d+/${pn}_\\d+\\.\\d+\\.\\d+_x64-setup\\.exe`,
+    'g',
+  );
+  let out = readme.replace(macRe, url);
+  if (out === readme) {
+    console.warn(
+      'tauri-bump: macOS download link not found in README.md — skipping',
+    );
+  }
+  const afterWin = out.replace(winRe, winX64Url);
+  if (afterWin === out) {
+    console.warn(
+      'tauri-bump: Windows download link not found in README.md — skipping',
+    );
+  }
+  out = afterWin;
+  if (out !== readme) writeFileSync(readmeUrl, out);
+} catch (err) {
+  console.warn(`tauri-bump: README update skipped (${err.message})`);
+}
 
 console.log(version);


### PR DESCRIPTION
## Problem

The **Tauri Auto Version** workflow has been failing on every `src-tauri` merge (e.g. the #354 merge in the screenshot):

```
tauri-bump: "Latest macOS build" line not found in README.md
Error: Process completed with exit code 1.
```

The landing README was redesigned with **download-button badges** (`.../app-v0.95.4/ibl.ai_0.95.4_universal.dmg`, …), which removed the `**Latest macOS build:**` / `**Latest Windows build:**` lines that `tauri-bump.mjs` required. The script `exit 1`s, so the `Bump tauri version` step fails → **no `app-v<X>` tag is pushed → neither release pipeline (macOS DMG nor the new Windows one) ever runs.**

## Fix

1. **Update the new badge/link format** — repoint the macOS + Windows(x64) download URLs to the new version by matching `…/app-v<X>/<product>_<X>_universal.dmg` and `…_x64-setup.exe` (works for the badges and any inline links). Verified against the current redesigned README: `0.95.4 → 0.95.5` updated both badges + the `DOWNLOADS.md` row.
2. **Make doc updates best-effort** — `DOWNLOADS.md` and `README.md` edits now warn and continue instead of `exit 1`. The version bump (and the `app-v<X>` tag that triggers the release builds) **always** happens, so a future README redesign can never again break the release chain.
3. **Add `workflow_dispatch`** to `tauri-autoversion.yml` so a bump→tag→release can be triggered **on demand** (to recover from the failed run, or force a build off current `main`), and always runs on manual dispatch.

## How to get a build now

After this merges, either:
- **Run workflow → Tauri Auto Version** (the new manual trigger) — bumps the version, pushes `app-v<X>`, and both the macOS DMG and Windows pipelines fire; **or**
- the next `src-tauri` change auto-triggers it.

Note: the diff includes a `CHANGELOG.md` bullet-style normalization from the repo's pre-commit `prettier --write .` hook (unrelated; it reformats the release-tool changelog on every commit).