### PR TITLE
fix(ci): queue guard must tell an offline runner from a busy one

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -207,6 +207,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+          TARGET_ENV: ${{ steps.env.outputs.target }}
         run: |
           set -uo pipefail
           # The central pipeline lives in a PRIVATE repo, so most contributors here cannot open its
@@ -217,16 +218,34 @@ jobs:
           # cannot tell that apart from idle. Without this guard the poll ran the full 2h and reported
           # a bare "timed_out", which says nothing about the cause. Fail in 15 min with a diagnosis.
           STARTED=0
+          STRIKES=0
           LAST=""
           for i in $(seq 1 240); do
             if [ "$STARTED" = "0" ]; then
               ACTIVE=$(gh api "repos/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}/jobs" \
                          --jq '[.jobs[] | select(.status != "queued")] | length' 2>/dev/null || echo 0)
               [ "${ACTIVE:-0}" -gt 0 ] && STARTED=1
-              if [ "$STARTED" = "0" ] && [ "$i" -ge 30 ]; then
-                echo "conclusion=runner_unavailable" >> "$GITHUB_OUTPUT"
-                echo "::error::the central run has been QUEUED for 15 min without starting a single job — the target environment's self-hosted runner is almost certainly offline. https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
-                exit 1
+              if [ "$STARTED" = "0" ]; then
+                # Distinguish OFFLINE from BUSY. Elapsed time alone cannot: with a single serialized
+                # runner and ~84-minute mentor suites, queueing well past 15 min is entirely normal,
+                # and an earlier version of this guard killed healthy runs because of that. An offline
+                # runner, by contrast, never appears executing ANY job anywhere — that is the signal.
+                RUNNER="${TARGET_ENV}-spa"
+                BUSY=$(for rid in $(gh run list -R iblai/iblai-deploy-ops --limit 10 \
+                                      --json databaseId --jq '.[].databaseId' 2>/dev/null); do
+                         gh api "repos/iblai/iblai-deploy-ops/actions/runs/$rid/jobs" \
+                           --jq '.jobs[] | select(.status=="in_progress") | .runner_name // empty' 2>/dev/null
+                       done | grep -cx "$RUNNER" || true)
+                if [ "${BUSY:-0}" -gt 0 ]; then
+                  STRIKES=0                       # runner is alive, we are simply queued behind work
+                else
+                  STRIKES=$((STRIKES + 1))        # queued AND nothing running on it
+                  if [ "$STRIKES" -ge 30 ]; then  # 15 min of both, consecutively
+                    echo "conclusion=runner_unavailable" >> "$GITHUB_OUTPUT"
+                    echo "::error::${RUNNER} has been idle for 15 min while this run stayed queued — the runner is offline or not accepting jobs. https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
+                    exit 1
+                  fi
+                fi
               fi
             fi        # up to 2h: image build + full suite
             PHASES=$(gh api "repos/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}/jobs" \


### PR DESCRIPTION
The guard added two PRs ago killed a **healthy** run. `os#390`, 18:09:

```
::error::the central run has been QUEUED for 15 min without starting a single job
         — the target environment's self-hosted runner is almost certainly offline
e2e conclusion: runner_unavailable
```

It was not offline. `stg1-spa` had been continuously busy with `os#361`'s 84-minute suite, and the central run went on to complete `drift check`, `swap mentor → PR image`, and start the suite normally.

### Root cause
I used **"time since dispatch with no job started"** as a proxy for **"runner offline"**. That proxy was reasonable when two environments shared the load. It is invalid now: with **stg1-only serialization and ~84-minute mentor suites, queueing well past 15 minutes is normal**.

### Worse than a wrong message
The caller failed while the central run kept going — **orphaning** it. It continued swapping the SPA and running a suite that nobody was waiting on, holding the runner and the env lock, with the PR showing a red `runner_unavailable`.

### The fix — measure the thing, not a proxy
An **offline runner never appears executing any job anywhere**. So:

| target runner | our run | → |
|---|---|---|
| busy | queued | keep waiting, **indefinitely** — this is normal |
| idle | queued, <15 min | keep waiting |
| **idle** | **queued, 15 consecutive min** | **fail `runner_unavailable`** |

Strikes reset the moment the runner is seen working, so a long queue behind a legitimate job can never trip it.

Verified against the real scenarios:
```
runner busy, 120 min   -> keep waiting ✓   (the os#390 case, now correct)
runner idle,  15 min   -> FAIL runner_unavailable ✓
runner idle,  14 min   -> keep waiting ✓
```

### Also fixes a live gap in iblai-web-frontend
It was generated from the os template **before** the stg1 pin landed, so it still carried the stg2 failover logic and had **no guard at all** — it could have dispatched to the environment that is currently down. Now identical to os and lms.

### Verification
Every `run:` block extracted and `bash -n`-checked; the strike logic exercised across all three boundaries; all three callers confirmed consistent on picker, strikes, message, and `TARGET_ENV` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)