### PR TITLE
chore(deps): bump @iblai/iblai-js to 2.2.7

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -181,8 +181,8 @@ jobs:
       - name: Dispatch e2e and wait for the result
         id: dispatch
         env:
-          GH_TOKEN:   ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
-          PR:         ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
           TARGET_ENV: ${{ steps.env.outputs.target }}
         run: |
           set -uo pipefail
@@ -373,7 +373,7 @@ jobs:
         if: cancelled() && steps.dispatch.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}
-          RUN_ID:   ${{ steps.dispatch.outputs.run_id }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
         run: |
           echo "caller cancelled — cancelling central run ${RUN_ID} so it does not orphan"
           gh run cancel "$RUN_ID" -R iblai/iblai-deploy-ops || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,48 +4,48 @@
 
 ### Bug Fixes
 
-* **pr-e2e:** make the eviction retry reachable and kill orphaned central runs ([8594bb2](https://github.com/iblai/os/commit/8594bb23084b554ad4b5ef63e0ceb80bee39c22b)), closes [os#367](https://github.com/iblai/os/issues/367) [os#394](https://github.com/iblai/os/issues/394)
+- **pr-e2e:** make the eviction retry reachable and kill orphaned central runs ([8594bb2](https://github.com/iblai/os/commit/8594bb23084b554ad4b5ef63e0ceb80bee39c22b)), closes [os#367](https://github.com/iblai/os/issues/367) [os#394](https://github.com/iblai/os/issues/394)
 
 ## [0.108.10](https://github.com/iblai/os/compare/v0.108.9...v0.108.10) (2026-07-30)
 
 ### Bug Fixes
 
-* **ci:** queue time must not count against the execution timeout ([e79488c](https://github.com/iblai/os/commit/e79488c2e5dd93187da2114b839f0608fdb75a6a)), closes [os#367](https://github.com/iblai/os/issues/367)
+- **ci:** queue time must not count against the execution timeout ([e79488c](https://github.com/iblai/os/commit/e79488c2e5dd93187da2114b839f0608fdb75a6a)), closes [os#367](https://github.com/iblai/os/issues/367)
 
 ## [0.108.9](https://github.com/iblai/os/compare/v0.108.8...v0.108.9) (2026-07-30)
 
 ### Bug Fixes
 
-* **iframe:** dispatch EDX metadata via chatActions.setMetadata ([0dbaac0](https://github.com/iblai/os/commit/0dbaac04c3562b9e21385ed9b9c6a629a1eec022))
-* **test:** drop spurious 3rd it.each arg in scrollbar-gutter test ([54fe443](https://github.com/iblai/os/commit/54fe443b5b484d901a318164c6f603fe435019fd)), closes [#2260](https://github.com/iblai/os/issues/2260)
-* **welcome-chat:** match the default welcome message to the chat input width ([05d53d5](https://github.com/iblai/os/commit/05d53d5abc4230af8c627e57ee29dece42ea9825))
+- **iframe:** dispatch EDX metadata via chatActions.setMetadata ([0dbaac0](https://github.com/iblai/os/commit/0dbaac04c3562b9e21385ed9b9c6a629a1eec022))
+- **test:** drop spurious 3rd it.each arg in scrollbar-gutter test ([54fe443](https://github.com/iblai/os/commit/54fe443b5b484d901a318164c6f603fe435019fd)), closes [#2260](https://github.com/iblai/os/issues/2260)
+- **welcome-chat:** match the default welcome message to the chat input width ([05d53d5](https://github.com/iblai/os/commit/05d53d5abc4230af8c627e57ee29dece42ea9825))
 
 ### Tests
 
-* **chat:** close the remaining [#2260](https://github.com/iblai/os/issues/2260) coverage gaps ([08d838b](https://github.com/iblai/os/commit/08d838b2d1fc2ea5faee61463a1ce5bd6f0e12c9))
+- **chat:** close the remaining [#2260](https://github.com/iblai/os/issues/2260) coverage gaps ([08d838b](https://github.com/iblai/os/commit/08d838b2d1fc2ea5faee61463a1ce5bd6f0e12c9))
 
 ### CI
 
-* adopt the current PR-e2e caller on this branch ([f7ff4e5](https://github.com/iblai/os/commit/f7ff4e55c2979c3cfe7b3c5a0a29d9f045e296f1))
+- adopt the current PR-e2e caller on this branch ([f7ff4e5](https://github.com/iblai/os/commit/f7ff4e55c2979c3cfe7b3c5a0a29d9f045e296f1))
 
 ## [0.108.8](https://github.com/iblai/os/compare/v0.108.7...v0.108.8) (2026-07-30)
 
 ### Bug Fixes
 
-* **ci:** cancel the dispatched run when the caller is cancelled ([dbc4259](https://github.com/iblai/os/commit/dbc425961e79fcc730a5b4ceb21a82350703be69)), closes [os#394](https://github.com/iblai/os/issues/394)
+- **ci:** cancel the dispatched run when the caller is cancelled ([dbc4259](https://github.com/iblai/os/commit/dbc425961e79fcc730a5b4ceb21a82350703be69)), closes [os#394](https://github.com/iblai/os/issues/394)
 
 ## [0.108.7](https://github.com/iblai/os/compare/v0.108.6...v0.108.7) (2026-07-30)
 
 ### Bug Fixes
 
-* **ci:** make the e2e queue survive three concurrent PRs ([4f27b31](https://github.com/iblai/os/commit/4f27b31c614dc4144198f3c64ef4fbaf582882f5)), closes [os#390](https://github.com/iblai/os/issues/390) [#394](https://github.com/iblai/os/issues/394) [#390](https://github.com/iblai/os/issues/390) [#367](https://github.com/iblai/os/issues/367)
-* **ci:** stagger the dispatch so N waiters do not collide ([aef9cc3](https://github.com/iblai/os/commit/aef9cc3d063402622ce1cc0595b887769046c881))
+- **ci:** make the e2e queue survive three concurrent PRs ([4f27b31](https://github.com/iblai/os/commit/4f27b31c614dc4144198f3c64ef4fbaf582882f5)), closes [os#390](https://github.com/iblai/os/issues/390) [#394](https://github.com/iblai/os/issues/394) [#390](https://github.com/iblai/os/issues/390) [#367](https://github.com/iblai/os/issues/367)
+- **ci:** stagger the dispatch so N waiters do not collide ([aef9cc3](https://github.com/iblai/os/commit/aef9cc3d063402622ce1cc0595b887769046c881))
 
 ## [0.108.6](https://github.com/iblai/os/compare/v0.108.5...v0.108.6) (2026-07-30)
 
 ### Bug Fixes
 
-* **ci:** push PR images to ECR instead of OCIR ([a149ca7](https://github.com/iblai/os/commit/a149ca7b8a2dbae76cc14968b1193b5bbe47dc5c))
+- **ci:** push PR images to ECR instead of OCIR ([a149ca7](https://github.com/iblai/os/commit/a149ca7b8a2dbae76cc14968b1193b5bbe47dc5c))
 
 ## [0.108.5](https://github.com/iblai/os/compare/v0.108.4...v0.108.5) (2026-07-30)
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@iblai/agent-ai": "2.5.2",
     "@iblai/iblai-api": "4.166.0-ai",
-    "@iblai/iblai-js": "1.27.1",
+    "@iblai/iblai-js": "2.2.7",
     "@iblai/iblai-web-mentor": "1.3.4",
     "@livekit/components-react": "2.8.1",
     "@livekit/components-styles": "1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 4.166.0-ai
         version: 4.166.0-ai
       '@iblai/iblai-js':
-        specifier: 1.27.1
-        version: 1.27.1(9c4bf11f74dcb8c14d4674502b60767d)
+        specifier: 2.2.7
+        version: 2.2.7(9c4bf11f74dcb8c14d4674502b60767d)
       '@iblai/iblai-web-mentor':
         specifier: 1.3.4
         version: 1.3.4(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2)(typescript@5.9.3)
@@ -858,8 +858,8 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@iblai/data-layer@1.9.7':
-    resolution: {integrity: sha512-cFQVESmMM+Zd1gxv8jJRIOwhyjQKgkZnrAPWPkbQkdItT0IhWSXW7T1ZjwlmFgdBlYJUoxtE989Uzeg84sTS3Q==}
+  '@iblai/data-layer@1.11.1':
+    resolution: {integrity: sha512-6fPaubA5K0OpulItPzelXAAm+2/RtfmNxIi7oxwpsbc/7lcij+G54qYDE3E7vSD0CywjuRE0Uq0YfAETDZJKxg==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@reduxjs/toolkit': 2.7.0
@@ -870,8 +870,8 @@ packages:
   '@iblai/iblai-api@4.166.0-ai':
     resolution: {integrity: sha512-dY9Jv+CkXEyTxRsOQFay5YvYe8K2LSQluJJvtssGQV2RbrxPPzONaKfnhcyarDs7Ft35Xqk1fuErjhUwNG3OIg==}
 
-  '@iblai/iblai-js@1.27.1':
-    resolution: {integrity: sha512-q3aReBd9zaKD9YhpCJAy8XHfQIg6nm581IFDo2WnFO7ITUr8IaOLZwOkR9c1MNFOQv0Pf1ftUDu5lqCtDCPRtQ==}
+  '@iblai/iblai-js@2.2.7':
+    resolution: {integrity: sha512-LmVVPa5/zHnsuZEobJ02vMmjY/iUzUhwMoUmmHvserJ0MrHBnnIqHgHYpKjrNnm1nyPDUKI1lXhauXERwC4v4A==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -895,18 +895,18 @@ packages:
   '@iblai/iblai-web-mentor@1.3.4':
     resolution: {integrity: sha512-w0K22cQl/LquXDDnVi7DgiOeuS+iha85poZxuLCtJqvwyCxAMLch1DWN3LbNCxw+YGhrV7BOEENp8s7bZ+7ZGw==}
 
-  '@iblai/mcp@1.8.3':
-    resolution: {integrity: sha512-3hmPUyfOaS07NUABSnrsyXSDzc/AROSJyUJmk4xSaCE7eMtBuIUXxfImPa04jUV76s9e8aU1ZaUbkmjLkAMyqQ==}
+  '@iblai/mcp@1.8.4':
+    resolution: {integrity: sha512-oUkiKAUysMjnNEpGceMuDtErJzsmwgmUn2xOkOV2hNICH3VdFOidlXdidqdL/AuhhCJvy4EO7NB3m9rQ/IVoOw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@iblai/web-containers@1.15.7':
-    resolution: {integrity: sha512-XiqomBavZ4xuBZJSIsvtygqIaOrUlk3gYyAsOp91lhjzy9aIdCXyoXD3NP5j1ZH/xsK7ReTT98GwjCxN4rzV1A==}
+  '@iblai/web-containers@1.15.8':
+    resolution: {integrity: sha512-DNucLqBAFYac9cA3a16Mpab90I6qhEsFB8DNJdYRTtWtE+KN/h/n+dV+cz4WKa56bLHL3jrQlANfxzqsiG341g==}
     engines: {node: 25.3.0}
     peerDependencies:
-      '@iblai/data-layer': 1.9.7
+      '@iblai/data-layer': 1.11.1
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.14.1
+      '@iblai/web-utils': 2.1.5
       '@livekit/components-react': 2.8.1
       '@radix-ui/react-dialog': ^1.1.7
       '@reduxjs/toolkit': 2.7.0
@@ -926,8 +926,8 @@ packages:
       sonner:
         optional: true
 
-  '@iblai/web-utils@1.14.1':
-    resolution: {integrity: sha512-SG3wcdrP91c73cGF4RaCIJpYdRMktsQop7dhfF2nsAxll2oRuuqKAeiPzZx3quPU5Ln1/mSV2vxrJi50DuSw0A==}
+  '@iblai/web-utils@2.1.6':
+    resolution: {integrity: sha512-znnXPvVKIPs9z58GE+ez/RobwMc4Zb+2JimtibkOBbyfYRipnAH41cWctCDpuwiou93RPmT9VU+/zgmGgVQllA==}
     engines: {node: 25.3.0}
     peerDependencies:
       '@iblai/data-layer': ^1.1.2
@@ -9924,7 +9924,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@iblai/data-layer@1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -9938,13 +9938,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@iblai/iblai-js@1.27.1(9c4bf11f74dcb8c14d4674502b60767d)':
+  '@iblai/iblai-js@2.2.7(9c4bf11f74dcb8c14d4674502b60767d)':
     dependencies:
-      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/mcp': 1.8.3
-      '@iblai/web-containers': 1.15.7(a94da25af4e66ad78d5b6a8d56c611bd)
-      '@iblai/web-utils': 1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/mcp': 1.8.4
+      '@iblai/web-containers': 1.15.8(b76c29ebb6fddbe1017b5845623760cf)
+      '@iblai/web-utils': 2.1.6(@iblai/data-layer@1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@reduxjs/toolkit': 2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.18.1
@@ -9985,7 +9985,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@iblai/mcp@1.8.3':
+  '@iblai/mcp@1.8.4':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
@@ -9993,11 +9993,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@iblai/web-containers@1.15.7(a94da25af4e66ad78d5b6a8d56c611bd)':
+  '@iblai/web-containers@1.15.8(b76c29ebb6fddbe1017b5845623760cf)':
     dependencies:
-      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
-      '@iblai/web-utils': 1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@iblai/web-utils': 2.1.6(@iblai/data-layer@1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@radix-ui/react-accordion': 1.2.8(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.7(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox': 1.2.3(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -10081,9 +10081,9 @@ snapshots:
       - supports-color
       - vinxi
 
-  '@iblai/web-utils@1.14.1(@iblai/data-layer@1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@iblai/web-utils@2.1.6(@iblai/data-layer@1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(@iblai/iblai-api@4.166.0-ai)(@tauri-apps/api@2.11.0)(@tauri-apps/plugin-os@2.3.2)(@types/react@19.1.17)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.0)(@types/node@20.17.48)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(redux@5.0.1)(sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@iblai/data-layer': 1.9.7(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      '@iblai/data-layer': 1.11.1(@reduxjs/toolkit@2.7.0(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@iblai/iblai-api': 4.166.0-ai
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.1.17)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       axios: 1.18.1


### PR DESCRIPTION
## Summary

Bumps `@iblai/iblai-js` from **1.27.1 → 2.2.7** (+ `pnpm-lock.yaml`).

Transitive SDK moves: `@iblai/web-utils` 1.14.1→2.1.6, `web-containers` 1.15.7→1.15.8, `data-layer` 1.9.7→1.11.1. Public type surfaces are purely additive (no removed exports / changed signatures); all import subpaths the app uses still exist.

## Verification

- `pnpm typecheck` — clean
- `pnpm build` — clean (standalone output produced)
- `pnpm test` — 395 files, 10,583 tests passed
- E2E journey coverage — unchanged (592 checkpoints, no regression)

## Notes for reviewers

- **Auth redirect param rename (native only):** the SDK renames the Tauri auth-redirect param `&token=` → `&edx_jwt_token=`. If the deployed auth SPA still reads `token`, desktop users lose session preservation and hit a full re-login. Confirm the auth SPA ships the new param first — this is the item to gate merge on. (CI can't catch it; nothing tests the param name.)
- **Peer-dep mismatch:** `web-containers@1.15.8` peer-pins `web-utils` at exactly `2.1.5`, but the tree installs `2.1.6`. Warning-only today, but would break `pnpm install --frozen-lockfile` if `strict-peer-dependencies` is enabled. Fix is upstream in the published SDK.
- Two unrelated prettier reformats (`CHANGELOG.md`, `pr-e2e-tests.yml`) rode along via the mandatory pre-commit formatter — pre-existing drift on `main`, harmless whitespace/bullet-style only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)