### PR TITLE
fix(ci): queue time must not count against the execution timeout

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -230,9 +230,15 @@ jobs:
 
           # Returns: 0 = completed (CONCLUSION set) · 1 = timed out · 2 = EVICTED (retryable)
           poll_run() {
-            local i started=0 strikes=0 any_job=0 last="" phases active busy s
+            local i started=0 strikes=0 any_job=0 exec_ticks=0 last="" phases active busy s
             echo "Phases: resolve -> baseline drift check -> sync (only if drifted) -> swap SPA -> e2e -> restore"
-            for i in $(seq 1 240); do
+            # Two separate budgets. Queue time must NOT count against the execution timeout: with one
+            # serialized runner and ~75-min suites, a PR queued behind one other already exceeds 2h,
+            # and the caller would give up on a perfectly healthy run — then download a result
+            # artifact that does not exist yet and report "unknown". os#367 lost its report exactly
+            # this way (dispatched 17:11, started 18:27, verdict 19:45, caller gave up 19:25).
+            # While QUEUED the liveness guard below is the protection, not the clock.
+            for i in $(seq 1 960); do
               phases=$(gh api "repos/$OPS/actions/runs/${RUN_ID}/jobs" \
                          --jq '[.jobs[] | "\(.name): \(.conclusion // .status)"] | join("  |  ")' 2>/dev/null || echo "")
               if [ -n "$phases" ] && [ "$phases" != "$last" ]; then
@@ -241,7 +247,17 @@ jobs:
               if [ "$started" = "0" ]; then
                 active=$(gh api "repos/$OPS/actions/runs/${RUN_ID}/jobs" \
                            --jq '[.jobs[] | select(.status != "queued")] | length' 2>/dev/null || echo 0)
-                if [ "${active:-0}" -gt 0 ]; then started=1; any_job=1; fi
+                if [ "${active:-0}" -gt 0 ]; then
+                  started=1; any_job=1
+                  echo "[$(date -u +%H:%M:%SZ)] run started executing — 2h execution budget begins now"
+                fi
+              else
+                exec_ticks=$((exec_ticks + 1))
+                if [ "$exec_ticks" -ge 240 ]; then
+                  CONCLUSION=timed_out
+                  echo "::error::the run has been EXECUTING for 2h without finishing. https://github.com/$OPS/actions/runs/${RUN_ID}"
+                  return 1
+                fi
               fi
               if [ "$started" = "0" ]; then
                 # An offline runner never appears executing ANY job anywhere; a merely BUSY one does.
@@ -272,7 +288,7 @@ jobs:
               sleep 30
             done
             CONCLUSION=timed_out
-            echo "::error::timed out after 2h waiting for the e2e run"; return 1
+            echo "::error::gave up after 8h — the run neither started nor finished"; return 1
           }
 
           # Every waiter notices the freed slot within the same poll window and would dispatch in the
@@ -339,7 +355,17 @@ jobs:
           set -uo pipefail
           # The Playwright report on tests.iblai.app IS public, so it is the link that actually helps
           # a developer here — unlike the private Actions run. Relay it onto the PR itself.
-          gh run download "$RUN_ID" -R iblai/iblai-deploy-ops -n pr-e2e-result -D /tmp/res 2>/dev/null || true
+          # Retry briefly: the artifact is uploaded by the central run's LAST job, so a caller that
+          # reaches here early (or races the upload) would otherwise silently render "unknown" and
+          # throw away a perfectly good result — which is exactly how os#367 lost its report link.
+          for a in 1 2 3 4 5 6; do
+            gh run download "$RUN_ID" -R iblai/iblai-deploy-ops -n pr-e2e-result -D /tmp/res 2>/dev/null && break
+            echo "  result artifact not available yet (attempt $a/6) — retrying in 20s"
+            sleep 20
+          done
+          if [ ! -f /tmp/res/pr-e2e-result.json ]; then
+            echo "::warning::could not download pr-e2e-result from run ${RUN_ID} — the comment will lack a report link. https://github.com/iblai/iblai-deploy-ops/actions/runs/${RUN_ID}"
+          fi
           python3 - <<'PY' > /tmp/body.md
           import json, pathlib
           p = pathlib.Path("/tmp/res/pr-e2e-result.json")


### PR DESCRIPTION
`os#367` finished with **no report link**. The result was fine — the artifact carried a valid `report_url`, `459`-style totals and all — but nobody was listening by the time it existed.

```
caller  Wait for e2e:  17:11:55 → 19:25:54    ← gave up after 2h
caller  Publish:       19:25:55               ← downloaded the artifact here
central verdict job:   19:44:56 → 19:45:03    ← artifact uploaded 19 MIN LATER
```

### Root cause
The run was dispatched at **17:11** but only began executing at **18:27** — 76 minutes queued behind another PR. The suite then ran ~75 minutes.

**The 2h budget started ticking at dispatch**, so most of it was consumed by queueing. The caller abandoned a perfectly healthy run, then downloaded an artifact that did not exist yet and rendered `unknown`.

With one serialized runner and ~75-minute suites, **a PR queued behind a single other PR already exceeds 2h**. The timeout was measuring the wrong thing — it bounded *waiting plus running* when it should bound *running*.

### The fix — two budgets
| phase | bound |
|---|---|
| **queued** | no clock — the busy-vs-offline **liveness guard** is the protection (it already distinguishes "runner idle and we are stuck" from "runner busy, we are legitimately waiting") |
| **executing** | **2h**, starting when the first job leaves `queued` |

The log now says so explicitly:
```
[18:27:03Z] run started executing — 2h execution budget begins now
```

### Also — stop discarding good results
The result artifact is uploaded by the central run's **last** job, so a caller arriving early loses it. The download now retries (6 × 20s) and, if still missing, emits a `::warning::` with the run URL rather than silently rendering "unknown".

That is what turns "the pipeline is broken" into "the report is late", which is a very different conversation with the team.

### Replay
`os#367`: queued 76 min (no longer fatal) + ran 75 min → would have completed and posted its report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)