### PR TITLE
Feat/2216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,41 @@
 
 ### Features
 
-* **llm:** map the ibl.ai model key to its brand spelling ([be167a3](https://github.com/iblai/os/commit/be167a357e909fedbe711fc0ee2c200f16812f1a))
+- **llm:** map the ibl.ai model key to its brand spelling ([be167a3](https://github.com/iblai/os/commit/be167a357e909fedbe711fc0ee2c200f16812f1a))
 
 ### Bug Fixes
 
-* **llm:** label model rows with the API display name ([2a2af60](https://github.com/iblai/os/commit/2a2af6004810ec45874fec311c500b0ee0cae045))
-* **llm:** show the ibl.ai label in the nav bar and mentors table ([457bf60](https://github.com/iblai/os/commit/457bf602de7ece75ecc4d2595ee8ffa4055721fc))
+- **llm:** label model rows with the API display name ([2a2af60](https://github.com/iblai/os/commit/2a2af6004810ec45874fec311c500b0ee0cae045))
+- **llm:** show the ibl.ai label in the nav bar and mentors table ([457bf60](https://github.com/iblai/os/commit/457bf602de7ece75ecc4d2595ee8ffa4055721fc))
 
 ### Documentation
 
-* **e2e:** record the new LLM tab checkpoints ([5b08a3e](https://github.com/iblai/os/commit/5b08a3eae39942a7104f3f2a2738906899e114f0))
+- **e2e:** record the new LLM tab checkpoints ([5b08a3e](https://github.com/iblai/os/commit/5b08a3eae39942a7104f3f2a2738906899e114f0))
 
 ### Tests
 
-* **e2e:** add provider-card accessors to the LLM tab page object ([9eaaeab](https://github.com/iblai/os/commit/9eaaeab91d696ae2bc0aaa503fa4438cec70f853))
-* **e2e:** cover the ibl.ai logo, provider ordering and graying ([269dfca](https://github.com/iblai/os/commit/269dfca2ab91ac1f09824ad77f851c31414ed747)), closes [#2318](https://github.com/iblai/os/issues/2318)
-* **e2e:** select model rows by wire key, not visible label ([e4002ec](https://github.com/iblai/os/commit/e4002ec07db4ac78dcd4caa762f958a2d776cc81))
+- **e2e:** add provider-card accessors to the LLM tab page object ([9eaaeab](https://github.com/iblai/os/commit/9eaaeab91d696ae2bc0aaa503fa4438cec70f853))
+- **e2e:** cover the ibl.ai logo, provider ordering and graying ([269dfca](https://github.com/iblai/os/commit/269dfca2ab91ac1f09824ad77f851c31414ed747)), closes [#2318](https://github.com/iblai/os/issues/2318)
+- **e2e:** select model rows by wire key, not visible label ([e4002ec](https://github.com/iblai/os/commit/e4002ec07db4ac78dcd4caa762f958a2d776cc81))
 
 ## [0.125.2](https://github.com/iblai/os/compare/v0.125.1...v0.125.2) (2026-08-13)
 
 ### Bug Fixes
 
-* **e2e:** restore the locator receiver dropped by the isVisibleWithin sweep ([cde2b20](https://github.com/iblai/os/commit/cde2b20d896ac5eaf735f7c43f12fe2802c0f300))
-* **e2e:** scope copy-mentor heading lookup to the visible h1 ([d80046e](https://github.com/iblai/os/commit/d80046efc55c0002d3b34d749daaa655c6ff3c0b))
+- **e2e:** restore the locator receiver dropped by the isVisibleWithin sweep ([cde2b20](https://github.com/iblai/os/commit/cde2b20d896ac5eaf735f7c43f12fe2802c0f300))
+- **e2e:** scope copy-mentor heading lookup to the visible h1 ([d80046e](https://github.com/iblai/os/commit/d80046efc55c0002d3b34d749daaa655c6ff3c0b))
 
 ### Chores
 
-* **format:** apply prettier to pre-existing drift ([0688de9](https://github.com/iblai/os/commit/0688de9fd4ec55da8470914a1c93816dde73f3e1))
+- **format:** apply prettier to pre-existing drift ([0688de9](https://github.com/iblai/os/commit/0688de9fd4ec55da8470914a1c93816dde73f3e1))
 
 ### Tests
 
-* **e2e:** add isVisibleWithin helper ([86b58d5](https://github.com/iblai/os/commit/86b58d53e7aaef160f051794e7eba453bd325b7d))
-* **e2e:** expand the sidebar before opening the Create Agent flow ([34e2a8e](https://github.com/iblai/os/commit/34e2a8e8f485be9350aa84bbf2d7b421b8ddd1a0))
-* **e2e:** give Edit Agent tab activation a realistic budget ([0af360a](https://github.com/iblai/os/commit/0af360a54a3f3cd97f6a4a5b445c1b91827944f7))
-* **e2e:** use isVisibleWithin for conditional checks in page objects ([8ea41d0](https://github.com/iblai/os/commit/8ea41d0ff99a8b1d1771c11b914da8e80df95883))
-* **e2e:** wait for the mentor URL to settle after landing ([8c42843](https://github.com/iblai/os/commit/8c428433a153ccffa9a614a278675f33651db5ea))
+- **e2e:** add isVisibleWithin helper ([86b58d5](https://github.com/iblai/os/commit/86b58d53e7aaef160f051794e7eba453bd325b7d))
+- **e2e:** expand the sidebar before opening the Create Agent flow ([34e2a8e](https://github.com/iblai/os/commit/34e2a8e8f485be9350aa84bbf2d7b421b8ddd1a0))
+- **e2e:** give Edit Agent tab activation a realistic budget ([0af360a](https://github.com/iblai/os/commit/0af360a54a3f3cd97f6a4a5b445c1b91827944f7))
+- **e2e:** use isVisibleWithin for conditional checks in page objects ([8ea41d0](https://github.com/iblai/os/commit/8ea41d0ff99a8b1d1771c11b914da8e80df95883))
+- **e2e:** wait for the mentor URL to settle after landing ([8c42843](https://github.com/iblai/os/commit/8c428433a153ccffa9a614a278675f33651db5ea))
 
 ## [0.125.1](https://github.com/iblai/os/compare/v0.125.0...v0.125.1) (2026-08-12)
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -227,3 +227,63 @@ body {
 [data-testid='chat-privacy-toggle'][data-state='on'] > span {
   transition-delay: 0ms;
 }
+
+/*
+ * Left-to-right shimmer for the in-progress row of the agent task list
+ * (`components/chat/agent-todo-list.tsx`). The gradient is clipped to the
+ * glyphs, so the band sweeps across the *text* rather than a block behind it.
+ *
+ * Direction: with `background-size: 200%`, position `100% 0` puts the image's
+ * midpoint (the bright band) at the box's LEFT edge and `0 0` puts it at the
+ * RIGHT edge — so animating 100% -> 0 sweeps left-to-right.
+ *
+ * Both gradient stops stay above the WCAG 1.4.3 4.5:1 floor against their
+ * background (gray-500 is 4.83:1 on white), so the text never dips below the
+ * contrast minimum mid-sweep. Colour is not a status cue here either — the
+ * icon shape carries that.
+ */
+@keyframes todo-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+
+.todo-shimmer {
+  --todo-shimmer-base: var(--color-gray-800);
+  --todo-shimmer-band: var(--color-gray-500);
+  background-image: linear-gradient(
+    90deg,
+    var(--todo-shimmer-base) 0%,
+    var(--todo-shimmer-base) 40%,
+    var(--todo-shimmer-band) 50%,
+    var(--todo-shimmer-base) 60%,
+    var(--todo-shimmer-base) 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: todo-shimmer 1.8s linear infinite;
+}
+
+.dark .todo-shimmer {
+  --todo-shimmer-base: var(--color-gray-200);
+  --todo-shimmer-band: var(--color-gray-500);
+}
+
+/*
+ * The sweep loops for as long as the step is running, which is exactly the
+ * indefinite motion WCAG 2.2.2 cautions against. Fall back to flat, solid
+ * text when the user asks for reduced motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .todo-shimmer {
+    background-image: none;
+    color: var(--todo-shimmer-base);
+    animation: none;
+  }
+}

--- a/components/chat/__tests__/agent-todo-list.test.tsx
+++ b/components/chat/__tests__/agent-todo-list.test.tsx
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import type { Todo } from '@iblai/iblai-js/web-utils';
+
+vi.mock('@/lib/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils')>();
+  return {
+    ...actual,
+    cn: (...args: (string | undefined | boolean)[]) =>
+      args.filter(Boolean).join(' '),
+  };
+});
+
+import { AgentTodoList, TODO_ANNOUNCE_THROTTLE_MS } from '../agent-todo-list';
+
+const todo = (content: string, status: Todo['status']): Todo => ({
+  content,
+  status,
+});
+
+const MIXED: Todo[] = [
+  todo('Read the brief', 'completed'),
+  todo('Draft the outline', 'in_progress'),
+  todo('Write the summary', 'pending'),
+];
+
+describe('AgentTodoList', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('no affordance when there is nothing to show', () => {
+    it('renders null when todos is undefined', () => {
+      const { container } = render(<AgentTodoList todos={undefined} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders null when todos is an empty array', () => {
+      const { container } = render(<AgentTodoList todos={[]} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders no live region when there are no todos', () => {
+      render(<AgentTodoList todos={[]} />);
+      expect(
+        screen.queryByTestId('agent-todo-list-announcer'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('list semantics', () => {
+    it('renders the todos as a real ordered list', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      const list = screen.getByRole('list');
+      expect(list.tagName).toBe('OL');
+      expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    });
+
+    it('renders one list item per todo, with its content', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      expect(screen.getByText('Read the brief')).toBeInTheDocument();
+      expect(screen.getByText('Draft the outline')).toBeInTheDocument();
+      expect(screen.getByText('Write the summary')).toBeInTheDocument();
+    });
+
+    it('keeps duplicate todo contents as separate rows', () => {
+      render(
+        <AgentTodoList
+          todos={[todo('Same', 'pending'), todo('Same', 'pending')]}
+          isCurrentlyStreaming
+        />,
+      );
+      expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    });
+  });
+
+  describe('status cues (never colour alone)', () => {
+    it('exposes every status to assistive tech without showing a label', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      // The status word is deliberately sr-only: sighted users read the icon
+      // shape, screen readers still hear the status. Dropping the word from the
+      // DOM entirely would leave colour as the only cue (WCAG 1.4.1).
+      for (const label of ['Done', 'In progress', 'To do']) {
+        expect(screen.getByText(label)).toHaveClass('sr-only');
+      }
+    });
+
+    it('shows no status text visually on a row', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      screen.getAllByTestId('agent-todo-item').forEach((row) => {
+        const visibleText = Array.from(row.querySelectorAll('span'))
+          .filter((span) => !span.classList.contains('sr-only'))
+          .map((span) => span.textContent)
+          .join(' ');
+        expect(visibleText).not.toMatch(/Done|In progress|To do/);
+      });
+    });
+
+    it('marks each row with its status for styling and assertions', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      const rows = screen.getAllByTestId('agent-todo-item');
+      expect(rows.map((row) => row.getAttribute('data-status'))).toEqual([
+        'completed',
+        'in_progress',
+        'pending',
+      ]);
+    });
+
+    it('shimmers only the in-progress row text', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      const shimmering = screen
+        .getAllByTestId('agent-todo-item')
+        .filter((row) => row.querySelector('.todo-shimmer') !== null);
+
+      expect(shimmering).toHaveLength(1);
+      expect(shimmering[0]).toHaveAttribute('data-status', 'in_progress');
+    });
+
+    it('shimmers the content text itself, not the whole row', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      const row = screen
+        .getAllByTestId('agent-todo-item')
+        .find((r) => r.getAttribute('data-status') === 'in_progress')!;
+      const shimmer = row.querySelector('.todo-shimmer');
+
+      // The gradient is clipped to the glyphs, so the class must sit on the
+      // element holding the todo text — not the <li> and not the icon.
+      expect(shimmer).toHaveTextContent('Draft the outline');
+      expect(shimmer?.tagName).toBe('SPAN');
+    });
+
+    it('stops shimmering once a step completes', () => {
+      const { container } = render(
+        <AgentTodoList
+          todos={[todo('Ship it', 'completed')]}
+          isCurrentlyStreaming
+        />,
+      );
+
+      expect(container.querySelector('.todo-shimmer')).not.toBeInTheDocument();
+    });
+
+    it('renders an icon alongside the label for every row', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+
+      screen.getAllByTestId('agent-todo-item').forEach((row) => {
+        expect(row.querySelector('svg')).toBeInTheDocument();
+      });
+    });
+
+    it('renders an unknown status as pending rather than dropping the row', () => {
+      render(
+        <AgentTodoList
+          todos={[{ content: 'Mystery step', status: 'wat' as Todo['status'] }]}
+          isCurrentlyStreaming
+        />,
+      );
+
+      expect(screen.getAllByRole('listitem')).toHaveLength(1);
+      expect(screen.getByText('Mystery step')).toBeInTheDocument();
+      expect(screen.getByText('To do')).toBeInTheDocument();
+    });
+  });
+
+  describe('progress summary', () => {
+    it('summarises how many todos are done', () => {
+      render(<AgentTodoList todos={MIXED} />);
+      expect(screen.getByTestId('agent-todo-list-progress')).toHaveTextContent(
+        '1 of 3 done',
+      );
+    });
+
+    it('counts every completed todo', () => {
+      render(
+        <AgentTodoList
+          todos={[
+            todo('a', 'completed'),
+            todo('b', 'completed'),
+            todo('c', 'pending'),
+          ]}
+        />,
+      );
+      expect(screen.getByTestId('agent-todo-list-progress')).toHaveTextContent(
+        '2 of 3 done',
+      );
+    });
+
+    it('shows the panel title', () => {
+      render(<AgentTodoList todos={MIXED} />);
+      expect(screen.getByText('Task list')).toBeInTheDocument();
+    });
+
+    it('replaces the whole list when a new set of todos arrives', () => {
+      const { rerender } = render(
+        <AgentTodoList todos={MIXED} isCurrentlyStreaming />,
+      );
+      expect(screen.getByText('Read the brief')).toBeInTheDocument();
+
+      rerender(
+        <AgentTodoList
+          todos={[todo('Brand new plan', 'in_progress')]}
+          isCurrentlyStreaming
+        />,
+      );
+
+      expect(screen.queryByText('Read the brief')).not.toBeInTheDocument();
+      expect(screen.getByText('Brand new plan')).toBeInTheDocument();
+      expect(screen.getByTestId('agent-todo-list-progress')).toHaveTextContent(
+        '0 of 1 done',
+      );
+    });
+  });
+
+  describe('collapsing', () => {
+    it('is expanded by default while the turn is still streaming', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('is collapsed by default once the turn has completed', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming={false} />);
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('defaults isCurrentlyStreaming to false', () => {
+      render(<AgentTodoList todos={MIXED} />);
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('auto-collapses when streaming ends', () => {
+      const { rerender } = render(
+        <AgentTodoList todos={MIXED} isCurrentlyStreaming />,
+      );
+      expect(screen.getByRole('list')).toBeInTheDocument();
+
+      rerender(<AgentTodoList todos={MIXED} isCurrentlyStreaming={false} />);
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('can be expanded again by the user after it collapsed', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming={false} />);
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('agent-todo-list-trigger'));
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('can be collapsed by the user while still streaming', () => {
+      render(<AgentTodoList todos={MIXED} isCurrentlyStreaming />);
+      fireEvent.click(screen.getByTestId('agent-todo-list-trigger'));
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('live region', () => {
+    it('exposes a polite, atomic, screen-reader-only status region', () => {
+      render(<AgentTodoList todos={MIXED} />);
+
+      const announcer = screen.getByTestId('agent-todo-list-announcer');
+      expect(announcer).toHaveAttribute('aria-live', 'polite');
+      expect(announcer).toHaveAttribute('aria-atomic', 'true');
+      expect(announcer).toHaveAttribute('role', 'status');
+      expect(announcer).toHaveClass('sr-only');
+    });
+
+    it('announces only the summary, never the todo contents', () => {
+      render(<AgentTodoList todos={MIXED} />);
+
+      const announcer = screen.getByTestId('agent-todo-list-announcer');
+      expect(announcer).toHaveTextContent('Step 1 of 3 complete');
+      expect(announcer.textContent).not.toContain('Read the brief');
+      expect(announcer.textContent).not.toContain('Draft the outline');
+    });
+
+    it('throttles announcements when the agent updates rapidly', () => {
+      vi.useFakeTimers();
+
+      const { rerender } = render(<AgentTodoList todos={MIXED} />);
+      const announcer = screen.getByTestId('agent-todo-list-announcer');
+
+      // First update announces immediately.
+      expect(announcer).toHaveTextContent('Step 1 of 3 complete');
+
+      // Two more list rewrites land inside the throttle window — neither is
+      // announced, so a fast-moving agent cannot spam the screen reader.
+      rerender(
+        <AgentTodoList
+          todos={[
+            todo('Read the brief', 'completed'),
+            todo('Draft the outline', 'completed'),
+            todo('Write the summary', 'pending'),
+          ]}
+        />,
+      );
+      expect(announcer).toHaveTextContent('Step 1 of 3 complete');
+
+      rerender(
+        <AgentTodoList
+          todos={[
+            todo('Read the brief', 'completed'),
+            todo('Draft the outline', 'completed'),
+            todo('Write the summary', 'completed'),
+          ]}
+        />,
+      );
+      expect(announcer).toHaveTextContent('Step 1 of 3 complete');
+
+      // Once the window closes only the newest summary is announced — three
+      // updates produced two announcements, not three.
+      act(() => {
+        vi.advanceTimersByTime(TODO_ANNOUNCE_THROTTLE_MS);
+      });
+      expect(announcer).toHaveTextContent('Step 3 of 3 complete');
+    });
+
+    it('announces again immediately once the throttle window has passed', () => {
+      vi.useFakeTimers();
+
+      const { rerender } = render(<AgentTodoList todos={MIXED} />);
+      const announcer = screen.getByTestId('agent-todo-list-announcer');
+      expect(announcer).toHaveTextContent('Step 1 of 3 complete');
+
+      act(() => {
+        vi.advanceTimersByTime(TODO_ANNOUNCE_THROTTLE_MS + 1);
+      });
+
+      rerender(
+        <AgentTodoList
+          todos={[
+            todo('Read the brief', 'completed'),
+            todo('Draft the outline', 'completed'),
+            todo('Write the summary', 'pending'),
+          ]}
+        />,
+      );
+      expect(announcer).toHaveTextContent('Step 2 of 3 complete');
+    });
+
+    it('clears a pending announcement timer on unmount', () => {
+      vi.useFakeTimers();
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      const { rerender, unmount } = render(<AgentTodoList todos={MIXED} />);
+      rerender(
+        <AgentTodoList
+          todos={[
+            todo('Read the brief', 'completed'),
+            todo('Draft the outline', 'completed'),
+            todo('Write the summary', 'pending'),
+          ]}
+        />,
+      );
+
+      unmount();
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+
+    it('does not throw when unmounted with no pending timer', () => {
+      const { unmount } = render(<AgentTodoList todos={MIXED} />);
+      expect(() => unmount()).not.toThrow();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has no axe violations while expanded', async () => {
+      const { container } = render(
+        <AgentTodoList todos={MIXED} isCurrentlyStreaming />,
+      );
+
+      const results = await axe(container);
+      // @ts-expect-error -- vitest-axe matcher is registered in vitest.setup.ts
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations while collapsed', async () => {
+      const { container } = render(<AgentTodoList todos={MIXED} />);
+
+      const results = await axe(container);
+      // @ts-expect-error -- vitest-axe matcher is registered in vitest.setup.ts
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/components/chat/__tests__/ai-message-bubble.test.tsx
+++ b/components/chat/__tests__/ai-message-bubble.test.tsx
@@ -11,7 +11,19 @@ const tenantMetadataReturnValue: { metadata: Record<string, unknown> } = {
   metadata: {},
 };
 
+// The SDK's todo parser. This suite stubs the whole `web-utils` module (the
+// transitive axios import does not resolve under vitest), so the real
+// `extractLatestTodos` is unavailable here — its own behaviour is covered by
+// the SDK. What matters for this component is what it does with the result.
+let mockLatestTodos: { content: string; status: string }[] | undefined;
+const extractLatestTodosArgs: unknown[] = [];
+
 vi.mock('@iblai/iblai-js/web-utils', () => ({
+  WRITE_TODOS_TOOL: 'write_todos',
+  extractLatestTodos: (toolCalls: unknown) => {
+    extractLatestTodosArgs.push(toolCalls);
+    return mockLatestTodos;
+  },
   selectShowingSharedChat: () => mockShowingSharedChat,
   useTenantMetadata: () => ({
     ...tenantMetadataReturnValue,
@@ -163,6 +175,22 @@ vi.mock('@/components/chat/tool-call-indicator', () => ({
   ),
 }));
 
+vi.mock('@/components/chat/agent-todo-list', () => ({
+  AgentTodoList: ({
+    todos,
+    isCurrentlyStreaming,
+  }: {
+    todos?: unknown[];
+    isCurrentlyStreaming?: boolean;
+  }) => (
+    <div
+      data-testid="agent-todo-list"
+      data-todo-count={todos?.length ?? 0}
+      data-is-currently-streaming={isCurrentlyStreaming ?? false}
+    />
+  ),
+}));
+
 vi.mock('@/lib/utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/utils')>();
   return {
@@ -236,6 +264,8 @@ describe('AIMessageBubble', () => {
     mockShowingSharedChat = false;
     mockChatPrivacyMode = 'normal';
     mockChatPrivacyReady = true;
+    mockLatestTodos = undefined;
+    extractLatestTodosArgs.length = 0;
     tenantMetadataReturnValue.metadata = {};
     mockPermissionRequests.current = [];
     const { isLoggedIn } = await import('@/lib/utils');
@@ -903,6 +933,167 @@ describe('AIMessageBubble', () => {
       expect(
         screen.queryByTestId('tool-call-indicator'),
       ).not.toBeInTheDocument();
+    });
+
+    it('should not render ToolCallIndicator when write_todos is the only tool call', () => {
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={[{ id: 'td', name: 'write_todos', log: '', result: '' }]}
+        />,
+      );
+      expect(
+        screen.queryByTestId('tool-call-indicator'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should still render ToolCallIndicator when a non-todo tool call is present', () => {
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={[
+            { id: 'td', name: 'write_todos', log: '', result: '' },
+            { id: 'tc1', name: 'web_search_call', log: '', result: '' },
+          ]}
+        />,
+      );
+      expect(screen.getByTestId('tool-call-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('agent todo list', () => {
+    const todoToolCalls = [
+      { id: 'td', name: 'write_todos', log: '', result: '' },
+    ];
+    const todos = [
+      { content: 'Read the brief', status: 'completed' },
+      { content: 'Write the summary', status: 'pending' },
+    ];
+
+    it('renders the task list when showReasoning is on and todos exist', () => {
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble {...defaultProps} toolCalls={todoToolCalls} />,
+      );
+
+      const list = screen.getByTestId('agent-todo-list');
+      expect(list).toBeInTheDocument();
+      expect(list).toHaveAttribute('data-todo-count', '2');
+    });
+
+    it('passes the turn tool calls to the SDK parser', () => {
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble {...defaultProps} toolCalls={todoToolCalls} />,
+      );
+      expect(extractLatestTodosArgs[0]).toEqual(todoToolCalls);
+    });
+
+    it('does not render the task list when showReasoning is off', () => {
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={todoToolCalls}
+          showReasoning={false}
+        />,
+      );
+      expect(screen.queryByTestId('agent-todo-list')).not.toBeInTheDocument();
+    });
+
+    it('does not call the SDK parser at all when showReasoning is off', () => {
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={todoToolCalls}
+          showReasoning={false}
+        />,
+      );
+      expect(extractLatestTodosArgs).toHaveLength(0);
+    });
+
+    it('renders no affordance when the turn has no write_todos call', () => {
+      mockLatestTodos = undefined;
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={[
+            { id: 'tc1', name: 'web_search_call', log: '', result: '' },
+          ]}
+        />,
+      );
+      expect(screen.queryByTestId('agent-todo-list')).not.toBeInTheDocument();
+    });
+
+    it('renders no affordance when the parser returns an empty list', () => {
+      mockLatestTodos = [];
+      renderWithRedux(
+        <AIMessageBubble {...defaultProps} toolCalls={todoToolCalls} />,
+      );
+      expect(screen.queryByTestId('agent-todo-list')).not.toBeInTheDocument();
+    });
+
+    it('passes isCurrentlyStreaming through to the task list', () => {
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          toolCalls={todoToolCalls}
+          isCurrentlyStreaming={true}
+        />,
+      );
+      expect(screen.getByTestId('agent-todo-list')).toHaveAttribute(
+        'data-is-currently-streaming',
+        'true',
+      );
+    });
+
+    it('renders a todos-only turn that has no text yet', () => {
+      // hasVisibleContent must count the todo list, otherwise a turn that
+      // writes its plan before producing any text renders nothing at all.
+      mockLatestTodos = todos;
+      renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          content=""
+          toolCalls={todoToolCalls}
+          isCurrentlyStreaming={true}
+        />,
+      );
+
+      expect(screen.getByTestId('agent-todo-list')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('tool-call-indicator'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders nothing for a todos-only turn while showReasoning is off', () => {
+      mockLatestTodos = todos;
+      const { container } = renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          content=""
+          toolCalls={todoToolCalls}
+          showReasoning={false}
+          isCurrentlyStreaming={true}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when a write_todos call yields no usable todos', () => {
+      // A malformed `write_todos` payload must not reserve an empty gray bubble.
+      mockLatestTodos = undefined;
+      const { container } = renderWithRedux(
+        <AIMessageBubble
+          {...defaultProps}
+          content=""
+          toolCalls={todoToolCalls}
+          isCurrentlyStreaming={true}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/components/chat/__tests__/tool-call-indicator.test.tsx
+++ b/components/chat/__tests__/tool-call-indicator.test.tsx
@@ -243,4 +243,99 @@ describe('ToolCallIndicator', () => {
       expect(trigger.className).not.toContain('text-gray-500');
     });
   });
+
+  it('pulses only the last tool call while streaming', () => {
+    const { container } = render(
+      <ToolCallIndicator
+        toolCalls={[
+          makeToolCall({ id: '1', name: 'web_search_call' }),
+          makeToolCall({ id: '2', name: 'vector_search' }),
+        ]}
+        isCurrentlyStreaming={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Used 2 tools'));
+    // Only the last of the two rows carries the pulse dot.
+    expect(container.querySelectorAll('.animate-pulse').length).toBe(1);
+  });
+
+  describe('write_todos exclusion', () => {
+    it('renders nothing when write_todos is the only tool call', () => {
+      const { container } = render(
+        <ToolCallIndicator
+          toolCalls={[makeToolCall({ id: 'td', name: 'write_todos' })]}
+        />,
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing when every tool call is write_todos', () => {
+      const { container } = render(
+        <ToolCallIndicator
+          toolCalls={[
+            makeToolCall({ id: 'td1', name: 'write_todos' }),
+            makeToolCall({ id: 'td2', name: 'write_todos' }),
+          ]}
+        />,
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('excludes write_todos from the "Used N tools" count', () => {
+      render(
+        <ToolCallIndicator
+          toolCalls={[
+            makeToolCall({ id: '1', name: 'web_search_call' }),
+            makeToolCall({ id: 'td', name: 'write_todos' }),
+          ]}
+        />,
+      );
+      expect(screen.getByText('Used 1 tool')).toBeInTheDocument();
+    });
+
+    it('does not render a card for write_todos when expanded', () => {
+      render(
+        <ToolCallIndicator
+          toolCalls={[
+            makeToolCall({
+              id: '1',
+              name: 'web_search_call',
+              input: { query: 'F1 race' },
+            }),
+            makeToolCall({
+              id: 'td',
+              name: 'write_todos',
+              input: { todos: [{ content: 'Step one', status: 'pending' }] },
+            }),
+          ]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Used 1 tool'));
+
+      expect(screen.getByText('Searching the web')).toBeInTheDocument();
+      expect(screen.queryByText('write_todos')).not.toBeInTheDocument();
+      expect(screen.queryByText('Step one')).not.toBeInTheDocument();
+    });
+
+    it('keeps the streaming pulse on the last non-todo tool call', () => {
+      const { container } = render(
+        <ToolCallIndicator
+          toolCalls={[
+            makeToolCall({
+              id: '1',
+              name: 'web_search_call',
+              input: { query: 'F1 race' },
+            }),
+            makeToolCall({ id: 'td', name: 'write_todos' }),
+          ]}
+          isCurrentlyStreaming={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Used 1 tool'));
+      expect(container.querySelectorAll('.animate-pulse').length).toBe(1);
+    });
+  });
 });

--- a/components/chat/agent-todo-list.tsx
+++ b/components/chat/agent-todo-list.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronRight, Circle, CircleCheck, CircleDot } from 'lucide-react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import { todosProgress, type Todo } from '@iblai/iblai-js/web-utils';
+
+/**
+ * Minimum gap between screen-reader announcements. A Base Agent can rewrite its
+ * plan several times a second while working, and every `write_todos` call
+ * replaces the whole list — announcing each one unthrottled would flood a
+ * screen reader. Only the summary is ever announced, never the list itself.
+ */
+export const TODO_ANNOUNCE_THROTTLE_MS = 2000;
+
+interface AgentTodoListProps {
+  todos: Todo[] | undefined;
+  isCurrentlyStreaming?: boolean;
+}
+
+interface StatusMeta {
+  Icon: typeof Circle;
+  labelKey: string;
+  iconClass: string;
+  contentClass: string;
+}
+
+/**
+ * Status presentation. Colour is never the only cue (WCAG 1.4.1): each status
+ * has a distinct icon *shape* — check / filled dot / hollow circle — plus a
+ * strikethrough on completed rows. The status word itself is rendered
+ * `sr-only`, so assistive tech announces it without the visual clutter of a
+ * label on every row.
+ */
+const STATUS_META: Record<string, StatusMeta> = {
+  completed: {
+    Icon: CircleCheck,
+    labelKey: 'agentTodoStatusCompleted',
+    iconClass: 'text-emerald-600 dark:text-emerald-400',
+    contentClass: 'text-gray-500 line-through dark:text-gray-500',
+  },
+  in_progress: {
+    Icon: CircleDot,
+    labelKey: 'agentTodoStatusInProgress',
+    iconClass: 'text-blue-600 dark:text-blue-400',
+    // The in-progress row's text carries a left-to-right shimmer so the active
+    // step is obvious at a glance now that no row shows a written status.
+    // `.todo-shimmer` (app/globals.css) owns the colour, since it paints the
+    // glyphs with a clipped gradient — don't add a `text-*` utility here or it
+    // will fight the `color: transparent` the clip depends on.
+    contentClass: 'todo-shimmer font-medium',
+  },
+  pending: {
+    Icon: Circle,
+    labelKey: 'agentTodoStatusPending',
+    iconClass: 'text-gray-400 dark:text-gray-500',
+    contentClass: 'text-gray-700 dark:text-gray-300',
+  },
+};
+
+/**
+ * The SDK already normalizes unknown statuses to `pending`, but the fallback
+ * keeps a row visible rather than crashing if a raw todo ever reaches the UI.
+ */
+function getStatusMeta(status: string): StatusMeta {
+  return STATUS_META[status] ?? STATUS_META.pending;
+}
+
+export function AgentTodoList({
+  todos,
+  isCurrentlyStreaming = false,
+}: AgentTodoListProps) {
+  const t = useTranslations('chatAiMessageBubble');
+
+  // Default expanded while the turn is still streaming so the user can watch
+  // the agent work; collapse once it completes so finished conversations stay
+  // readable. Mirrors `tool-call-item.tsx`.
+  const [isOpen, setIsOpen] = useState(() => isCurrentlyStreaming);
+
+  useEffect(() => {
+    if (!isCurrentlyStreaming) {
+      setIsOpen(false);
+    }
+  }, [isCurrentlyStreaming]);
+
+  const items = todos ?? [];
+  const { done, total } = todosProgress(todos);
+  const hasTodos = total > 0;
+
+  // Throttled polite announcement — summary only.
+  const [announcement, setAnnouncement] = useState('');
+  const lastAnnouncedAtRef = useRef(0);
+  const pendingRef = useRef('');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const summaryAnnouncement = hasTodos
+    ? t('agentTodoAnnouncement', { done, total })
+    : '';
+
+  useEffect(() => {
+    if (!summaryAnnouncement) return;
+
+    const elapsed = Date.now() - lastAnnouncedAtRef.current;
+
+    if (elapsed >= TODO_ANNOUNCE_THROTTLE_MS) {
+      lastAnnouncedAtRef.current = Date.now();
+      setAnnouncement(summaryAnnouncement);
+      return;
+    }
+
+    // Inside the throttle window: remember the newest summary and let the
+    // already-scheduled trailing announcement pick it up. Everything in
+    // between is dropped rather than queued, so the screen reader hears one
+    // update per window no matter how fast the agent rewrites its plan.
+    pendingRef.current = summaryAnnouncement;
+    if (timerRef.current !== null) return;
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      lastAnnouncedAtRef.current = Date.now();
+      setAnnouncement(pendingRef.current);
+    }, TODO_ANNOUNCE_THROTTLE_MS - elapsed);
+  }, [summaryAnnouncement]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    },
+    [],
+  );
+
+  // No `write_todos` call on this turn -> no affordance at all.
+  if (!hasTodos) {
+    return null;
+  }
+
+  const summary = t('agentTodoProgress', { done, total });
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="mb-2"
+      data-testid="agent-todo-list"
+    >
+      <CollapsibleTrigger
+        className="flex cursor-pointer items-center gap-1 pt-1 text-xs text-gray-500 transition-colors hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300"
+        data-testid="agent-todo-list-trigger"
+      >
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 shrink-0 transition-transform duration-200',
+            isOpen && 'rotate-90',
+          )}
+        />
+        <span className="font-medium">{t('agentTodoListTitle')}</span>
+        <span
+          className="text-gray-400 dark:text-gray-500"
+          data-testid="agent-todo-list-progress"
+        >
+          — {summary}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pb-2 pl-4">
+        <ol
+          className="space-y-1.5 border-l-2 border-gray-200 pt-2 pl-3 text-xs leading-relaxed dark:border-gray-700"
+          data-testid="agent-todo-list-items"
+        >
+          {items.map((todo, index) => {
+            const meta = getStatusMeta(todo.status);
+            const { Icon } = meta;
+            const statusLabel = t(meta.labelKey);
+
+            return (
+              <li
+                key={`${index}-${todo.content}`}
+                className="flex items-start gap-1.5"
+                data-testid="agent-todo-item"
+                data-status={todo.status}
+              >
+                <Icon
+                  aria-hidden="true"
+                  className={cn('mt-0.5 h-3 w-3 shrink-0', meta.iconClass)}
+                />
+                <span className="sr-only">{statusLabel}</span>
+                <span className={cn('min-w-0 flex-1', meta.contentClass)}>
+                  {todo.content}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </CollapsibleContent>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="agent-todo-list-announcer"
+      >
+        {announcement}
+      </div>
+    </Collapsible>
+  );
+}

--- a/components/chat/ai-message-bubble.tsx
+++ b/components/chat/ai-message-bubble.tsx
@@ -14,6 +14,8 @@ import { AIMessageCopy } from './ai-message-copy';
 import { AIMessageShare } from './ai-message-share';
 import { AIMessageSpeak } from './ai-message-speak';
 import {
+  WRITE_TODOS_TOOL,
+  extractLatestTodos,
   selectShowingSharedChat,
   useTenantMetadata as useTenantMetadataHook,
   type Message,
@@ -33,6 +35,7 @@ import {
   CodePermissionCards,
   useCodePermissionRequests,
 } from './code-permission-card';
+import { AgentTodoList } from './agent-todo-list';
 import { config } from '@/lib/config';
 import { useChatPrivacy } from '@iblai/iblai-js/web-containers';
 import { useUsername } from '@/hooks/use-user';
@@ -139,11 +142,15 @@ export function AIMessageBubble({
   // bubble has something visible (text, a visible verbose surface, actions, or
   // an artifact preview); the typing indicator covers the interim.
   const hasReasoningToShow = !!(showReasoning && reasoningContent);
+  // `write_todos` calls render as the dedicated task list, not as generic tool
+  // cards, so they must not on their own make the tool-call indicator "visible"
+  // — otherwise a todos-only turn would reserve an empty gray bubble.
   const hasToolCallsToShow = !!(
     showReasoning &&
-    toolCalls &&
-    toolCalls.length > 0
+    toolCalls?.some((toolCall) => toolCall?.name !== WRITE_TODOS_TOOL)
   );
+  const todos = showReasoning ? extractLatestTodos(toolCalls) : undefined;
+  const hasTodosToShow = !!todos?.length;
   const hasVisibleContent =
     (content ?? '').trim().length > 0 ||
     hasReasoningToShow ||
@@ -151,6 +158,7 @@ export function AIMessageBubble({
     // A permission prompt can be the FIRST thing in a Code turn, before any text.
     // Without this the bubble renders as null and the turn looks silently stalled.
     hasPermissionPrompts ||
+    hasTodosToShow ||
     !!message?.actions?.length ||
     hasArtifactVersions(message);
 
@@ -191,9 +199,15 @@ export function AIMessageBubble({
                   isCurrentlyStreaming={isCurrentlyStreaming}
                 />
               )}
-              {showReasoning && toolCalls && toolCalls.length > 0 && (
+              {hasToolCallsToShow && (
                 <ToolCallIndicator
-                  toolCalls={toolCalls}
+                  toolCalls={toolCalls!}
+                  isCurrentlyStreaming={isCurrentlyStreaming}
+                />
+              )}
+              {hasTodosToShow && (
+                <AgentTodoList
+                  todos={todos}
                   isCurrentlyStreaming={isCurrentlyStreaming}
                 />
               )}

--- a/components/chat/tool-call-indicator.tsx
+++ b/components/chat/tool-call-indicator.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
 import Markdown from '@/components/markdown';
-import type { ToolCallInfo } from '@iblai/iblai-js/web-utils';
+import { WRITE_TODOS_TOOL, type ToolCallInfo } from '@iblai/iblai-js/web-utils';
 import { getFriendlyToolName, getQueryLabel } from './tool-call-utils';
 
 interface ToolCallIndicatorProps {
@@ -43,13 +43,19 @@ export function ToolCallIndicator({
 }: ToolCallIndicatorProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  if (!toolCalls || toolCalls.length === 0) {
+  // `write_todos` has a dedicated renderer (`AgentTodoList`), so it must never
+  // appear as a generic tool card nor be counted in "Used N tools".
+  const visibleToolCalls = (toolCalls ?? []).filter(
+    (tc) => tc?.name !== WRITE_TODOS_TOOL,
+  );
+
+  if (visibleToolCalls.length === 0) {
     return null;
   }
 
   const isStreaming = isCurrentlyStreaming;
 
-  const uniqueToolCount = new Set(toolCalls.map((tc) => tc.name)).size;
+  const uniqueToolCount = new Set(visibleToolCalls.map((tc) => tc.name)).size;
   const headerLabel = `Used ${uniqueToolCount} tool${uniqueToolCount === 1 ? '' : 's'}`;
 
   return (
@@ -75,10 +81,10 @@ export function ToolCallIndicator({
         {/* `pt-2.5` matches `space-y-2.5` so the first tool sits the same
             distance from the header as the gap between consecutive tools. */}
         <div className="space-y-2.5 border-l-2 border-gray-300 pt-2.5 pl-3 text-xs leading-relaxed text-gray-600">
-          {toolCalls.map((toolCall, index) => {
+          {visibleToolCalls.map((toolCall, index) => {
             const query = getQueryLabel(toolCall);
             const Icon = getToolIcon(toolCall?.name);
-            const isLast = index === toolCalls.length - 1;
+            const isLast = index === visibleToolCalls.length - 1;
 
             return (
               <div key={toolCall?.id || index}>

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-08-12 | 638 checkpoints (607 covered, 8 pending/fixme, 11 not-reproducible in default env, 12 deprecated) | 69 journeys (68 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-08-13 | 649 checkpoints (618 covered, 8 pending/fixme, 11 not-reproducible in default env, 12 deprecated) | 70 journeys (69 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -1354,3 +1354,60 @@ surfaces:
 - [x] slash-16: Skills dropdown (next to Canvas) lists enabled skills as name + `/slug`; selecting inserts the token AT THE CARET with context-aware spacing; the active pill shows the armed name + the standard ✕ (disarms without opening the menu); toggling removes cleanly; arming another replaces (single selection); `/`-picker arming updates the button — one composer-text source of truth
 - [x] slash-15: NON-ADMIN — with the assignments endpoint readable (mocked granted state; a 403 degrades to an inactive picker) the "/" picker offers skills; selecting completes the token and the sent invocation message receives a live AI reply — skips when the environment denies the non-admin CHAT permission entirely (composer disabled with a "you don't have permission to chat" placeholder): the picker rides on top of chat access
 - [x] slash-14: A "/" token typed after existing text (caret-adjacent, preceded by whitespace) opens the picker; selecting completes the invocation at that index keeping the sentence. A "/" glued inside a word (and/or, URLs) never triggers
+
+---
+
+## Journey 68: Agent Task List (11 checkpoints) — `journeys/68-agent-todo-list.spec.ts`
+
+**Source files:** `components/chat/agent-todo-list.tsx`, `components/chat/ai-message-bubble.tsx`, `components/chat/tool-call-indicator.tsx`, `app/globals.css`
+
+Issue #2216 — a Base Agent plans multi-step work with the deep-agent `write_todos`
+tool. Every call streams a FULL REPLACEMENT todo list, rendered as a collapsible
+task list (`AgentTodoList`) on the assistant turn, gated on the mentor's
+`show_reasoning` setting (default `false`) — the same gate as the reasoning
+section and the generic tool-call indicator.
+
+Two independent, deterministic seams are used, since neither one alone covers
+the whole feature:
+
+- **REST history seam** (Tier 1, tests 1–4): drives the LIVE, authenticated
+  chat page (not the public shared-chat page — that page never passes
+  `showReasoning`, and its `transformChatMessage` normalizer drops tool calls
+  entirely). Patches the mentor-settings GET (`show_reasoning: true`, via
+  `route.fetch()` so every other field stays real) and mocks the session
+  chat-history GET (`GET /api/ai-mentor/orgs/{org}/users/{user_id}/sessions/{sessionId}/`)
+  to inject a `write_todos` tool call onto a historical AI message. This is
+  the first real fixture-backed validation of the SDK's history-parsing
+  contract (`toolCallFromHistoryEntry` in `@iblai/web-utils`), which accepts
+  two shapes that had no prior fixture in either repo: LangChain
+  (`{id, name, args}`) and OpenAI
+  (`{id, type: 'function', function: {name, arguments}}`), plus a malformed
+  entry that must be dropped without throwing.
+- **`page.routeWebSocket()`** (Tier 2, test 5): mocks the live chat socket
+  (`wss://.../ws/langflow/`) to script a real streaming turn end-to-end —
+  a `generation_id` start frame, two `write_todos` `tool_call`/`tool_call.end`
+  pairs with different ids (proving wholesale replacement, not a merge), and
+  `eos`. This is what a static history fixture cannot cover: the
+  expanded-while-streaming → auto-collapse-on-completion transition, the
+  shimmer on the live in-progress row, and the throttled screen-reader
+  announcer. `page.routeWebSocket` was previously assumed impractical for
+  this app's chat socket (see Journey 61's comment) without knowing the exact
+  frame shapes; those shapes are now confirmed and the mock works.
+
+A lone leading `assistant`-role history message is special-cased by
+`components/chat/index.tsx` as a "welcome message" (rendered via
+`WelcomeChatNew`, never through `AIMessageBubble`) — every Tier 1 history
+fixture therefore includes a preceding human message so the AI message with
+tool calls actually mounts `AgentTodoList`.
+
+- [x] atl-01: The task list renders as a real `<ol>` with one `<li>` per todo; status via `data-status` + a sr-only status word + a distinct icon per status — no visible status text on the row itself
+- [x] atl-02: The panel header shows an "N of M done" progress summary, visible even while the row list underneath is collapsed
+- [x] atl-03: The panel is expanded by default while the turn is streaming, auto-collapses once the turn completes, and clicking the trigger re-expands it (collapsed-by-default also verified for historical/reload-recovered turns)
+- [x] atl-04: A second `write_todos` call within the same streaming turn replaces the list wholesale — never merges or appends onto the previous call's rows
+- [x] atl-05: An unrecognized todo status (e.g. "blocked") renders as pending rather than being dropped
+- [x] atl-06: A turn that never emits `write_todos` shows no affordance at all — no panel, no header, no skeleton
+- [x] atl-07: `write_todos` never appears in the generic "Used N tools" indicator or as its own raw tool card, even with a companion tool call present on the same turn
+- [x] atl-08: The in-progress row's text carries the `.todo-shimmer` left-to-right sweep class
+- [x] atl-09: The sr-only `aria-live` announcer carries only the throttled "Step N of M complete" summary, never any todo row text
+- [x] atl-10: The task list survives a page reload, recovered from chat history
+- [x] atl-11: First fixture-backed validation of the LangChain-shape and OpenAI-shape `write_todos` history parsing, plus a malformed entry dropped without throwing

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "lastUpdated": "2026-08-11",
+  "lastUpdated": "2026-08-13",
   "summary": {
-    "totalCheckpoints": 638,
-    "coveredCheckpoints": 607,
+    "totalCheckpoints": 649,
+    "coveredCheckpoints": 618,
     "deprecatedCheckpoints": 12,
     "notReproducibleCheckpoints": 11,
     "pendingCheckpoints": 8,
     "percent": 100,
-    "totalJourneys": 69,
-    "activeJourneys": 68
+    "totalJourneys": 70,
+    "activeJourneys": 69
   },
   "journeys": [
     {
@@ -4044,6 +4044,74 @@
         {
           "id": "slash-16",
           "description": "Skills dropdown button (inside-buttons row, next to Canvas) lists the mentor's enabled skills as name + /slug (no descriptions); selecting inserts the /slug token AT THE CARET with context-aware spacing (highlighted in the composer) and the button shows the armed skill's name with the same ✕ affordance as other active tool pills (✕ disarms without opening the menu); toggling removes the token cleanly; arming another skill replaces the current one (single selection); arming via the \"/\" picker updates the button — both surfaces derive from the composer text so they stay in sync",
+          "status": "covered"
+        }
+      ]
+    },
+    {
+      "id": "agent-todo-list",
+      "name": "Agent Task List",
+      "spec": "68-agent-todo-list.spec.ts",
+      "sourceFiles": [
+        "components/chat/agent-todo-list.tsx",
+        "components/chat/ai-message-bubble.tsx",
+        "components/chat/tool-call-indicator.tsx",
+        "app/globals.css"
+      ],
+      "checkpoints": [
+        {
+          "id": "atl-01",
+          "description": "The task list renders as a real <ol> with one <li> per todo; status communicated via data-status + a sr-only status word + a distinct icon shape per status — no visible status text on the row itself (issue #2216)",
+          "status": "covered"
+        },
+        {
+          "id": "atl-02",
+          "description": "The panel header shows an \"N of M done\" progress summary, visible even while the row list underneath is collapsed",
+          "status": "covered"
+        },
+        {
+          "id": "atl-03",
+          "description": "The panel is expanded by default while the assistant turn is still streaming, auto-collapses once the turn completes, and clicking the trigger re-expands it (collapsed-by-default is also verified for historical/non-streaming turns loaded from chat history)",
+          "status": "covered"
+        },
+        {
+          "id": "atl-04",
+          "description": "A second write_todos call within the same streaming turn replaces the list wholesale — rows are reordered/added/dropped, never merged or appended onto the previous call's rows",
+          "status": "covered"
+        },
+        {
+          "id": "atl-05",
+          "description": "An unrecognized todo status (e.g. \"blocked\") renders as pending rather than being dropped from the list",
+          "status": "covered"
+        },
+        {
+          "id": "atl-06",
+          "description": "A turn that never emits write_todos shows no affordance at all — no panel, no header, no skeleton",
+          "status": "covered"
+        },
+        {
+          "id": "atl-07",
+          "description": "write_todos never appears in the generic \"Used N tools\" indicator or as its own raw tool card, and its todo text never leaks into that indicator's content, even when a companion tool call is present on the same turn",
+          "status": "covered"
+        },
+        {
+          "id": "atl-08",
+          "description": "The in-progress row's text carries the .todo-shimmer left-to-right sweep class",
+          "status": "covered"
+        },
+        {
+          "id": "atl-09",
+          "description": "The sr-only aria-live announcer carries only the throttled \"Step N of M complete\" summary, never any todo row text",
+          "status": "covered"
+        },
+        {
+          "id": "atl-10",
+          "description": "The task list (and its wholesale-replaced content) survives a page reload, recovered from chat history",
+          "status": "covered"
+        },
+        {
+          "id": "atl-11",
+          "description": "First real fixture-backed validation of the SDK's write_todos history-parsing contract (toolCallFromHistoryEntry in @iblai/web-utils): both the LangChain shape ({id, name, args}) and the OpenAI shape ({id, type: 'function', function: {name, arguments}}) are accepted, and a malformed entry (missing name) is dropped without throwing or tripping the ErrorBoundary",
           "status": "covered"
         }
       ]

--- a/e2e/journeys/68-agent-todo-list.spec.ts
+++ b/e2e/journeys/68-agent-todo-list.spec.ts
@@ -1,0 +1,470 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/mentor-test';
+import { navigateToMentorApp, getPlatformContext } from '../utils/auth';
+import { MENTOR_NEXTJS_HOST } from '../fixtures/test-data';
+import { ChatPage } from '../page-objects/chat.page';
+
+/**
+ * Journey 68: Agent Task List (write_todos)
+ *
+ * Covers the "agent task list" feature (issue #2216): a Base Agent plans
+ * multi-step work with the deep-agent `write_todos` tool. Every call streams
+ * a FULL REPLACEMENT todo list (`components/chat/agent-todo-list.tsx`), and
+ * is gated on the mentor's `show_reasoning` setting
+ * (`hooks/use-mentors/use-mentor-settings.ts`, default `false`) — same gate
+ * as the generic tool-call indicator and reasoning section.
+ *
+ * Two independent, deterministic seams are used because no single seam
+ * covers the whole feature:
+ *
+ * TIER 1 — REST history seam (live, authenticated chat page). Mocks the
+ * mentor-settings GET (`show_reasoning: true`, patched onto the real
+ * response via `route.fetch()` so every other field stays real) and the
+ * session chat-history GET
+ * (`GET /api/ai-mentor/orgs/{org}/users/{user_id}/sessions/{sessionId}/`,
+ * `useLazyGetSessionIdQuery` from `@iblai/data-layer`) to inject a
+ * `write_todos` tool call onto a historical AI message. This is the FIRST
+ * real fixture-backed validation of the SDK's `toolCallFromHistoryEntry`
+ * parser (`@iblai/web-utils`), which accepts two guessed-at shapes with no
+ * prior fixture in either repo:
+ *   - LangChain: `{ id, name, args: { todos: [...] } }`
+ *   - OpenAI:    `{ id, type: 'function', function: { name, arguments: '<json>' } }`
+ * Deliberately NOT the shared-chat REST seam used by Journey 61
+ * (`ChatPage.mockSharedChatSession`): the shared-chat page never passes
+ * `showReasoning` (the list would never render), and
+ * `transformChatMessage` (`hooks/use-shared-chat-messages.ts`) normalizes
+ * history down to `{role, content}`, dropping tool calls entirely.
+ *
+ * TIER 2 — `page.routeWebSocket()` against the live chat socket
+ * (`wss://.../ws/langflow/`, `useChat` in `@iblai/iblai-js/web-utils`).
+ * Scripts the minimum protocol (`generation_id` start frame, `tool_call` /
+ * `tool_call.end` pairs, `eos`) to drive a real streaming turn end-to-end,
+ * covering the behaviours a static history fixture cannot: auto-collapse on
+ * completion, wholesale replacement of the list mid-turn, the shimmer on
+ * the active row, and the throttled screen-reader announcer.
+ *
+ * Both tiers share the serial-mode + cached-platform-context pattern from
+ * Journey 61: only the FIRST test performs a real `navigateToMentorApp`
+ * login; every following test reuses the cached `tenantKey`/`mentorId` and
+ * navigates directly (each test still gets Playwright's default fresh
+ * page/context, so per-test mocks never leak across tests — only the two
+ * *strings* are cached, not any live browser state).
+ */
+test.describe('Journey 68: Agent Task List', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let tenantKey = '';
+  let mentorId = '';
+
+  test.beforeEach(async ({ page, chatPage }) => {
+    if (!tenantKey || !mentorId) {
+      await navigateToMentorApp(page);
+      ({ tenantKey, mentorId } = await getPlatformContext(page));
+    }
+    void chatPage;
+  });
+
+  /** Unique per-test session id so route mocks never collide across tests. */
+  function newSessionId(label: string): string {
+    return `e2e-todo-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /** Navigates to the (cached) mentor's chat page and waits for the shell. */
+  async function gotoReadyChat(page: Page, chatPage: ChatPage) {
+    await chatPage.gotoChat(MENTOR_NEXTJS_HOST, tenantKey, mentorId);
+    await expect(
+      page.getByRole('button', { name: 'Selected agent dropdown button' }),
+    ).toBeVisible({ timeout: 30_000 });
+  }
+
+  test('admin views chat history with a LangChain-shape write_todos call and sees the rendered, collapsible task list', async ({
+    page,
+    chatPage,
+  }) => {
+    const sessionId = newSessionId('langchain');
+    const todos = [
+      { content: 'Gather course requirements', status: 'completed' },
+      { content: 'Draft the course outline', status: 'in_progress' },
+      { content: 'Get user approval', status: 'pending' },
+    ];
+
+    await chatPage.mockShowReasoning();
+    await chatPage.seedCachedSessionId(mentorId, sessionId);
+    await chatPage.mockChatHistoryWithToolCalls(
+      sessionId,
+      [{ id: 'toolu_01', name: 'write_todos', args: { todos } }],
+      { aiContent: 'Let me plan this out.' },
+    );
+
+    await gotoReadyChat(page, chatPage);
+    const aiMessage = await chatPage.waitForAiMessageWithText(
+      'Let me plan this out.',
+    );
+
+    // Checkpoint 1 (panel + header): the panel and its collapsed trigger
+    // are visible immediately — title + progress summary render even
+    // before the row list itself is expanded.
+    const panel = chatPage.getAgentTodoList(aiMessage);
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+
+    // Checkpoint 2: "N of M done" progress summary (1 completed of 3) is
+    // visible even while the row list underneath is collapsed.
+    await expect(chatPage.getAgentTodoProgress(aiMessage)).toContainText(
+      '1 of 3 done',
+    );
+
+    // Checkpoint 3 (collapsed-when-complete half): a historical (non
+    // streaming) message's row list starts collapsed — Radix's
+    // `CollapsibleContent` does not mount its children until opened, so the
+    // `<li>` rows genuinely do not exist in the DOM yet.
+    const itemsContainer = chatPage.getAgentTodoItemsContainer(aiMessage);
+    await expect(itemsContainer).not.toBeVisible();
+    await expect(chatPage.getAgentTodoItems(aiMessage)).toHaveCount(0);
+
+    // Clicking the trigger re-expands it, mounting the rows.
+    await chatPage.getAgentTodoTrigger(aiMessage).click();
+    await expect(itemsContainer).toBeVisible({ timeout: 10_000 });
+
+    // Checkpoint 1 (rows): a real <ol> with one <li> per todo, status via
+    // data-status + sr-only word + icon — no visible status text on rows.
+    const items = chatPage.getAgentTodoItems(aiMessage);
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toHaveAttribute('data-status', 'completed');
+    await expect(items.nth(1)).toHaveAttribute('data-status', 'in_progress');
+    await expect(items.nth(2)).toHaveAttribute('data-status', 'pending');
+    // Each row carries a decorative (aria-hidden) status icon.
+    await expect(items.nth(0).locator('svg[aria-hidden="true"]')).toHaveCount(
+      1,
+    );
+
+    // Status words exist in the DOM for assistive tech but are not
+    // rendered as visible row text — `sr-only` clips the box to 1x1px
+    // rather than setting `display:none`, so Playwright's `toBeVisible()`
+    // (which only checks display/visibility/zero-size) still reports it as
+    // visible. Asserting the `sr-only` class directly is the precise,
+    // cross-browser-safe proof that this is screen-reader-only content.
+    await expect(items.nth(0).getByText('Done', { exact: true })).toHaveClass(
+      /\bsr-only\b/,
+    );
+    await expect(
+      items.nth(1).getByText('In progress', { exact: true }),
+    ).toHaveClass(/\bsr-only\b/);
+    await expect(items.nth(2).getByText('To do', { exact: true })).toHaveClass(
+      /\bsr-only\b/,
+    );
+
+    // Bonus (component behaviour, not gated on streaming state): the
+    // in-progress row's text carries the shimmer sweep class.
+    await expect(items.nth(1).locator('.todo-shimmer')).toHaveCount(1);
+
+    // Checkpoint 7: write_todos never appears in the generic "Used N
+    // tools" indicator — with no other tool call present, that indicator
+    // must not render at all.
+    await expect(aiMessage.getByText(/Used \d+ tools?/)).toHaveCount(0);
+
+    // Checkpoint 10: the list survives a page reload (recovered from chat
+    // history), and mounts freshly collapsed again.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const aiMessageAfterReload = await chatPage.waitForAiMessageWithText(
+      'Let me plan this out.',
+    );
+    await expect(
+      chatPage.getAgentTodoItemsContainer(aiMessageAfterReload),
+    ).not.toBeVisible();
+    await chatPage.getAgentTodoTrigger(aiMessageAfterReload).click();
+    await expect(chatPage.getAgentTodoItems(aiMessageAfterReload)).toHaveCount(
+      3,
+    );
+    await expect(
+      chatPage.getAgentTodoProgress(aiMessageAfterReload),
+    ).toContainText('1 of 3 done');
+  });
+
+  test('admin views chat history with an OpenAI-shape write_todos call alongside another tool, and write_todos stays out of the generic tool indicator', async ({
+    page,
+    chatPage,
+  }) => {
+    const sessionId = newSessionId('openai');
+    const todos = [
+      { content: 'Look up docs', status: 'completed' },
+      { content: 'Summarize findings', status: 'pending' },
+    ];
+
+    await chatPage.mockShowReasoning();
+    await chatPage.seedCachedSessionId(mentorId, sessionId);
+    await chatPage.mockChatHistoryWithToolCalls(
+      sessionId,
+      [
+        // A companion, non-write_todos tool call (LangChain shape) so the
+        // generic "Used N tools" indicator has something legitimate to show.
+        {
+          id: 'call_web_1',
+          name: 'web_search_call',
+          args: { query: 'course design best practices' },
+        },
+        // The write_todos call itself, OpenAI shape: function.arguments is
+        // a JSON *string*, not a structured object.
+        {
+          id: 'call_wt_1',
+          type: 'function',
+          function: {
+            name: 'write_todos',
+            arguments: JSON.stringify({ todos }),
+          },
+        },
+      ],
+      { aiContent: 'Let me look into that for you.' },
+    );
+
+    await gotoReadyChat(page, chatPage);
+    const aiMessage = await chatPage.waitForAiMessageWithText(
+      'Let me look into that for you.',
+    );
+
+    // Progress summary is visible even before the row list is expanded.
+    await expect(chatPage.getAgentTodoProgress(aiMessage)).toContainText(
+      '1 of 2 done',
+    );
+
+    // Expand the task-list panel — its rows render both todos from the
+    // OpenAI-shape call.
+    const itemsContainer = chatPage.getAgentTodoItemsContainer(aiMessage);
+    await chatPage.getAgentTodoTrigger(aiMessage).click();
+    await expect(itemsContainer).toBeVisible({ timeout: 10_000 });
+    const items = chatPage.getAgentTodoItems(aiMessage);
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toHaveAttribute('data-status', 'completed');
+    await expect(items.nth(1)).toHaveAttribute('data-status', 'pending');
+
+    // Checkpoint 7: the generic indicator counts only the companion tool
+    // (1) — write_todos is never counted, never shown as its own "Write
+    // todos" row, and its todo text never leaks into the generic card.
+    const genericTrigger = aiMessage.getByText(/^Used 1 tool$/);
+    await expect(genericTrigger).toBeVisible({ timeout: 10_000 });
+    await genericTrigger.click();
+    await expect(
+      aiMessage.getByText('course design best practices'),
+    ).toBeVisible({ timeout: 10_000 });
+    expect(await aiMessage.getByText('Write todos').count()).toBe(0);
+    // The todo content itself only ever appears once on the page — inside
+    // the task-list panel, never duplicated into a generic tool row.
+    await expect(page.getByText('Look up docs')).toHaveCount(1);
+  });
+
+  test('admin views chat history with an unrecognized todo status and a malformed tool-call entry, and the task list degrades gracefully', async ({
+    page,
+    chatPage,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err));
+
+    const sessionId = newSessionId('malformed');
+    const todos = [
+      { content: 'Investigate the issue', status: 'blocked' }, // unknown status
+      { content: 'Confirm the fix', status: 'completed' },
+    ];
+
+    await chatPage.mockShowReasoning();
+    await chatPage.seedCachedSessionId(mentorId, sessionId);
+    await chatPage.mockChatHistoryWithToolCalls(
+      sessionId,
+      [
+        // Malformed: no `name` and no `function.name` — must be dropped by
+        // `toolCallFromHistoryEntry` without throwing.
+        { id: 'bad-no-name' },
+        { id: 'toolu_ok', name: 'write_todos', args: { todos } },
+      ],
+      { aiContent: 'Working through this now.' },
+    );
+
+    await gotoReadyChat(page, chatPage);
+    const aiMessage = await chatPage.waitForAiMessageWithText(
+      'Working through this now.',
+    );
+
+    // Expand the panel — rows only mount once opened.
+    await chatPage.getAgentTodoTrigger(aiMessage).click();
+    await expect(chatPage.getAgentTodoItemsContainer(aiMessage)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Checkpoint 5: unknown status ("blocked") renders as pending rather
+    // than being dropped.
+    const items = chatPage.getAgentTodoItems(aiMessage);
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toHaveAttribute('data-status', 'pending');
+    await expect(items.nth(1)).toHaveAttribute('data-status', 'completed');
+    // sr-only status word reflects the normalized status, attached to the
+    // DOM even though visually hidden.
+    await expect(
+      items.nth(0).getByText('To do', { exact: true }),
+    ).toBeAttached();
+
+    // The malformed entry did not crash the page or trip the ErrorBoundary.
+    await expect(page.getByText('Oops, there was an error!')).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('admin views chat history for a turn with no write_todos call and sees no task-list affordance', async ({
+    page,
+    chatPage,
+  }) => {
+    const sessionId = newSessionId('none');
+
+    await chatPage.mockShowReasoning();
+    await chatPage.seedCachedSessionId(mentorId, sessionId);
+    // No tool calls at all on this turn.
+    await chatPage.mockChatHistoryWithToolCalls(sessionId, [], {
+      aiContent: 'Here is a quick answer, no plan needed.',
+    });
+
+    await gotoReadyChat(page, chatPage);
+    const aiMessage = await chatPage.waitForAiMessageWithText(
+      'Here is a quick answer, no plan needed.',
+    );
+
+    // Checkpoint 6: no panel, no header, no skeleton — nothing at all.
+    await expect(chatPage.getAgentTodoList(aiMessage)).toHaveCount(0);
+    await expect(aiMessage.getByText(/Used \d+ tools?/)).toHaveCount(0);
+  });
+
+  // ── Tier 2: live streaming via the mocked chat WebSocket ──────────────────
+
+  test('admin sends a message and watches the agent task list stream live, replace wholesale, and auto-collapse when the turn completes', async ({
+    page,
+    chatPage,
+  }) => {
+    await chatPage.mockShowReasoning();
+    const ws = await chatPage.mockChatWebSocket();
+
+    await gotoReadyChat(page, chatPage);
+    await chatPage.startNewChat();
+
+    const prompt = 'Plan a short onboarding course for new hires.';
+    await chatPage.sendMessage(prompt);
+
+    // Observe the client's outbound send before scripting any response.
+    const clientMessage = await ws.waitForClientMessage();
+    expect(clientMessage.prompt).toBe(prompt);
+    const sid =
+      typeof clientMessage.session_id === 'string'
+        ? clientMessage.session_id
+        : '';
+
+    const genId = `e2e-gen-${Date.now()}`;
+    ws.send({ generation_id: genId, session_id: sid });
+
+    // First write_todos call — Plan A.
+    const planA = [
+      { content: 'Gather course requirements', status: 'completed' },
+      { content: 'Draft the outline', status: 'in_progress' },
+    ];
+    ws.send({
+      type: 'tool_call',
+      value: {
+        id: 'toolu_planA',
+        name: 'write_todos',
+        tool_input: { todos: planA },
+        log: "Invoking: `write_todos` with `{'todos': [...]}`",
+      },
+      status_code: 200,
+      session_id: sid,
+    });
+    ws.send({
+      type: 'tool_call.end',
+      value: {
+        id: 'toolu_planA',
+        name: 'write_todos',
+        tool_input: { todos: planA },
+        log: "Invoking: `write_todos` with `{'todos': [...]}`",
+        result: 'Updated todo list to [...]',
+      },
+      status_code: 200,
+      session_id: sid,
+    });
+
+    await expect(chatPage.aiMessages).toHaveCount(1, { timeout: 15_000 });
+    const aiMessage = chatPage.getLastAiMessage();
+
+    // Checkpoint 3 (expanded-while-streaming half): the panel is open by
+    // default while the turn is still streaming — no click required.
+    const itemsContainer = chatPage.getAgentTodoItemsContainer(aiMessage);
+    await expect(itemsContainer).toBeVisible({ timeout: 15_000 });
+    let items = chatPage.getAgentTodoItems(aiMessage);
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toHaveAttribute('data-status', 'completed');
+    await expect(items.nth(1)).toHaveAttribute('data-status', 'in_progress');
+    // Checkpoint 8: the in-progress row shimmers while streaming.
+    await expect(items.nth(1).locator('.todo-shimmer')).toHaveCount(1);
+
+    // Second write_todos call — Plan B, a DIFFERENT id, completely
+    // different content and count.
+    const planB = [
+      { content: 'Review pricing options', status: 'pending' },
+      { content: 'Send proposal', status: 'pending' },
+      { content: 'Schedule kickoff', status: 'pending' },
+    ];
+    ws.send({
+      type: 'tool_call',
+      value: {
+        id: 'toolu_planB',
+        name: 'write_todos',
+        tool_input: { todos: planB },
+        log: "Invoking: `write_todos` with `{'todos': [...]}`",
+      },
+      status_code: 200,
+      session_id: sid,
+    });
+    ws.send({
+      type: 'tool_call.end',
+      value: {
+        id: 'toolu_planB',
+        name: 'write_todos',
+        tool_input: { todos: planB },
+        log: "Invoking: `write_todos` with `{'todos': [...]}`",
+        result: 'Updated todo list to [...]',
+      },
+      status_code: 200,
+      session_id: sid,
+    });
+
+    // Checkpoint 4: wholesale replacement — Plan B entirely replaces Plan
+    // A, never merges/appends.
+    items = chatPage.getAgentTodoItems(aiMessage);
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toHaveAttribute('data-status', 'pending');
+    await expect(items.nth(1)).toHaveAttribute('data-status', 'pending');
+    await expect(items.nth(2)).toHaveAttribute('data-status', 'pending');
+    await expect(chatPage.getAgentTodoProgress(aiMessage)).toContainText(
+      '0 of 3 done',
+    );
+    const replacedText = await itemsContainer.innerText();
+    expect(replacedText).not.toContain('Gather course requirements');
+    expect(replacedText).not.toContain('Draft the outline');
+    expect(replacedText).toContain('Review pricing options');
+
+    // Checkpoint 9: the throttled announcer carries ONLY the summary for
+    // the latest (Plan B) list, never todo text. `TODO_ANNOUNCE_THROTTLE_MS`
+    // is 2s — `toHaveText` polls rather than a fixed sleep.
+    const announcer = chatPage.getAgentTodoAnnouncer(aiMessage);
+    await expect(announcer).toHaveText(/Step 0 of 3 complete/, {
+      timeout: 6_000,
+    });
+    const announcerText = await announcer.innerText();
+    expect(announcerText).not.toContain('Review pricing options');
+
+    // End the turn.
+    ws.send({ data: 'All set — check out the plan above.', session_id: sid });
+    ws.send({ eos: true, session_id: sid });
+
+    // Checkpoint 3 (auto-collapse half): once the turn completes, the
+    // panel auto-collapses (but the panel itself, with its progress
+    // summary, stays).
+    await expect(itemsContainer).not.toBeVisible({ timeout: 15_000 });
+    await expect(chatPage.getAgentTodoList(aiMessage)).toBeVisible();
+
+    // Clicking the trigger re-expands it.
+    await chatPage.getAgentTodoTrigger(aiMessage).click();
+    await expect(itemsContainer).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/page-objects/chat.page.ts
+++ b/e2e/page-objects/chat.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, expect } from '@playwright/test';
+import { Page, Locator, Route, WebSocketRoute, expect } from '@playwright/test';
 
 /**
  * Minimal shape accepted by `mockEffectiveSkills` — mirrors the SDK's
@@ -546,5 +546,256 @@ export class ChatPage {
     return this.slashSkillPicker.getByRole('option', {
       name: new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
     });
+  }
+
+  // ── Agent task list (write_todos) mocking helpers — Journey 68 ─────────────
+  //
+  // `AgentTodoList` (components/chat/agent-todo-list.tsx) renders only when
+  // `showReasoning` (mentor-settings `show_reasoning`, default `false`) is on
+  // AND the assistant turn's `toolCalls` contains a `write_todos` entry
+  // (`extractLatestTodos` in `@iblai/iblai-js/web-utils`). Two independent
+  // seams are needed to exercise it deterministically:
+  //   - REST: patch the mentor-settings GET(s) to flip `show_reasoning`, and
+  //     mock the session chat-history GET to inject a `write_todos` tool call
+  //     onto a historical AI message (covers reload/history rendering).
+  //   - WebSocket: mock the live chat socket to script `tool_call` /
+  //     `tool_call.end` frames during an active turn (covers streaming
+  //     behaviour: auto-collapse, wholesale replacement, shimmer, announcer).
+
+  /**
+   * Patches the mentor-settings GET(s) so `show_reasoning` reads `true`,
+   * without stubbing the rest of the payload. Uses `route.fetch()` against
+   * the REAL backend and only overwrites the one field, so every other
+   * mentor-settings-derived value (name, avatar, LLM provider, ...) stays
+   * real and the rest of the chat page renders normally.
+   *
+   * Both the admin settings endpoint AND the public-settings endpoint are
+   * patched: `useMentorSettings` reads `effectiveSettings?.show_reasoning ??
+   * effectivePublicSettings?.show_reasoning`, and only the first one is
+   * strictly required for a logged-in admin, but patching both keeps this
+   * helper correct if it's ever reused for a non-admin/public context.
+   */
+  async mockShowReasoning(): Promise<void> {
+    const patchShowReasoning = async (route: Route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      let json: Record<string, unknown>;
+      try {
+        json = await response.json();
+      } catch {
+        await route.continue();
+        return;
+      }
+      json.show_reasoning = true;
+      await route.fulfill({ response, json });
+    };
+
+    await this.page.route(
+      '**/api/ai-mentor/orgs/*/users/*/mentors/*/settings/**',
+      patchShowReasoning,
+    );
+    await this.page.route(
+      '**/api/ai-mentor/orgs/*/users/*/mentors/*/public-settings/**',
+      patchShowReasoning,
+    );
+  }
+
+  /**
+   * Seeds `localStorage.session_id` (the `Record<mentorId, sessionId>` map
+   * read by `components/chat/index.tsx`) via `page.addInitScript`, so the
+   * chat page picks up a caller-chosen `sessionId` for `mentorId` on its very
+   * next navigation — before the app's own JS runs. Pairs with
+   * `mockChatHistoryWithToolCalls`, which must intercept the history GET for
+   * that same `sessionId` before the navigation that triggers the fetch.
+   */
+  async seedCachedSessionId(
+    mentorId: string,
+    sessionId: string,
+  ): Promise<void> {
+    await this.page.addInitScript(
+      ({ mentorId, sessionId }) => {
+        window.localStorage.setItem(
+          'session_id',
+          JSON.stringify({ [mentorId]: sessionId }),
+        );
+      },
+      { mentorId, sessionId },
+    );
+  }
+
+  /**
+   * Intercepts the session chat-history GET
+   * (`GET /api/ai-mentor/orgs/{org}/users/{user_id}/sessions/{sessionId}/`,
+   * `useLazyGetSessionIdQuery` from `@iblai/data-layer`) for `sessionId` and
+   * fulfills it with a synthetic two-message history: a human message
+   * followed by an AI message carrying `aiToolCalls` verbatim as the raw
+   * `tool_calls` array.
+   *
+   * The envelope is DRF-paginated (`{count, next, previous, results}`), and
+   * `normalizeSessionResults` reverses `results` before use, so `results`
+   * here is supplied newest-first: `[ai, human]`.
+   *
+   * A preceding human message is NOT optional: `components/chat/index.tsx`
+   * special-cases a lone leading `assistant`-role message as a "welcome
+   * message" and renders it via `WelcomeChatNew` instead of
+   * `AIMessageBubble`/`ChatMessages` — which would never mount
+   * `AgentTodoList`. Two messages `[human, ai]` sidesteps that path.
+   *
+   * `aiToolCalls` is passed through untouched onto the raw history entry's
+   * `tool_calls` field, so callers can exercise both accepted shapes
+   * (LangChain `{id, name, args}` and OpenAI `{id, type, function}`) and
+   * malformed entries.
+   */
+  async mockChatHistoryWithToolCalls(
+    sessionId: string,
+    aiToolCalls: unknown[],
+    options: { aiContent?: string; humanContent?: string } = {},
+  ): Promise<void> {
+    const aiContent = options.aiContent ?? 'Let me plan this out.';
+    const humanContent = options.humanContent ?? 'Plan a course for me.';
+    const now = Date.now();
+
+    await this.page.route(
+      `**/api/ai-mentor/orgs/*/users/*/sessions/${sessionId}/**`,
+      async (route) => {
+        if (route.request().method() !== 'GET') {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+              {
+                id: `e2e-msg-ai-${now}`,
+                type: 'ai',
+                content: aiContent,
+                timestamp: new Date(now).toISOString(),
+                tool_calls: aiToolCalls,
+              },
+              {
+                id: `e2e-msg-human-${now}`,
+                type: 'human',
+                content: humanContent,
+                timestamp: new Date(now - 1000).toISOString(),
+              },
+            ],
+          }),
+        });
+      },
+    );
+  }
+
+  /**
+   * Navigates directly to a mentor's chat page (no `?prompt=`). Pair with
+   * `seedCachedSessionId` + `mockChatHistoryWithToolCalls` /
+   * `mockChatWebSocket`, which must be registered first.
+   */
+  async gotoChat(
+    host: string,
+    tenantKey: string,
+    mentorId: string,
+  ): Promise<void> {
+    await this.page.goto(`${host}/platform/${tenantKey}/${mentorId}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+  }
+
+  /**
+   * Mocks the live chat WebSocket (`wss://.../ws/langflow/`, opened by
+   * `useChat` in `@iblai/iblai-js/web-utils`) via `page.routeWebSocket`. Must
+   * be registered before navigation, since the socket opens on mount.
+   *
+   * Since `connectToServer()` is never called, Playwright fully mocks the
+   * connection — nothing reaches the real ASGI backend. Returns a small
+   * controller so the calling test can, in order:
+   *   1. trigger a real UI send (`chatPage.sendMessage(...)`),
+   *   2. `await waitForClientMessage()` to observe + assert the outbound
+   *      `{flow, session_id, token, prompt}` payload,
+   *   3. `send(frame)` scripted server frames one at a time, interleaving
+   *      Playwright web-first assertions between them to verify each step
+   *      of the turn as it streams in.
+   *
+   * Frame shapes match `CHAT_MESSAGE_TYPES` / the message handler in
+   * `use-chat-v2.ts` (`@iblai/web-utils`): a bare `{generation_id}` frame
+   * starts a turn, `{type: 'tool_call'|'tool_call.end', value, ...}` frames
+   * carry tool calls (same `id` on both halves of a pair upserts one entry;
+   * a different `id` appends a new one — this is what makes a *second*
+   * `write_todos` pair a wholesale replacement, since `extractLatestTodos`
+   * reads only the last `write_todos`-named entry), and `{eos: true}` ends
+   * the turn.
+   */
+  async mockChatWebSocket(): Promise<{
+    waitForClientMessage: () => Promise<Record<string, unknown>>;
+    send: (frame: Record<string, unknown>) => void;
+  }> {
+    let capturedWs: WebSocketRoute | undefined;
+    let resolveMessage: ((msg: Record<string, unknown>) => void) | undefined;
+    const messagePromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveMessage = resolve;
+    });
+
+    await this.page.routeWebSocket('**/ws/langflow/**', (ws) => {
+      capturedWs = ws;
+      ws.onMessage((raw) => {
+        try {
+          const parsed = JSON.parse(raw.toString());
+          resolveMessage?.(parsed);
+        } catch {
+          // Non-JSON frame from the page — not expected on this socket,
+          // ignore rather than throw out of the WS event handler.
+        }
+      });
+    });
+
+    return {
+      waitForClientMessage: () => messagePromise,
+      send: (frame: Record<string, unknown>) => {
+        if (!capturedWs) {
+          throw new Error(
+            '[mockChatWebSocket] send() called before the page opened the mocked socket',
+          );
+        }
+        capturedWs.send(JSON.stringify(frame));
+      },
+    };
+  }
+
+  /** Returns the agent task-list panel root within `scope` (default: page). */
+  getAgentTodoList(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-list');
+  }
+
+  /** Returns the collapsible trigger for the agent task-list panel. */
+  getAgentTodoTrigger(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-list-trigger');
+  }
+
+  /** Returns the "N of M done" progress summary node. */
+  getAgentTodoProgress(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-list-progress');
+  }
+
+  /** Returns the `<ol>` wrapping the rendered todo `<li>` rows. */
+  getAgentTodoItemsContainer(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-list-items');
+  }
+
+  /** Returns all rendered `<li data-testid="agent-todo-item">` rows. */
+  getAgentTodoItems(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-item');
+  }
+
+  /** Returns the sr-only `aria-live` announcer node for the task list. */
+  getAgentTodoAnnouncer(scope?: Locator): Locator {
+    return (scope ?? this.page).getByTestId('agent-todo-list-announcer');
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -389,7 +389,13 @@
   },
   "chatAiMessageBubble": {
     "retryScreenReader": "Retry for a new response",
-    "retryTooltip": "Retry"
+    "retryTooltip": "Retry",
+    "agentTodoListTitle": "Task list",
+    "agentTodoStatusCompleted": "Done",
+    "agentTodoStatusInProgress": "In progress",
+    "agentTodoStatusPending": "To do",
+    "agentTodoProgress": "{done} of {total} done",
+    "agentTodoAnnouncement": "Step {done} of {total} complete"
   },
   "chatAiMessageCopy": {
     "copyToClipboard": "Copy to Clipboard",

--- a/messages/es.json
+++ b/messages/es.json
@@ -389,7 +389,13 @@
   },
   "chatAiMessageBubble": {
     "retryScreenReader": "Reintentar para obtener una nueva respuesta",
-    "retryTooltip": "Reintentar"
+    "retryTooltip": "Reintentar",
+    "agentTodoListTitle": "Lista de tareas",
+    "agentTodoStatusCompleted": "Hecho",
+    "agentTodoStatusInProgress": "En curso",
+    "agentTodoStatusPending": "Pendiente",
+    "agentTodoProgress": "{done} de {total} completadas",
+    "agentTodoAnnouncement": "Paso {done} de {total} completado"
   },
   "chatAiMessageCopy": {
     "copyToClipboard": "Copiar al portapapeles",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -389,7 +389,13 @@
   },
   "chatAiMessageBubble": {
     "retryScreenReader": "Réessayer pour une nouvelle réponse",
-    "retryTooltip": "Réessayer"
+    "retryTooltip": "Réessayer",
+    "agentTodoListTitle": "Liste des tâches",
+    "agentTodoStatusCompleted": "Terminé",
+    "agentTodoStatusInProgress": "En cours",
+    "agentTodoStatusPending": "À faire",
+    "agentTodoProgress": "{done} sur {total} terminées",
+    "agentTodoAnnouncement": "Étape {done} sur {total} terminée"
   },
   "chatAiMessageCopy": {
     "copyToClipboard": "Copier dans le presse-papiers",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -389,7 +389,13 @@
   },
   "chatAiMessageBubble": {
     "retryScreenReader": "重试以获取新的回复",
-    "retryTooltip": "重试"
+    "retryTooltip": "重试",
+    "agentTodoListTitle": "任务清单",
+    "agentTodoStatusCompleted": "已完成",
+    "agentTodoStatusInProgress": "进行中",
+    "agentTodoStatusPending": "待办",
+    "agentTodoProgress": "已完成 {done}/{total}",
+    "agentTodoAnnouncement": "第 {done} 步，共 {total} 步已完成"
   },
   "chatAiMessageCopy": {
     "copyToClipboard": "复制到剪贴板",


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Renders a Base Agent's self-written plan as a collapsible task list in the chat UI, driven by the deep-agent write_todos tool
- Every write_todos call carries the whole list, so each one replaces the previous list wholesale — never merges or appends
- Gated behind the mentor's show_reasoning setting (default false) — same gate as the reasoning section and the tool-call indicator
- Degrades to nothing: a turn that never emits write_todos shows no panel, no header, no skeleton
- closes https://github.com/iblai/iblai-platform/issues/2216

## Screenshots
https://github.com/user-attachments/assets/e42f7c07-78f0-45db-8972-ffd84e44f068

https://github.com/user-attachments/assets/214fc316-183f-40b6-ab4f-e26b752d5263

<img width="2881" height="1636" alt="Screenshot from 2026-08-13 21-09-40" src="https://github.com/user-attachments/assets/8c06dfdf-b641-4dcc-bc6d-0bfced3ed998" />