### PR TITLE
fix(pr-e2e): make the eviction retry reachable and kill orphaned central runs

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -189,6 +189,33 @@ jobs:
           TARGET="$TARGET_ENV"
           RUNNER="${TARGET}-spa"
           OPS=iblai/iblai-deploy-ops
+          # The central run-name, reproduced exactly, so we can find OUR runs and only ours.
+          MYTITLE="PR e2e — os#${PR} → ${TARGET}"
+
+          # A superseded caller (label removed+re-added, or a new push) leaves the central run it
+          # already dispatched ORPHANED: nothing polls it, its result is discarded, yet it holds the
+          # single env runner for a full ~74-min suite and deepens the queue for everyone else.
+          # Cleanup cannot live in the DYING caller — a cancelled job is the least reliable place to
+          # run anything, and a caller killed before its dispatch step published outputs has no run
+          # id to clean up with. So the SURVIVING caller does it: before claiming a slot, cancel any
+          # still-active central run for this same PR. Only one caller per PR is ever alive
+          # (concurrency: pr-e2e-<PR>, cancel-in-progress), so any other active run for this exact
+          # title is by definition an orphan.
+          cancel_stale_siblings() {
+            local ids id
+            ids=$(MYTITLE="$MYTITLE" gh run list -R "$OPS" --workflow=pr-e2e.yml --limit 40 \
+                    --json databaseId,status,displayTitle \
+                    --jq '[.[] | select((.status=="queued" or .status=="pending" or .status=="in_progress")
+                                        and .displayTitle==env.MYTITLE) | .databaseId] | .[]' 2>/dev/null) || ids=""
+            for id in $ids; do
+              [ "$id" = "${RUN_ID:-}" ] && continue
+              echo "::warning::cancelling orphaned central run ${id} for this PR — superseded by this caller"
+              gh run cancel "$id" -R "$OPS" >/dev/null 2>&1 || true
+            done
+            # Never let this housekeeping abort the step: it runs unguarded under `bash -e`, and a
+            # transient `gh` failure or an empty result must be a no-op, not a dead PR check.
+            return 0
+          }
 
           # GitHub keeps only ONE pending run per concurrency group. A third dispatch CANCELS the
           # previously-pending one before it starts a single job — silently, with no diagnosis on the
@@ -309,11 +336,18 @@ jobs:
 
           RUN_ID=""; CONCLUSION=""; EVICTIONS=0
           for attempt in $(seq 1 10); do
+            cancel_stale_siblings
             stagger_then_claim || { echo "conclusion=no_slot" >> "$GITHUB_OUTPUT"; exit 1; }
             do_dispatch  || { echo "::error::dispatched but the run never appeared"; echo "conclusion=dispatch_failed" >> "$GITHUB_OUTPUT"; exit 1; }
             echo "dispatched run $RUN_ID (attempt $attempt)"
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-            poll_run; rc=$?
+            # `run:` steps execute under `bash -e` (see the job log's "shell: /usr/bin/bash -e {0}"),
+            # and `set -uo pipefail` above does NOT clear errexit. A bare `poll_run; rc=$?` therefore
+            # terminates the whole step the instant poll_run returns non-zero — so the eviction branch
+            # below was unreachable dead code, and every evicted run died as a bare "exit code 2" with
+            # no conclusion, no retry and no report link (os#367, 2026-07-30). Guarding the call keeps
+            # errexit on for everything else while letting the return value reach $rc.
+            rc=0; poll_run || rc=$?
             if [ "$rc" -eq 2 ]; then
               EVICTIONS=$((EVICTIONS + 1))
               # Greppable marker: this is the signal to watch. If evictions become routine the


### PR DESCRIPTION
## Why

`os#367` ran the full pipeline and finished with **no report and no verdict**
([run](https://github.com/iblai/os/actions/runs/30583844163)). Root-causing it turned up two
distinct defects — neither of them the queue design itself.

### 1. `bash -e` made the eviction retry unreachable

GitHub runs `run:` steps under `bash -e` (the job log literally prints
`shell: /usr/bin/bash -e {0}`), and the step's `set -uo pipefail` does **not** clear errexit.
So this line:

```bash
poll_run; rc=$?
```

terminates the step the instant `poll_run` returns non-zero. `rc=$?` never executes, and the
`if [ "$rc" -eq 2 ]` eviction branch beneath it was **dead code from the day it was written**.

Reproduction, matching the failing run exactly:

```console
$ bash -e -c 'set -uo pipefail; poll_run(){ return 2; }
    for a in 1 2 3; do poll_run; rc=$?
      if [ "$rc" -eq 2 ]; then echo "RETRY $a"; continue; fi; break; done
    echo "conclusion=done"'
$ echo $?
2                     # nothing printed, no retry — exactly os#367's "exit code 2"
```

What actually happened to os#367:

```
21:41:30  stagger 35s (PR 367)
21:42:14  dispatched run 30584429876 (attempt 1)
22:15:44  ##[error]Process completed with exit code 2
```

Central run `30584429876` shows the textbook eviction signature — `cancelled` with **zero jobs
ever started**. It was evicted from the single pending slot when another PR dispatched at 22:15
(GitHub keeps only one pending run per concurrency group). The retry existed to handle precisely
this and could never fire, so `conclusion=` was never written and the gate reported `unknown`
with no report link.

### 2. Superseded callers leave orphaned central runs

Removing and re-adding the label starts a second caller. `concurrency: pr-e2e-<PR>` cancels the
first — but the **central run it already dispatched keeps running**. Nothing polls it, its result
is discarded, and it occupies the single env runner for a full ~74-minute suite while the real
run queues behind it. `os#394` ran twice this way today; the zombie had to be cancelled by hand.

The existing `if: cancelled()` cleanup step cannot fix this: it asks a **process being killed** to
clean up its own child, and a caller killed before its dispatch step published outputs has no run
id to clean up with.

## What changed

- `rc=0; poll_run || rc=$?` — the return value reaches `$rc` instead of terminating the shell.
  errexit stays on for everything else.
- New `cancel_stale_siblings()`, called at the top of each dispatch attempt: the **surviving**
  caller cancels any still-active central run for this same PR before claiming a slot. Only one
  caller per PR is ever alive, so any other active run with this exact title is by definition an
  orphan. It returns 0 unconditionally and tolerates a failing `gh`, so housekeeping can never
  abort the PR check.

## Verification

- `ruby -ryaml` parse + `bash -n` on the extracted step — all three repos.
- Retry loop with a stubbed `poll_run` returning 2 twice: now retries and exits 0 with
  `conclusion=success` (was: immediate exit 2).
- `cancel_stale_siblings` against a stubbed run list — cancels the orphan, spares our own run,
  ignores `completed` runs, ignores other PRs, and ignores `lms#394` when we are `os#394`.
- Failing-`gh` regression: step continues, exit 0.

Same change is going into `os`, `lms`, and `iblai-web-frontend` together, since all three
callers share this step.

> [!IMPORTANT]
> Because `pull_request` runs use the workflow from the **merge commit**, already-open PRs keep
> running the old step until `main` is merged into their branch. That staleness is what let a
> pre-guard caller evict `os#367` in the first place.
