### PR TITLE
feat(ci): slash commands for PR e2e — /retest, /status, /report, /cancel

### DIFF
--- a/.github/workflows/pr-e2e-commands.yml
+++ b/.github/workflows/pr-e2e-commands.yml
@@ -1,0 +1,48 @@
+name: PR e2e commands
+
+# Slash commands for the PR e2e pipeline: /retest, /retest <spec>, /status, /report, /cancel.
+#
+# SECURITY — why this shape is safe on a PUBLIC repo:
+#   1. `issue_comment` runs this workflow from the DEFAULT BRANCH, never from the PR. A fork PR
+#      cannot edit this file to weaken its own checks.
+#   2. Authorization is a repo COLLABORATOR PERMISSION check (write/maintain/admin) inside the
+#      action — NOT `author_association`, which reports MEMBER for org members with no write
+#      access here and would let them occupy a shared test environment.
+#   3. Fork PRs are refused, mirroring the `gate` job in pr-e2e-tests.yml.
+#   4. `permissions` below is the minimum: label + comment + cancel our own runs. No contents
+#      write, no package access.
+#
+# The action NEVER dispatches the pipeline itself — /retest recycles the `run-tests` label and
+# lets the normal `pull_request` path run. That keeps one trigger path to reason about, and it is
+# what refreshes the PR's REQUIRED CHECK; a command that only produced a report would leave the
+# PR unmergeable while looking like it worked.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write         # labels, comments, reactions
+  pull-requests: read   # fork detection
+  actions: write        # /cancel
+
+concurrency:
+  # Serialize per PR so two rapid commands cannot recycle the label at the same moment.
+  group: pr-e2e-cmd-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  command:
+    # Cheap pre-filter: PR comments that start with a slash. Everything else never starts a job.
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: iblai/pr-e2e-action/command@v1
+        with:
+          source_repo:    os
+          pr_number:      ${{ github.event.issue.number }}
+          comment_body:   ${{ github.event.comment.body }}
+          comment_author: ${{ github.event.comment.user.login }}
+          comment_id:     ${{ github.event.comment.id }}
+          repo_token:     ${{ secrets.GITHUB_TOKEN }}
+          dispatch_token: ${{ secrets.DEPLOY_OPS_DISPATCH_TOKEN }}


### PR DESCRIPTION
Adds `/retest`, `/retest <spec>`, `/status`, `/report` and `/cancel` as PR comments.

**48 lines here** — all logic is in [`iblai/pr-e2e-action/command@v1`](https://github.com/iblai/pr-e2e-action), so a fix reaches all three repos without three PRs.

## Why

Re-triggering was a manual ritual — remove the label, re-add it. Most developers didn't know that, so they asked a maintainer; it was the single biggest interruption on 2026-08-04. And every re-run cost a **full ~45 min suite** even when one spec was at fault, which is also what backs the queue up.

| command | what it does |
|---|---|
| `/retest` | re-run the full suite |
| **`/retest <spec>`** | **re-run only matching files — minutes instead of ~45** |
| `/status` | queue position + what's running |
| `/report` | link to the latest report |
| `/cancel` | stop this PR's run, free the environment |

`<spec>` is a substring: `/retest 34` resolves to `e2e/journeys/34-workflows.spec.ts`. An unmatched token starts nothing and says so, rather than silently running everything.

**No new plumbing was needed** — the `specs` input already runs end to end (action → `pr-e2e.yml` → `_test.yml` → `stg-test.sh`). This is the wiring.

## It never dispatches the pipeline

The handler's only trigger action is recycling the `run-tests` label. Two reasons, the second being the one that bites: there's one trigger path to secure rather than two, and **a PR's required check only refreshes when the caller workflow runs** — a command that produced a report without refreshing the check would look like it worked while leaving the PR unmergeable.

## Security on a public repo

1. **`issue_comment` runs from the default branch, never the PR** — a fork PR cannot edit this handler to weaken its own checks
2. **Repo collaborator permission** (`write`/`maintain`/`admin`), deliberately **not** `author_association` — that reports `MEMBER` for org members with *no* write access here, who could then occupy a shared test environment
3. **Fork PRs refused**, mirroring the `gate` job
4. **Minimum permissions**: `issues: write`, `pull-requests: read`, `actions: write`. No `contents` write

Worst case for an unauthorized commenter: a job that posts "not authorized" and exits. No runner touched, no secrets reachable.

### How `/retest <spec>` reaches the run

Via a marker comment the root action reads, honoured only if **both** hold:

- authored by `github-actions[bot]` — a user cannot post as the bot, so hand-writing the comment can't bypass the permission check
- its `head_sha` matches the commit under test — otherwise a selective request made against an earlier commit would silently narrow a **later** push's run to a few files, leaving the rest untested behind a green check

Either failing falls back to auto-detection; a malformed marker is ignored.

## Verification

- Both actions: YAML parses, every `run:` block `bash -n` clean
- **26/26 offline logic tests** — parser (CRLF, quoted replies, prose, unknown slash commands, first-line-only), marker round-trip, the stale-sha guard, five malformed/hostile marker bodies, spec resolution including partial-miss abort
- All embedded `python3 -c` heredocs were converted to `jq`: the block is indented into a YAML block scalar, so a multi-line heredoc arrives with uniform leading whitespace and dies on `IndentationError` — which `bash -n` does *not* catch, so it would have failed only at runtime
- The action path itself was proven end-to-end on os#381 today: full green, report published, required check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)