### PR TITLE
fix(ci): pr-e2e commands need pull-requests: write to reply

### DIFF
--- a/.github/workflows/pr-e2e-commands.yml
+++ b/.github/workflows/pr-e2e-commands.yml
@@ -22,8 +22,12 @@ on:
     types: [created]
 
 permissions:
-  issues: write         # labels, comments, reactions
-  pull-requests: read   # fork detection
+  issues: write         # labels and reactions
+  # MUST be write, not read. Commenting on a PULL REQUEST via /issues/{n}/comments needs
+  # pull-requests: write — `issues: write` alone covers real issues only, and the POST comes back
+  # 403 "Resource not accessible by integration". pr-e2e-tests.yml has always had write for the
+  # same reason. Also used for fork detection.
+  pull-requests: write
   actions: write        # /cancel
 
 concurrency:


### PR DESCRIPTION
Every slash command failed silently. `/status` on os#381 fired the workflow, authorized correctly (`permission=admin`), ran 3.5s and posted nothing.

## Root cause

```
POST /repos/iblai/os/issues/381/comments
403 "Resource not accessible by integration"
```

**Commenting on a pull request requires `pull-requests: write`.** `issues: write` covers real issues only. `pr-e2e-tests.yml` has always had `pull-requests: write` for exactly this reason — I set `read` because I was only thinking of fork detection.

```diff
-  pull-requests: read   # fork detection
+  pull-requests: write  # replying on a PR needs write; issues:write covers issues only
```

`issues: write` stays — labels and reactions do need it.

## Why it took three attempts to see

Two bugs were hiding it, both now fixed in the action (`v1.3.1`, `v1.3.2`):

1. **Every API call ended in `>/dev/null 2>&1 || true`.** A failed POST looked identical to a successful one: green workflow, empty log, nothing for the user. The 403 above was being thrown away.
2. **`bash -e` killed the script before it could report.** `shell: bash` runs composite steps with `-e -o pipefail`, so `C=$(central_run)` terminated the shell instantly and silently when the substitution exited non-zero — and `set -uo pipefail` does *not* disable errexit, only `set +e` does. Same class as the `bash -e` bug that made the eviction-retry branch dead code in os#367.

The action now runs `set +e` with explicit `RC` tracking, guards every command substitution, and reports failures via `::error::` — so the next failure of any kind names itself instead of vanishing.

## Verification

- The 403 came from the run's own log once the swallowing was removed, not from inference
- The errexit behaviour was reproduced with a probe: errexit on → the script prints its first line and dies before the reply; off → it reaches the reply. That is exactly the observed symptom
- Compared against `pr-e2e-tests.yml`, which posts PR comments successfully with `pull-requests: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)