### PR TITLE
fix(tauri): end intermittent app freeze from webview-manager mutex deadlock

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -781,6 +781,31 @@ async fn stop_ollama(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Emit an app-wide event to the frontend WITHOUT racing the main thread's
+/// webview-manager mutex.
+///
+/// Tauri's app-wide `Emitter::emit` locks the webview-manager mutex to fan a
+/// payload out to every webview. Every async `#[command]` here runs on a tokio
+/// worker, so calling `app.emit(...)` directly from one can deadlock against the
+/// main thread locking the SAME mutex to service a webview IPC message
+/// (`AppManager::get_webview`) — the intermittent "Not Responding" freeze
+/// (see `check_ollama_status`, which the UI polls). Marshalling every emit onto
+/// the main thread serializes it with IPC handling, so the two can never contend
+/// the lock across threads. `run_on_main_thread` only posts to the event loop (it
+/// does not block and preserves FIFO order), so it is safe to call from async
+/// code and keeps streamed events (e.g. `ollama:token`) in order.
+fn emit_on_main<S>(app: &AppHandle, event: &'static str, payload: S)
+where
+    S: serde::Serialize + Clone + Send + 'static,
+{
+    let handle = app.clone();
+    if let Err(err) = app.run_on_main_thread(move || {
+        let _ = handle.emit(event, payload);
+    }) {
+        eprintln!("[emit_on_main] could not schedule '{event}' on main thread: {err}");
+    }
+}
+
 /// Check Ollama installation and model status
 #[command]
 async fn check_ollama_status(app: AppHandle) -> Result<OllamaStatus, String> {
@@ -812,7 +837,7 @@ async fn check_ollama_status(app: AppHandle) -> Result<OllamaStatus, String> {
     };
 
     // Emit status update event
-    let _ = app.emit(EVENT_OLLAMA_STATUS, &status);
+    emit_on_main(&app, EVENT_OLLAMA_STATUS, status.clone());
 
     Ok(status)
 }
@@ -831,7 +856,7 @@ async fn check_disk_space_for_model(app: AppHandle) -> Result<bool, String> {
                 available_gb, REQUIRED_FREE_SPACE_GB
             ),
         };
-        let _ = app.emit(EVENT_DISK_SPACE_ERROR, &error);
+        emit_on_main(&app, EVENT_DISK_SPACE_ERROR, error);
         return Ok(false);
     }
 
@@ -872,7 +897,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
     let app_log = Arc::new(app.clone());
 
     // Emit initial log
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_INSTALLATION_LOG,
         InstallationLog {
             timestamp: get_timestamp(),
@@ -883,7 +909,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
 
     // Check if Ollama is running
     if !is_ollama_running().await {
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -901,7 +928,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
             return Err("Could not start Ollama server. Please start Ollama manually.".to_string());
         }
 
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -922,13 +950,14 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
                 available_gb, REQUIRED_FREE_SPACE_GB
             ),
         };
-        let _ = app.emit(EVENT_DISK_SPACE_ERROR, &error);
+        emit_on_main(&app, EVENT_DISK_SPACE_ERROR, error.clone());
         return Err(error.message);
     }
 
     // Check if already installed
     if is_model_installed(&model).await {
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_DOWNLOAD_PROGRESS,
             DownloadProgress {
                 status: "completed".to_string(),
@@ -940,7 +969,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
             },
         );
 
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -956,10 +986,10 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
     pull_model(
         &model,
         move |progress| {
-            let _ = app_progress.emit(EVENT_DOWNLOAD_PROGRESS, &progress);
+            emit_on_main(&app_progress, EVENT_DOWNLOAD_PROGRESS, progress);
         },
         move |log| {
-            let _ = app_log.emit(EVENT_INSTALLATION_LOG, &log);
+            emit_on_main(&app_log, EVENT_INSTALLATION_LOG, log);
         },
     )
     .await
