### PR TITLE
test(e2e): deflake journey 62 csd-02 against backend auto-titling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Bug Fixes
 
-* **chat:** let shareable-link sessions bypass the RBAC chat gate ([55501d3](https://github.com/iblai/os/commit/55501d3999643fb5ce590ab80edabf52b3193243))
+- **chat:** let shareable-link sessions bypass the RBAC chat gate ([55501d3](https://github.com/iblai/os/commit/55501d3999643fb5ce590ab80edabf52b3193243))
 
 ### Styles
 
-* normalize pre-existing CHANGELOG prettier drift ([2fe046a](https://github.com/iblai/os/commit/2fe046aa522c78d6c25e32cd79018edb0badf735))
+- normalize pre-existing CHANGELOG prettier drift ([2fe046a](https://github.com/iblai/os/commit/2fe046aa522c78d6c25e32cd79018edb0badf735))
 
 ### Tests
 
-* **e2e:** add embed access-control and shareable-link page-object helpers ([508bb74](https://github.com/iblai/os/commit/508bb7459a9fab8c0704cbc9257d58874992826e))
-* **e2e:** add journey 64 shareable-link RBAC bypass ([e852557](https://github.com/iblai/os/commit/e852557b3c9d064c2a48d5cebdd589d17194ef4b)), closes [#chat](https://github.com/iblai/os/issues/chat)
-* **e2e:** record journey 64 coverage ([c4e4127](https://github.com/iblai/os/commit/c4e412752c656f04fa2325f4bd23b9c33e1a63e2))
+- **e2e:** add embed access-control and shareable-link page-object helpers ([508bb74](https://github.com/iblai/os/commit/508bb7459a9fab8c0704cbc9257d58874992826e))
+- **e2e:** add journey 64 shareable-link RBAC bypass ([e852557](https://github.com/iblai/os/commit/e852557b3c9d064c2a48d5cebdd589d17194ef4b)), closes [#chat](https://github.com/iblai/os/issues/chat)
+- **e2e:** record journey 64 coverage ([c4e4127](https://github.com/iblai/os/commit/c4e412752c656f04fa2325f4bd23b9c33e1a63e2))
 
 ## [0.102.2](https://github.com/iblai/os/compare/v0.102.1...v0.102.2) (2026-07-23)
 

--- a/e2e/journeys/62-chat-search-dialog.spec.ts
+++ b/e2e/journeys/62-chat-search-dialog.spec.ts
@@ -162,8 +162,7 @@ test.describe('Journey 62: Chat Search Dialog', () => {
     chatPage,
     chatSearchDialogPage,
   }) => {
-    const seeds = await seedThreeChats(page, chatPage);
-    const pastaSeed = seeds[2];
+    await seedThreeChats(page, chatPage);
 
     await chatSearchDialogPage.openFromSidebar();
 
@@ -181,15 +180,20 @@ test.describe('Journey 62: Chat Search Dialog', () => {
     }
 
     // A row renders its label as a single line — no embedded newline. The
-    // freshest (pasta) session has no `startNewChat()` after it, so it is
-    // the one row still virtually guaranteed to show the raw first human
-    // message (not yet auto-retitled), letting us assert it matches the
-    // sent text exactly once whitespace is normalized (chatRowLabel does
-    // `content.replace(/\s+/g, ' ').trim()`).
+    // label is either the raw first human message OR a backend
+    // auto-generated title: `chatRowLabel` prefers `row.title` once the
+    // backend sets it (asynchronously, some time after the first
+    // response), so even the freshest (pasta) session can be retitled by
+    // the time this runs (e.g. "Give me a pasta recipe <ts>" →
+    // "Pasta Recipe Request"). Assert the single-line guarantee — the real
+    // point of this journey — and match on the topic keyword rather than
+    // the full sent sentence, which would race the auto-titler.
     const rowText =
       (await chatSearchDialogPage.rowByText('pasta').textContent()) ?? '';
+    const normalized = rowText.replace(/\s+/g, ' ').trim();
     expect(rowText.includes('\n')).toBe(false);
-    expect(rowText.trim()).toBe(pastaSeed.trim());
+    expect(normalized).not.toBe('');
+    expect(normalized.toLowerCase()).toContain('pasta');
   });
 
   // csd-03: Search filters (server-side, debounced)


### PR DESCRIPTION
The single-line-labels assertion matched the pasta row's label against the raw sent sentence with exact equality. The backend asynchronously auto-titles a session after its first response, and chatRowLabel prefers row.title once set, so even the freshest (pasta) row is retitled (e.g. "Give me a pasta recipe <ts>" -> "Pasta Recipe Request") before the assertion runs. Under parallel load this raced 9/10 runs.

Keep the journey's real guarantee — the label is single-line, non-empty — and match on the topic keyword instead of the full sentence, which is correct whether or not the session has been auto-titled. Drop the now unused pastaSeed local.

## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
