### PR TITLE
fix(seo): correctly-cased agent titles + server-rendered h1 (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* **ci:** import Developer ID cert so DMG re-master can re-sign ([4dc3ce8](https://github.com/iblai/os/commit/4dc3ce82caf4b86939598c0a1a6e033212141cd8))
+- **ci:** import Developer ID cert so DMG re-master can re-sign ([4dc3ce8](https://github.com/iblai/os/commit/4dc3ce82caf4b86939598c0a1a6e033212141cd8))
 
 ## [0.111.0](https://github.com/iblai/os/compare/v0.110.1...v0.111.0) (2026-08-03)
 

--- a/app/platform/[tenantKey]/[mentorId]/page.tsx
+++ b/app/platform/[tenantKey]/[mentorId]/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from 'next';
 
 import type { TenantKeyMentorIdParams } from '@/lib/types';
-import { buildMentorMetadata, mentorJsonLd } from '@/lib/seo-mentor';
+import {
+  buildMentorMetadata,
+  mentorJsonLd,
+  fetchMentorDisplayName,
+} from '@/lib/seo-mentor';
 import { JsonLd } from '@/components/seo/json-ld';
 
 import MentorPageContent from './mentor-page-content';
@@ -27,12 +31,20 @@ export default async function Page({
   params: Promise<TenantKeyMentorIdParams>;
 }) {
   const { tenantKey, mentorId } = await params;
-  // Deduped with generateMetadata's fetch within the same request.
-  const jsonLd = await mentorJsonLd(tenantKey, mentorId);
+  // Both reuse the same public-settings fetch as generateMetadata (deduped
+  // within the request), so this adds no extra network round-trips.
+  const [jsonLd, agentName] = await Promise.all([
+    mentorJsonLd(tenantKey, mentorId),
+    fetchMentorDisplayName(tenantKey, mentorId),
+  ]);
 
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
+      {/* Server-rendered page heading for crawlers and screen readers. Visually
+          hidden (sr-only) so the chat UI is unchanged — the SPA draws the visible
+          chrome after it hydrates. */}
+      {agentName && <h1 className="sr-only">{agentName}</h1>}
       <MentorPageContent />
     </>
   );

--- a/lib/__tests__/seo-mentor.test.ts
+++ b/lib/__tests__/seo-mentor.test.ts
@@ -21,6 +21,8 @@ import {
   fetchMentorPublicMeta,
   buildMentorMetadata,
   mentorJsonLd,
+  normalizeAcronyms,
+  fetchMentorDisplayName,
 } from '@/lib/seo-mentor';
 
 const fetchMock = vi.fn();
@@ -151,5 +153,58 @@ describe('mentorJsonLd', () => {
       image: 'https://img/x.png',
       provider: { '@type': 'Organization', name: 'ibl.ai' },
     });
+  });
+});
+
+describe('normalizeAcronyms', () => {
+  it('uppercases known acronyms that were naively title-cased', () => {
+    expect(normalizeAcronyms('Hr Agent')).toBe('HR Agent');
+    expect(normalizeAcronyms('It Help Desk Agent')).toBe('IT Help Desk Agent');
+    expect(normalizeAcronyms('Kyc Aml Agent')).toBe('KYC AML Agent');
+  });
+
+  it('leaves already-correct names untouched (idempotent)', () => {
+    expect(normalizeAcronyms('HR Assistant')).toBe('HR Assistant');
+    expect(normalizeAcronyms(normalizeAcronyms('Hr Agent'))).toBe('HR Agent');
+  });
+
+  it('only matches whole words, not acronym substrings', () => {
+    // "Hit" contains "it" but is a distinct word, so it must stay as-is.
+    expect(normalizeAcronyms('Hit List')).toBe('Hit List');
+    expect(normalizeAcronyms('Marketing Agent')).toBe('Marketing Agent');
+  });
+});
+
+describe('buildMentorMetadata — acronym casing (integration)', () => {
+  it('fixes acronym casing in the title of a public agent', async () => {
+    respond({ allow_anonymous: true, mentor_name: 'It Help Desk Agent' });
+    const m = await buildMentorMetadata('acme', 'x');
+    expect(m.title).toBe('IT Help Desk Agent');
+  });
+});
+
+describe('fetchMentorDisplayName', () => {
+  it('returns the acronym-normalized name for a mentor that has one', async () => {
+    respond({ allow_anonymous: true, mentor_name: 'It Help Desk Agent' });
+    expect(await fetchMentorDisplayName('acme', 'x')).toBe(
+      'IT Help Desk Agent',
+    );
+  });
+
+  it('returns the name even for a non-public mentor (h1 is a11y, not indexing)', async () => {
+    respond({ allow_anonymous: false, mentor_name: 'Enrollment' });
+    expect(await fetchMentorDisplayName('highereducation', 'x')).toBe(
+      'Enrollment',
+    );
+  });
+
+  it('returns null when the mentor has no name', async () => {
+    respond({ allow_anonymous: true });
+    expect(await fetchMentorDisplayName('acme', 'x')).toBeNull();
+  });
+
+  it('returns null when the fetch fails', async () => {
+    respond({}, false);
+    expect(await fetchMentorDisplayName('acme', 'x')).toBeNull();
   });
 });

--- a/lib/seo-mentor.ts
+++ b/lib/seo-mentor.ts
@@ -87,6 +87,52 @@ export async function fetchMentorPublicMeta(
 }
 
 /**
+ * Acronyms that must stay fully uppercase in agent titles/headings. The backend
+ * sometimes stores naively title-cased names (slug "hr-agent" -> "Hr Agent"), so
+ * we correct them for SEO output.
+ */
+const ACRONYMS = new Set([
+  'HR',
+  'IT',
+  'KYC',
+  'AML',
+  'AI',
+  'SIS',
+  'LMS',
+  'CRM',
+  'API',
+  'UI',
+  'UX',
+  'QA',
+  'SEO',
+]);
+
+/**
+ * Uppercase any whole word that matches a known acronym; leave every other word
+ * untouched. Fixes "Hr Agent" -> "HR Agent" and "Kyc Aml Agent" -> "KYC AML
+ * Agent" without disturbing already-correct names ("HR Assistant" stays).
+ * Idempotent.
+ */
+export function normalizeAcronyms(name: string): string {
+  return name.replace(/\p{L}+/gu, (word) =>
+    ACRONYMS.has(word.toUpperCase()) ? word.toUpperCase() : word,
+  );
+}
+
+/**
+ * The public agent's display name (acronyms fixed), or null when unavailable.
+ * Used to server-render an `<h1>` so crawlers and screen readers see the page's
+ * heading even before the client app hydrates.
+ */
+export async function fetchMentorDisplayName(
+  org: string,
+  mentor: string,
+): Promise<string | null> {
+  const meta = await fetchMentorPublicMeta(org, mentor);
+  return meta?.name ? normalizeAcronyms(meta.name) : null;
+}
+
+/**
  * Build the `Metadata` for a mentor page. Public mentors get rich, indexable
  * metadata (name, description, avatar card); everything else stays noindex.
  */
@@ -102,7 +148,7 @@ export async function buildMentorMetadata(
     return buildMetadata({ path });
   }
 
-  const name = meta.name ?? 'AI Agent';
+  const name = normalizeAcronyms(meta.name ?? 'AI Agent');
   const description =
     meta.description ?? `Chat with ${name}, an AI agent on ${SITE_NAME}.`;
 
@@ -125,7 +171,7 @@ export async function mentorJsonLd(
   if (!meta?.isPublic) return null;
 
   const origin = await getSiteUrl();
-  const name = meta.name ?? 'AI Agent';
+  const name = normalizeAcronyms(meta.name ?? 'AI Agent');
 
   return {
     '@context': 'https://schema.org',


### PR DESCRIPTION
Addresses two of the four agent-page SEO defects from #401 (the frontend-fixable ones).

## Changes
- **Acronym casing** — `normalizeAcronyms()` uppercases known acronyms (HR/IT/KYC/AML/AI/…), so `Hr Agent` → **`HR Agent`**, `Kyc Aml Agent` → **`KYC AML Agent`**. Applied to the `<title>`, JSON-LD name, and the `<h1>`. Idempotent — already-correct names (`HR Assistant`) are untouched.
- **Missing `<h1>`** — the page now server-renders a **visually-hidden (`sr-only`) `<h1>`** with the agent name, so crawlers and screen readers get a heading before the SPA hydrates. The visible chat UI is unchanged. Reuses the same public-settings fetch as `generateMetadata` (request-deduped, no extra round-trips).

Files: `lib/seo-mentor.ts`, `app/platform/[tenantKey]/[mentorId]/page.tsx`, + tests (`lib/__tests__/seo-mentor.test.ts`, 21 passing, `seo-mentor.ts` at 100% line coverage).

## Deliberately not in this PR
- **Duplicate titles (segment qualifier)** — dropped per discussion; not needed for now.
- **The two generic-fallback pages** (Enrollment, Financial Aid) — they're configured `viewable_by_tenant_students` (non-public), so the app correctly noindexes them. **They need to be made public in tenant config** — not a code change.
- The backend's stored `mentor_name` casing (this PR fixes the SEO output; the chat UI still shows the stored name).

## Verification
typecheck clean; 21 unit tests pass; the pre-push gate ran fully green (coverage/e2e/review) before landing. Happy to re-audit against a preview deploy per the issue author's offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)