### PR TITLE
fix(ci): push PR images to ECR instead of OCIR

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -88,8 +88,13 @@ jobs:
     with:
       dockerfile-path: Dockerfile
       build-context: .
-      image-name: iblai-mentor-spa-pro
-      registry-type: ocir
+      # Same repo as the release images; PR builds are distinguished by the `pr-` tag prefix.
+      image-name: iblai-os-spa
+      # ECR, not OCIR: the OCIR org secrets were removed, which broke every PR build with
+      # "Password required" at docker login. The AWS credentials are already provisioned here
+      # and release images already live in ECR, so this drops a registry dependency rather
+      # than replacing one with another.
+      registry-type: ecr
       event-name: pull_request
       pr-number: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
**Every PR build in this repo is currently broken.** Not caused by any PR.

```
build-app-image / build  →  step 10 "Log in to OCIR"
##[error]Password required
```

### Root cause
The **OCIR org secrets were removed**. `OCIR_AUTH_TOKEN` resolves to empty, so `docker login` fails before anything is built. This repo can currently see 6 org secrets and none are `OCIR_*`; the reusable's OCIR path needs four (`OCIR_AUTH_TOKEN`, `OCIR_USERNAME`, `OCIR_REGISTRY`, `OCIR_NAMESPACE`).

The timeline pins it to an infrastructure change, not code:
```
2026-07-29 19:11   build-app-image  SUCCESS
2026-07-30 05:41   build-app-image  FAILURE — Password required
```

### The fix
```diff
-      registry-type: ocir
-      image-name: <old -pro name>
+      registry-type: ecr
+      image-name: iblai-os-spa
```

The reusable already supports `registry-type: ecr`, and **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are already visible to this repo**. So this *removes* a registry dependency rather than swapping one for another — and puts PR images where release images already live.

PR builds are distinguished from releases by the tag: `iblai-os-spa:pr-390-abc` vs `iblai-os-spa:0.108.4`.

### Verified the existing safeguards still hold
- **drift check** excludes the SPA under test, so a PR image in the release repo cannot cause false drift
- **state-pollution guard** compares full `repo:tag`, and `iblai-os-spa:pr-…` ≠ `iblai-os-spa:<semver>`, so a PR run's fingerprint still differs from a release run's

### ⚠️ For whoever adds an ECR lifecycle policy to `iblai-os-spa`
It **must** be scoped to `tagPrefixList: ["pr-"]`. A blanket "expire after N days" on this repo would **delete release images**. PR images accumulate one per push and nothing cleans them up, so a scoped rule is worth adding — just not an unscoped one.

### Also note
The Playwright suite image is **not** pushed anywhere — deploy-ops builds it locally on the runner as `ibl-<platform>-playwright:local`. The old flow pushed both an app image and a Playwright image to OCIR; this pipeline pushes only the app image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)