@@ -998,7 +1028,8 @@ async fn check_network_status() -> Result<bool, String> {
 /// Cancel an ongoing model download
 #[command]
 async fn cancel_model_download(app: AppHandle) -> Result<(), String> {
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_INSTALLATION_LOG,
         InstallationLog {
             timestamp: get_timestamp(),
@@ -1009,7 +1040,8 @@ async fn cancel_model_download(app: AppHandle) -> Result<(), String> {
 
     cancel_download()?;
 
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_DOWNLOAD_PROGRESS,
         DownloadProgress {
             status: "cancelled".to_string(),
@@ -1389,7 +1421,7 @@ async fn ollama_chat_stream(
                         if let Some(content) = json.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_str()) {
                             full_content.push_str(content);
                             // Emit token event
-                            let _ = app.emit("ollama:token", serde_json::json!({
+                            emit_on_main(&app, "ollama:token", serde_json::json!({
                                 "generation_id": generation_id,
                                 "token": content,
                                 "full_content": full_content
@@ -1413,7 +1445,7 @@ async fn ollama_chat_stream(
                                 continue;
                             }
                             // No tool calls -> final answer.
-                            let _ = app.emit("ollama:done", serde_json::json!({
+                            emit_on_main(&app, "ollama:done", serde_json::json!({
                                 "generation_id": generation_id,
                                 "full_content": full_content
                             }));
@@ -1423,7 +1455,7 @@ async fn ollama_chat_stream(
                 }
             }
             Err(e) => {
-                let _ = app.emit("ollama:error", serde_json::json!({
+                emit_on_main(&app, "ollama:error", serde_json::json!({
                     "generation_id": generation_id,
                     "error": format!("Stream error: {}", e)
                 }));
@@ -1433,7 +1465,7 @@ async fn ollama_chat_stream(
     }
 
     // Stream closed without a tool-free `done` — emit done with what we have.
-    let _ = app.emit("ollama:done", serde_json::json!({
+    emit_on_main(&app, "ollama:done", serde_json::json!({
         "generation_id": generation_id,
         "full_content": full_content
     }));

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -72,6 +72,31 @@ fn in_app_popup_title(url: &str) -> Option<&'static str> {
         .map(|(_, title)| *title)
 }
 
+/// Emit an app-wide event to the frontend WITHOUT racing the main thread's
+/// webview-manager mutex.
+///
+/// Tauri's app-wide `Emitter::emit` locks the webview-manager mutex to fan a
+/// payload out to every webview. Every async `#[command]` here runs on a tokio
+/// worker, so calling `app.emit(...)` directly from one can deadlock against the
+/// main thread locking the SAME mutex to service a webview IPC message
+/// (`AppManager::get_webview`) — the intermittent "Not Responding" freeze
+/// (see `check_ollama_status`, which the UI polls). Marshalling every emit onto
+/// the main thread serializes it with IPC handling, so the two can never contend
+/// the lock across threads. `run_on_main_thread` only posts to the event loop (it
+/// does not block and preserves FIFO order), so it is safe to call from async
+/// code and keeps streamed events (e.g. `ollama:token`) in order.
+fn emit_on_main<S>(app: &AppHandle, event: &'static str, payload: S)
+where
+    S: serde::Serialize + Clone + Send + 'static,
+{
+    let handle = app.clone();
+    if let Err(err) = app.run_on_main_thread(move || {
+        let _ = handle.emit(event, payload);
+    }) {
+        eprintln!("[emit_on_main] could not schedule '{event}' on main thread: {err}");
+    }
+}
+
 /// Open OAuth URL in an in-app popup window
 /// The window monitors for callback URLs and closes automatically when auth completes
 fn open_oauth_in_popup(url: &str, app_handle: &AppHandle, title: &str) -> Result<(), String> {
@@ -399,7 +424,7 @@ async fn check_ollama_status(app: AppHandle) -> Result<OllamaStatus, String> {
                 model_installed: true, // Pretend model is installed
                 installed_models: Vec::new(), // Foundry path: Ollama model table is hidden
             };
-            let _ = app.emit(EVENT_OLLAMA_STATUS, &status);
+            emit_on_main(&app, EVENT_OLLAMA_STATUS, status.clone());
             return Ok(status);
         }
     }
@@ -446,7 +471,7 @@ async fn check_ollama_status(app: AppHandle) -> Result<OllamaStatus, String> {
     };
 
     // Emit status update event
-    let _ = app.emit(EVENT_OLLAMA_STATUS, &status);
+    emit_on_main(&app, EVENT_OLLAMA_STATUS, status.clone());
 
     Ok(status)
 }
@@ -591,7 +616,7 @@ async fn check_disk_space_for_model(app: AppHandle) -> Result<bool, String> {
                 available_gb, REQUIRED_FREE_SPACE_GB
             ),
         };
-        let _ = app.emit(EVENT_DISK_SPACE_ERROR, &error);
+        emit_on_main(&app, EVENT_DISK_SPACE_ERROR, error);
         return Ok(false);
     }
 
@@ -633,7 +658,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
     let app_log = Arc::new(app.clone());
 
     // Emit initial log
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_INSTALLATION_LOG,
         InstallationLog {
             timestamp: get_timestamp(),
@@ -644,7 +670,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
 
     // Check if Ollama is running
     if !is_ollama_running().await {
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -663,7 +690,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
             return Err("Could not start Ollama server. Please start Ollama manually.".to_string());
         }
 
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -684,13 +712,14 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
                 available_gb, REQUIRED_FREE_SPACE_GB
             ),
         };
-        let _ = app.emit(EVENT_DISK_SPACE_ERROR, &error);
+        emit_on_main(&app, EVENT_DISK_SPACE_ERROR, error.clone());
         return Err(error.message);
     }
 
     // Check if already installed
     if is_model_installed(&model).await {
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_DOWNLOAD_PROGRESS,
             DownloadProgress {
                 status: "completed".to_string(),
@@ -702,7 +731,8 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
             },
         );
 
-        let _ = app.emit(
+        emit_on_main(
+            &app,
             EVENT_INSTALLATION_LOG,
             InstallationLog {
                 timestamp: get_timestamp(),
@@ -718,10 +748,10 @@ async fn download_ollama_model(app: AppHandle, model: String) -> Result<(), Stri
     pull_model(
         &model,
         move |progress| {
-            let _ = app_progress.emit(EVENT_DOWNLOAD_PROGRESS, &progress);
+            emit_on_main(&app_progress, EVENT_DOWNLOAD_PROGRESS, progress);
         },
         move |log| {
-            let _ = app_log.emit(EVENT_INSTALLATION_LOG, &log);
+            emit_on_main(&app_log, EVENT_INSTALLATION_LOG, log);
         },
     )
     .await
@@ -760,7 +790,8 @@ async fn check_network_status() -> Result<bool, String> {
 /// Cancel an ongoing model download
 #[command]
 async fn cancel_model_download(app: AppHandle) -> Result<(), String> {
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_INSTALLATION_LOG,
         InstallationLog {
             timestamp: get_timestamp(),
@@ -771,7 +802,8 @@ async fn cancel_model_download(app: AppHandle) -> Result<(), String> {
 
     cancel_download()?;
 
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         EVENT_DOWNLOAD_PROGRESS,
         DownloadProgress {
             status: "cancelled".to_string(),
@@ -1147,7 +1179,8 @@ async fn ollama_chat_stream(
                         {
                             full_content.push_str(content);
                             // Emit token event
-                            let _ = app.emit(
+                            emit_on_main(
+                                &app,
                                 "ollama:token",
                                 serde_json::json!({
                                     "generation_id": generation_id,
@@ -1175,7 +1208,8 @@ async fn ollama_chat_stream(
                                 continue;
                             }
                             // No tool calls -> final answer.
-                            let _ = app.emit(
+                            emit_on_main(
+                                &app,
                                 "ollama:done",
                                 serde_json::json!({
                                     "generation_id": generation_id,
@@ -1188,7 +1222,8 @@ async fn ollama_chat_stream(
                 }
             }
             Err(e) => {
-                let _ = app.emit(
+                emit_on_main(
+                    &app,
                     "ollama:error",
                     serde_json::json!({
                         "generation_id": generation_id,
@@ -1201,7 +1236,8 @@ async fn ollama_chat_stream(
     }
 
     // Stream closed without a tool-free `done` — emit done with what we have.
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         "ollama:done",
         serde_json::json!({
             "generation_id": generation_id,
@@ -1921,7 +1957,8 @@ async fn foundry_chat_stream(
                                     full_content.push_str(content);
                                     println!("[FoundryChat] Emitting token: '{}'", content);
                                     // Emit token event
-                                    let _ = app.emit(
+                                    emit_on_main(
+                                        &app,
                                         "ollama:token",
                                         serde_json::json!({
                                             "generation_id": generation_id,
@@ -1948,7 +1985,8 @@ async fn foundry_chat_stream(
             Err(e) => {
                 let err_msg = format!("Stream error: {}", e);
                 println!("[FoundryChat] ERROR: {}", err_msg);
-                let _ = app.emit(
+                emit_on_main(
+                    &app,
                     "ollama:error",
                     serde_json::json!({
                         "generation_id": generation_id,
@@ -1967,7 +2005,8 @@ async fn foundry_chat_stream(
     );
 
     // Emit done event
-    let _ = app.emit(
+    emit_on_main(
+        &app,
         "ollama:done",
         serde_json::json!({
             "generation_id": generation_id,


### PR DESCRIPTION
## The freeze

The desktop app intermittently froze ("Not Responding"). A `sample` of a frozen instance captured a **two-thread mutex deadlock** on Tauri's webview manager:

- **Main (UI) thread** — `handle_ipc_message → AppManager::get_webview → Mutex::lock`, servicing a webview IPC message.
- **tokio worker** — `check_ollama_status → AppHandle::emit(OllamaStatus) → Emitter::emit → Mutex::lock`, fanning an event out to every webview.

Tauri's app-wide `Emitter::emit` locks the webview-manager mutex. Every async `#[command]` here runs on a tokio worker, so calling `app.emit(...)` directly from one races the main thread locking the **same** mutex to look up a webview. When they collide, the app deadlocks — and it was intermittent because it needs simultaneous lock contention. `check_ollama_status` (polled by the model-download UI) plus the streaming token emits made that collision likely.

## The fix

Add an `emit_on_main` helper that marshals every emit onto the main thread via `run_on_main_thread`, so emits **serialize** with IPC handling and can never contend the manager mutex across threads. `run_on_main_thread` only posts to the event loop (non-blocking, FIFO), so streamed events (`ollama:token`, …) stay ordered.

Converted every `app.emit(...)` in the async commands of:
- `src-tauri/src/main.rs` — the **desktop** binary entry (the frozen Mac app).
- `src-tauri/src/lib.rs` — the **mobile** entry point, hand-kept in sync, which had the identical deadlock.

## Verification

- `cargo check` passes (both `bin` and `lib` targets).
- Pre-push validation (typecheck, lint, build, 10560 unit tests, coverage) passed green — Rust-only change, no JS behaviour touched. Landed via authorized `--no-verify` due to the known mentorai SIGPIPE-after-green-hook transport flake.

## Follow-up (optional, not in this PR)

`check_ollama_status` is polled frequently by `useModelDownload`/`useTauri`. Throttling that render storm would cut redundant main-thread emit traffic. Not required for correctness now that emits can't deadlock, but a worthwhile cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)