### PR TITLE
fix(ci): run-name claimed 4 browsers when only chrome runs

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -24,7 +24,7 @@ on:
       - 'vitest.config.*'
       - 'playwright.config.*'
 
-run-name: 'PR E2E Tests — stg1 (firefox,chrome,safari,edge)'
+run-name: 'PR E2E — mentor #${{ github.event.pull_request.number }} → stg1 (chrome)'
 
 permissions:
   contents: read


### PR DESCRIPTION
One line. The workflow name has advertised four browsers since the OCI days:

```diff
-run-name: 'PR E2E Tests — stg1 (firefox,chrome,safari,edge)'
+run-name: 'PR E2E — mentor #${{ github.event.pull_request.number }} → stg1 (chrome)'
```

Only chrome has ever run. The old OCI job passed `browsers: 'chrome'` with `total-shards: 1`, whose own description reads *"1=single chrome"*; the central pipeline runs `--project=mentor-desktop-chrome`. The four-browser text was label only.

`playwright.config.ts` does declare all four projects — they have simply never been exercised in PR CI. Enabling them is a separate decision: mentor is ~545 specs / ~50 min on chrome, so four browsers would be ~3.5 h on a required check. Nightly or an opt-in label would suit better.

The new name also surfaces the PR number and target env, which beat a browser list that never changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)