### PR TITLE
ci(e2e): run PR e2e on the central pipeline (replaces OCI container instances)

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -137,6 +137,9 @@ jobs:
           gh workflow run pr-e2e.yml -R iblai/iblai-deploy-ops --ref main \
             -f source_repo=os \
             -f pr_number='${{ github.event.pull_request.number }}' \
+            # github.sha on a pull_request IS the merge commit — the same ref actions/checkout
+            # used to build the app image, so specs and app code come from one commit.
+            -f merge_sha='${{ github.sha }}' \
             -f head_sha='${{ github.event.pull_request.head.sha }}' \
             -f app_image='${{ needs.build-app-image.outputs.image-uri }}' \
             -f target_env=stg1 \

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -89,67 +89,109 @@ jobs:
       pr-number: ${{ github.event.pull_request.number }}
 
   # ============================================================
-  # BUILD PLAYWRIGHT IMAGE
+  # E2E — dispatched to the central pipeline (iblai/iblai-deploy-ops)
+  #
+  # Replaces the old OCI container-instance runner. The central pipeline swaps this
+  # PR's SPA image into the target env, builds the Playwright image from THIS PR's
+  # sha, runs the suite, publishes the standard report, then ALWAYS restores the
+  # env's original image. We dispatch (not `uses:`) because a public repo cannot
+  # call a private reusable workflow, and we poll so this job — and therefore the
+  # required check — carries the real e2e result.
   # ============================================================
-  build-playwright-image:
-    needs: gate
-    uses: ./.github/workflows/reusable-pr-docker-build.yml
-    secrets: inherit
-    with:
-      dockerfile-path: e2e/Dockerfile
-      build-context: .
-      image-name: ibl-mentor-playwright
-      registry-type: ocir
-      image-tag: pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-      event-name: pull_request
-      pr-number: ${{ github.event.pull_request.number }}
+  e2e:
+    name: E2E (central pipeline)
+    needs: build-app-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # need the base ref to diff changed specs
 
