### PR TITLE
fix(ci): cancel the dispatched run when the caller is cancelled

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -314,6 +314,20 @@ jobs:
             echo "::notice::QUEUE_EVICTION_COUNT=${EVICTIONS} for this PR"
           fi
           echo "conclusion=${CONCLUSION:-unknown}" >> "$GITHUB_OUTPUT"
+      - name: Cancel the dispatched run if this caller is cancelled
+        # A caller can be superseded (concurrency: pr-e2e-<PR>, cancel-in-progress) or cancelled by
+        # hand — but the central run it dispatched keeps going. That orphan occupies the single env
+        # runner for a full suite, produces a result nobody reads, and deepens the queue for everyone
+        # else. Worse, it can PASS while the PR shows red: os#394 did exactly that (456/0/3 green,
+        # PR reported "unknown"), because the surviving caller was watching a different run.
+        if: cancelled() && steps.dispatch.outputs.run_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          RUN_ID:   ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          echo "caller cancelled — cancelling central run ${RUN_ID} so it does not orphan"
+          gh run cancel "$RUN_ID" -R iblai/iblai-deploy-ops || true
+
       - name: Publish the result on this PR
         if: always() && steps.dispatch.outputs.run_id != ''
         env:


### PR DESCRIPTION
Cancelling a caller does **not** cancel the central run it dispatched. The orphan keeps running.

### It can invert a verdict
`os#394` is the proof:
```
central run 30564855132   SUCCESS   456 passed · 0 failed · 3 flaky   gate=PASS
PR #394 showed            ❌ red    "PR E2E - unknown / No report link"
```
The caller that dispatched the **passing** run was superseded by concurrency (`pr-e2e-<PR>`, `cancel-in-progress: true`). Its central run carried on unattended and passed. The surviving caller was watching a *different* run that had been cancelled, so it reported failure.

**A clean pass presented as a failure** — the inverse of the stale-image bug, and just as misleading.

### It also costs the queue
An orphan occupies the single env runner for a full ~74-minute suite producing a result nobody reads — while other PRs wait behind it. With everything pinned to stg1 that is expensive.

### The fix
```yaml
- name: Cancel the dispatched run if this caller is cancelled
  if: cancelled() && steps.dispatch.outputs.run_id != ""
  run: gh run cancel "$RUN_ID" -R iblai/iblai-deploy-ops || true
```

`|| true` deliberately: a best-effort cleanup must never itself fail the run, and the run may already have finished.

Observed twice today — os#390 during the guard incident, and os#394 above. Both times the orphan ran to completion on the shared runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)