-  # ============================================================
-  # RUN PLAYWRIGHT TESTS ON OCI
-  # ============================================================
-  run-tests:
-    needs: [build-app-image, build-playwright-image]
-    uses: ./.github/workflows/reusable-oci-test-runner.yml
-    secrets: inherit
-    with:
-      domain-number: '1'
-      app-type: mentor
-      playwright-image: ${{ needs.build-playwright-image.outputs.image-uri }}
-      max-wait: 10800
-      total-shards: 1
-      run-type: main
-      browsers: 'chrome'
-      workers: '3'
-      registry-type: 'ocir'
-      ec2-host: '98.82.66.78'
-      runs-on: iblai-stg-runner
-      ec2-user: 'ubuntu'
-      ec2-commands: >-
-        cd /ibl/app/ibl-spa/mentor &&
-        sed -i 's|image: .*|image: ${{ needs.build-app-image.outputs.image-uri }}|' docker-compose.yml &&
-        docker compose down &&
-        docker image prune -af &&
-        docker compose up -d
+      - name: Detect changed spec files
+        id: specs
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- 'e2e/**/*.spec.ts' | tr '\n' ' ' | sed 's/ $//')
+          OTHER=$(git diff --name-only "$BASE" "$HEAD" -- . ':(exclude)e2e/**' | head -1)
+          N=$(printf '%s' "$CHANGED" | wc -w | tr -d ' ')
+          # Only spec files touched (and not many) -> run just those for fast feedback.
+          # Any app-source change -> full suite, since behaviour may have moved anywhere.
+          if [ -n "$CHANGED" ] && [ -z "$OTHER" ] && [ "$N" -le 5 ]; then
+            echo "mode=selective" >> "$GITHUB_OUTPUT"; echo "specs=$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "selective: $CHANGED"
+          else
+            echo "mode=full" >> "$GITHUB_OUTPUT"; echo "specs=" >> "$GITHUB_OUTPUT"
+            echo "full suite (changed specs=$N, non-spec changes=${OTHER:-none})"
+          fi
+
+      - name: Dispatch e2e
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          BEFORE=$(gh run list -R iblai/iblai-deploy-ops --workflow=pr-e2e.yml -L 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run pr-e2e.yml -R iblai/iblai-deploy-ops --ref main \
+            -f source_repo=os \
+            -f pr_number='${{ github.event.pull_request.number }}' \
+            -f head_sha='${{ github.event.pull_request.head.sha }}' \
+            -f app_image='${{ needs.build-app-image.outputs.image-uri }}' \
+            -f target_env=stg1 \
+            -f mode='${{ steps.specs.outputs.mode }}' \
+            -f specs='${{ steps.specs.outputs.specs }}'
+          for i in $(seq 1 30); do
+            sleep 5
+            ID=$(gh run list -R iblai/iblai-deploy-ops --workflow=pr-e2e.yml -L 1 --json databaseId --jq '.[0].databaseId // 0')
+            if [ "$ID" != "$BEFORE" ] && [ "$ID" != "0" ]; then
+              echo "run_id=$ID" >> "$GITHUB_OUTPUT"
+              echo "dispatched: https://github.com/iblai/iblai-deploy-ops/actions/runs/$ID"; exit 0
+            fi
+          done
+          echo "::error::dispatched but the run never appeared"; exit 1
+
+      - name: Wait for the e2e result
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -uo pipefail
+          URL="https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
+          for i in $(seq 1 240); do        # up to 2h: image build + full suite
+            sleep 30
+            S=$(gh api "repos/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}" --jq '.status+"|"+(.conclusion//"")' 2>/dev/null)
+            if [ "${S%%|*}" = "completed" ]; then
+              C="${S##*|}"
+              { echo "### E2E → **$C**"; echo ""; echo "[Run details]($URL)"; } >> "$GITHUB_STEP_SUMMARY"
+              echo "e2e finished: $C — $URL"
+              [ "$C" = "success" ] && exit 0 || exit 1
+            fi
+          done
+          echo "::error::timed out waiting for $URL"; exit 1
 
   # ============================================================
   # SUMMARY
   # ============================================================
   summary:
-    needs: [build-app-image, build-playwright-image, run-tests]
+    needs: [build-app-image, unit-tests, e2e]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Results
         run: |
-          echo "# PR E2E Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "| Step | Result |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Build App | ${{ needs.build-app-image.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build Playwright | ${{ needs.build-playwright-image.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Run Tests (firefox,chrome,safari,edge) | ${{ needs.run-tests.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Mode: skip-infra-launch — tests ran against the pre-existing stg1 instance." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# PR E2E Test Results"
+            echo "| Step | Result |"
+            echo "|------|--------|"
+            echo "| Unit tests (vitest) | ${{ needs.unit-tests.result }} |"
+            echo "| Build App image | ${{ needs.build-app-image.result }} |"
+            echo "| E2E (central pipeline) | ${{ needs.e2e.result }} |"
+            echo ""
+            echo "E2E ran on the central pipeline against **stg1**; the SPA image is restored afterwards."
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Fail if tests did not pass
-        if: needs.run-tests.result != 'success' && needs.run-tests.result != 'skipped'
+      - name: Fail if anything did not pass
+        if: needs.e2e.result != 'success' || needs.unit-tests.result != 'success'
         run: exit 1

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -28,6 +28,7 @@ run-name: 'PR E2E Tests — stg1 (firefox,chrome,safari,edge)'
 
 permissions:
   contents: read
+  pull-requests: write   # the e2e job posts the report link as a PR comment
 
 concurrency:
   group: pr-e2e-${{ github.event.pull_request.number }}
@@ -131,14 +132,15 @@ jobs:
         id: dispatch
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           BEFORE=$(gh run list -R iblai/iblai-deploy-ops --workflow=pr-e2e.yml -L 1 --json databaseId --jq '.[0].databaseId // 0')
+          # github.sha on a pull_request IS the merge commit — the same ref actions/checkout used to
+          # build the app image, so the specs and the app code come from one commit.
           gh workflow run pr-e2e.yml -R iblai/iblai-deploy-ops --ref main \
             -f source_repo=os \
-            -f pr_number='${{ github.event.pull_request.number }}' \
-            # github.sha on a pull_request IS the merge commit — the same ref actions/checkout
-            # used to build the app image, so specs and app code come from one commit.
+            -f pr_number="$PR" \
             -f merge_sha='${{ github.sha }}' \
             -f head_sha='${{ github.event.pull_request.head.sha }}' \
             -f app_image='${{ needs.build-app-image.outputs.image-uri }}' \
@@ -150,30 +152,99 @@ jobs:
             ID=$(gh run list -R iblai/iblai-deploy-ops --workflow=pr-e2e.yml -L 1 --json databaseId --jq '.[0].databaseId // 0')
             if [ "$ID" != "$BEFORE" ] && [ "$ID" != "0" ]; then
               echo "run_id=$ID" >> "$GITHUB_OUTPUT"
-              echo "dispatched: https://github.com/iblai/iblai-deploy-ops/actions/runs/$ID"; exit 0
+              echo "dispatched run $ID"; exit 0
             fi
           done
           echo "::error::dispatched but the run never appeared"; exit 1
 
-      - name: Wait for the e2e result
+      - name: Wait for e2e
+        id: wait
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
         run: |
           set -uo pipefail
-          URL="https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
+          # The central pipeline lives in a PRIVATE repo, so most contributors here cannot open its
+          # Actions log. Mirror every phase transition into THIS log, which is public — otherwise a
+          # developer stares at a spinner for an hour with no idea what is happening.
+          echo "Phases: resolve -> baseline drift check -> sync (only if drifted) -> swap SPA -> e2e -> restore"
+          LAST=""
           for i in $(seq 1 240); do        # up to 2h: image build + full suite
-            sleep 30
+            PHASES=$(gh api "repos/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}/jobs" \
+                       --jq '[.jobs[] | "\(.name): \(.conclusion // .status)"] | join("  |  ")' 2>/dev/null || echo "")
+            if [ -n "$PHASES" ] && [ "$PHASES" != "$LAST" ]; then
+              echo "[$(date -u +%H:%M:%SZ)] $PHASES"
+              LAST="$PHASES"
+            fi
             S=$(gh api "repos/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}" --jq '.status+"|"+(.conclusion//"")' 2>/dev/null)
             if [ "${S%%|*}" = "completed" ]; then
-              C="${S##*|}"
-              { echo "### E2E → **$C**"; echo ""; echo "[Run details]($URL)"; } >> "$GITHUB_STEP_SUMMARY"
-              echo "e2e finished: $C — $URL"
-              [ "$C" = "success" ] && exit 0 || exit 1
+              echo "conclusion=${S##*|}" >> "$GITHUB_OUTPUT"
+              echo "e2e finished: ${S##*|}"
+              exit 0
             fi
+            sleep 30
           done
-          echo "::error::timed out waiting for $URL"; exit 1
+          echo "conclusion=timed_out" >> "$GITHUB_OUTPUT"
+          echo "::error::timed out after 2h waiting for the e2e run"; exit 1
 
+      - name: Publish the result on this PR
+        if: always() && steps.dispatch.outputs.run_id != ''
+        env:
+          GH_TOKEN:   ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID:     ${{ steps.dispatch.outputs.run_id }}
+          PR:         ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          # The Playwright report on tests.iblai.app IS public, so it is the link that actually helps
+          # a developer here — unlike the private Actions run. Relay it onto the PR itself.
+          gh run download "$RUN_ID" -R iblai/iblai-deploy-ops -n pr-e2e-result -D /tmp/res 2>/dev/null || true
+          python3 - <<'PY' > /tmp/body.md
+          import json, pathlib
+          p = pathlib.Path("/tmp/res/pr-e2e-result.json")
+          d = json.loads(p.read_text()) if p.exists() else {}
+          v    = d.get("verdict") or "unknown"
+          icon = {"success": "OK", "failure": "FAILED", "cancelled": "cancelled"}.get(v, v)
+          rep  = d.get("report_url") or ""
+          rows = [("result", f"**{icon}**")]
+          if d.get("platform"):
+              rows.append(("suite", f'`{d["platform"]}` - mode `{d.get("mode","?")}` - env `{d.get("target_env","?")}`'))
+          if d.get("baseline"):
+              synced = " (env was synced to it first)" if d.get("drifted") == "true" else " (env already on it)"
+              rows.append(("tested against", f'prod release `{d["baseline"]}`{synced}'))
+          for label, key in (("failed", "failed"), ("new failures", "new_failures")):
+              if d.get(key) not in (None, ""):
+                  rows.append((label, f'`{d[key]}`'))
+          out = ["<!-- pr-e2e-report -->", f"### PR E2E - {icon}", ""]
+          if rep:
+              out += [f"**[Full report, traces and screenshots]({rep})**", ""]
+          out += ["| | |", "|---|---|"] + [f"| {k} | {val} |" for k, val in rows]
+          if not rep:
+              out += ["", "_No report link - the run likely failed before the suite started."
+                          " Ask a maintainer to check the central pipeline._"]
+          print("\n".join(out))
+          PY
+          cat /tmp/body.md >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/body.md
+
+          # Sticky comment: update the existing one so re-runs do not spam the PR.
+          python3 -c "import json;print(json.dumps({'body':open('/tmp/body.md').read()}))" > /tmp/payload.json
+          CID=$(GH_TOKEN="$REPO_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+                  --jq '[.[] | select(.body | startswith("<!-- pr-e2e-report -->"))] | .[-1].id // empty' 2>/dev/null || true)
+          if [ -n "$CID" ]; then
+            GH_TOKEN="$REPO_TOKEN" gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${CID}" \
+              --input /tmp/payload.json >/dev/null && echo "updated PR comment $CID"
+          else
+            GH_TOKEN="$REPO_TOKEN" gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              --input /tmp/payload.json >/dev/null && echo "posted PR comment"
+          fi
+
+      - name: Gate on the e2e result
+        if: always()
+        run: |
+          C="${{ steps.wait.outputs.conclusion }}"
+          echo "e2e conclusion: ${C:-<none>}"
+          [ "$C" = "success" ]
   # ============================================================
   # SUMMARY
   # ============================================================


### PR DESCRIPTION
## What
Replaces the OCI container-instance e2e path with the **central pipeline** in `iblai/iblai-deploy-ops` — same style, gate and report as the stg2 release-validation flow.

## Flow (unchanged trigger: the `run-tests` label)
```
run-tests label → build the PR SPA image → dispatch iblai-deploy-ops/pr-e2e.yml
                → central pipeline: swap the env SPA to this PR image, build the Playwright
                  image from THIS PR sha, run the suite, publish the report, ALWAYS restore
                → this job polls and mirrors the result
```
Because the `e2e` job carries the real conclusion, **`PR E2E Tests (Required)` still works as a required check** and blocks merge until e2e passes. The workflow `name:`, trigger, path filters and concurrency are unchanged.

## Improvements over the OCI path
- **The env is restored afterwards.** The old flow `sed`-swapped the SPA image and never put it back — which is why stg1 was found still serving `iblai-mentor-spa-pro:pr-371-…` days later. Restore now runs `if: always()`.
- **Changed-spec detection** — if a PR only touches spec files (≤5), just those run (minutes instead of ~1h); any app-source change runs the full suite.
- **Real reports** — the standard S3/CloudFront report, regression-only gate, traces and 30-day history, instead of raw logs.
- **One less image build** — the central pipeline builds the Playwright image from the PR sha, so `build-playwright-image` is gone.
- Runs on the **stg1** environment via the maintained runner pool, so PR testing no longer competes with release validation on stg2.

## Safety (unchanged)
Both guards kept: the `run-tests` label (labels need write access, so a maintainer vouches) **and** `head.repo.full_name == github.repository` (no fork PRs). Dispatch+poll is required because a public repo cannot call a private reusable workflow.

## Requires
Org secret `DEPLOY_OPS_DISPATCH_TOKEN` (fine-grained PAT, Actions: read+write on `iblai-deploy-ops`) — already created and scoped to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)