### PR TITLE
fix(embed): persist embed-mode params so they survive hard navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### Bug Fixes
 
-* **code-mode:** attach learner_id to compat-proxy calls and surface upstream 402 as the credit UX ([8659bb6](https://github.com/iblai/os/commit/8659bb6c61868b7e98751053d308b87e589f2119))
+- **code-mode:** attach learner_id to compat-proxy calls and surface upstream 402 as the credit UX ([8659bb6](https://github.com/iblai/os/commit/8659bb6c61868b7e98751053d308b87e589f2119))
 
 ### Chores
 
-* **tauri:** release app-v0.95.14 ([923121c](https://github.com/iblai/os/commit/923121cdb927f88d5e0620d2141cf6f143c4fdba))
+- **tauri:** release app-v0.95.14 ([923121c](https://github.com/iblai/os/commit/923121cdb927f88d5e0620d2141cf6f143c4fdba))
 
 ### Tests
 
-* fix failed tests ([8a23269](https://github.com/iblai/os/commit/8a2326967d92fc2c8abc931d6547a35a40c2417b))
+- fix failed tests ([8a23269](https://github.com/iblai/os/commit/8a2326967d92fc2c8abc931d6547a35a40c2417b))
 
 ## [0.128.1](https://github.com/iblai/os/compare/v0.128.0...v0.128.1) (2026-08-18)
 
 ### Chores
 
-* **deps:** bump @iblai/iblai-js to 2.5.1 ([f28d824](https://github.com/iblai/os/commit/f28d82446e2739cf1a009f21dbe8e157df4378e4))
+- **deps:** bump @iblai/iblai-js to 2.5.1 ([f28d824](https://github.com/iblai/os/commit/f28d82446e2739cf1a009f21dbe8e157df4378e4))
 
 ## [0.128.0](https://github.com/iblai/os/compare/v0.127.0...v0.128.0) (2026-08-18)
 

--- a/hooks/use-embed-mode.ts
+++ b/hooks/use-embed-mode.ts
@@ -1,15 +1,15 @@
 import { useSearchParams } from 'next/navigation';
 
+import { isEmbedMode } from '@/lib/embed-context';
+
 export function useEmbedMode() {
   const searchParams = useSearchParams();
   if (searchParams.get('embed') === 'true') return true;
   // `useSearchParams()` can momentarily return empty params (e.g. a
-  // statically-prerendered first paint or a mid-navigation render), which
-  // briefly flips embed mode OFF and flashes the full (non-embed) sidebar —
-  // Projects / Notifications / Support — inside an iframe. Fall back to the
-  // live URL on the client so embed mode stays correct from first paint.
-  if (typeof window !== 'undefined') {
-    return new URLSearchParams(window.location.search).get('embed') === 'true';
-  }
+  // statically-prerendered first paint or a mid-navigation render), and a
+  // client-side navigation can land on a path that no longer carries the embed
+  // param at all. Fall back to the live URL, then to the persisted embed
+  // context, so embed mode stays correct for the iframe's whole lifetime.
+  if (typeof window !== 'undefined') return isEmbedMode();
   return false;
 }

--- a/hooks/use-tenant-redirect.ts
+++ b/hooks/use-tenant-redirect.ts
@@ -7,6 +7,7 @@ import {
   useLazyGetUserTenantsQuery,
 } from '@/features/tenants/api-slice';
 import { tenantSchema } from '@/lib/types';
+import { appendEmbedContext } from '@/lib/embed-context';
 
 type UseTenantProviderProps = {
   onAuthSuccess?: () => void;
@@ -65,8 +66,11 @@ export function useTenantProvider({
 
       // check if the tenant is active
       if (tenantMetadata?.metadata?.spa_domains?.mentor?.active) {
-        window.location.href =
-          tenantMetadata?.metadata?.spa_domains?.mentor?.domain;
+        // Cross-origin redirect: sessionStorage doesn't follow to another
+        // domain, so carry the embed params explicitly to keep the embed view.
+        window.location.href = appendEmbedContext(
+          tenantMetadata?.metadata?.spa_domains?.mentor?.domain,
+        );
         onAuthSuccess?.();
         return;
       }

--- a/lib/__tests__/embed-context.test.ts
+++ b/lib/__tests__/embed-context.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import {
+  persistEmbedContextFromUrl,
+  getEmbedContext,
+  isEmbedMode,
+  embedContextQuery,
+  appendEmbedContext,
+} from '@/lib/embed-context';
+
+/** Point window.location at a path+query the way a real navigation would. */
+function setUrl(pathWithQuery: string) {
+  window.history.replaceState({}, '', pathWithQuery);
+}
+
+const EMBED_URL =
+  '/platform/acme/bot-1?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally';
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  setUrl('/');
+});
+
+describe('not in embed mode', () => {
+  it('returns empty/none when the URL has no embed param and nothing is stored', () => {
+    expect(getEmbedContext()).toBeNull();
+    expect(isEmbedMode()).toBe(false);
+    expect(embedContextQuery()).toBe('');
+  });
+
+  it('persistEmbedContextFromUrl is a no-op when not embedded', () => {
+    persistEmbedContextFromUrl();
+    expect(window.sessionStorage.getItem('ibl:embed-context')).toBeNull();
+  });
+
+  it('appendEmbedContext leaves the URL unchanged', () => {
+    expect(appendEmbedContext('/platform/acme/x')).toBe('/platform/acme/x');
+  });
+});
+
+describe('reading embed context from the live URL', () => {
+  beforeEach(() => setUrl(EMBED_URL));
+
+  it('detects embed mode and preserves all four keys', () => {
+    expect(isEmbedMode()).toBe(true);
+    expect(getEmbedContext()).toEqual({
+      embed: 'true',
+      mode: 'anonymous',
+      component: 'chat',
+      'extra-body-classes': 'iframed-externally',
+    });
+    expect(embedContextQuery()).toBe(
+      '?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally',
+    );
+  });
+
+  it('omits keys that are not present in the URL', () => {
+    setUrl('/platform/acme/bot-1?embed=true&mode=anonymous');
+    expect(embedContextQuery()).toBe('?embed=true&mode=anonymous');
+  });
+});
+
+describe('surviving a hard navigation that wipes the query (the bug)', () => {
+  it('recovers embed mode from sessionStorage after window.location goes to "/"', () => {
+    // 1. Embedded iframe loads with the params and persists them.
+    setUrl(EMBED_URL);
+    persistEmbedContextFromUrl();
+
+    // 2. A tenant-mismatch hard reset navigates to "/" with NO query.
+    setUrl('/');
+    expect(new URLSearchParams(window.location.search).get('embed')).toBeNull();
+
+    // 3. Embed mode is still recovered from the persisted copy.
+    expect(isEmbedMode()).toBe(true);
+    expect(getEmbedContext()).toMatchObject({
+      embed: 'true',
+      mode: 'anonymous',
+    });
+    expect(embedContextQuery()).toContain('embed=true');
+  });
+
+  it('the live URL wins over a stale stored copy', () => {
+    setUrl('/platform/acme/bot-1?embed=true&component=analytics-overview');
+    persistEmbedContextFromUrl();
+    // A fresh embedded load with a different component.
+    setUrl('/platform/acme/bot-1?embed=true&component=recent-messages');
+    expect(getEmbedContext()?.component).toBe('recent-messages');
+  });
+});
+
+describe('appendEmbedContext', () => {
+  beforeEach(() => setUrl(EMBED_URL));
+
+  it('appends with "?" to a bare path', () => {
+    expect(appendEmbedContext('/')).toBe(
+      '/?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally',
+    );
+  });
+
+  it('appends with "&" when the target already has a query', () => {
+    expect(appendEmbedContext('https://acme.ibl.ai/platform?foo=1')).toBe(
+      'https://acme.ibl.ai/platform?foo=1&embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally',
+    );
+  });
+
+  it('preserves a trailing hash fragment', () => {
+    expect(appendEmbedContext('/platform#section')).toBe(
+      '/platform?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally#section',
+    );
+  });
+
+  it('works cross-origin (tenant custom domain)', () => {
+    expect(appendEmbedContext('https://tenant.example.com')).toBe(
+      'https://tenant.example.com?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally',
+    );
+  });
+});
+
+describe('resilience', () => {
+  it('ignores a stored copy whose embed flag is not "true"', () => {
+    setUrl('/');
+    window.sessionStorage.setItem(
+      'ibl:embed-context',
+      JSON.stringify({ embed: 'false', mode: 'anonymous' }),
+    );
+    expect(isEmbedMode()).toBe(false);
+    expect(getEmbedContext()).toBeNull();
+  });
+
+  it('ignores malformed JSON in storage', () => {
+    setUrl('/');
+    window.sessionStorage.setItem('ibl:embed-context', '{not json');
+    expect(getEmbedContext()).toBeNull();
+  });
+
+  it('swallows sessionStorage write failures', () => {
+    setUrl(EMBED_URL);
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceeded');
+      });
+    expect(() => persistEmbedContextFromUrl()).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/lib/embed-context.ts
+++ b/lib/embed-context.ts
@@ -1,0 +1,105 @@
+// Embed-context params keep the mentor in its stripped-down embedded view when
+// it's iframed by a host app (the `agent-ai` web component appends them:
+// `embed=true`, `mode`, `component`, `extra-body-classes`). They live ONLY in
+// the iframe URL's query string, so any client-side navigation that rebuilds
+// the path drops them and flips the iframe back to the full app. The worst
+// offenders are the automatic hard `window.location.href` resets on tenant
+// mismatch / tenant redirect — those can't carry a query string forward at all,
+// and once they fire the embed view is lost until the iframe is reloaded from
+// the parent (which is why logging out and back in "fixes" it).
+//
+// To make embed mode survive ANY navigation — including hard resets — we mirror
+// the params into `sessionStorage`, which is scoped per browsing context (the
+// iframe), persists across same-origin page loads within that context, and is
+// storage-partitioned so it never leaks into a standalone (first-party) tab.
+// Readers prefer the live URL and fall back to the stored copy.
+
+export const EMBED_CONTEXT_KEYS = [
+  'embed',
+  'mode',
+  'component',
+  'extra-body-classes',
+] as const;
+
+const STORAGE_KEY = 'ibl:embed-context';
+
+type EmbedContext = Record<string, string>;
+
+function readUrlEmbedContext(): EmbedContext | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('embed') !== 'true') return null;
+  const ctx: EmbedContext = {};
+  for (const key of EMBED_CONTEXT_KEYS) {
+    const value = params.get(key);
+    if (value !== null) ctx[key] = value;
+  }
+  return ctx;
+}
+
+function readStoredEmbedContext(): EmbedContext | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as EmbedContext;
+    return parsed?.embed === 'true' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the embed context from the current URL. Call once on first (embedded)
+ * load — later hard navigations can then recover embed mode from the store even
+ * after they've wiped the URL query. No-op when the URL isn't in embed mode.
+ */
+export function persistEmbedContextFromUrl(): void {
+  const ctx = readUrlEmbedContext();
+  if (!ctx) return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(ctx));
+  } catch {
+    // sessionStorage unavailable (private mode / disabled). The live-URL path
+    // still works within a single page load; only cross-navigation recovery is lost.
+  }
+}
+
+/** The embed context from the live URL, falling back to the stored copy. */
+export function getEmbedContext(): EmbedContext | null {
+  return readUrlEmbedContext() ?? readStoredEmbedContext();
+}
+
+/** Whether the app should render in embedded mode (URL or persisted). */
+export function isEmbedMode(): boolean {
+  return getEmbedContext()?.embed === 'true';
+}
+
+/**
+ * The embed-context query string (with leading `?`), or '' when not embedded.
+ * Append to same-origin navigation targets so they keep the embed view.
+ */
+export function embedContextQuery(): string {
+  const ctx = getEmbedContext();
+  if (!ctx) return '';
+  const params = new URLSearchParams();
+  for (const key of EMBED_CONTEXT_KEYS) {
+    if (ctx[key] !== undefined) params.set(key, ctx[key]);
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * Append the embed-context query to any URL (absolute or path), preserving an
+ * existing query/hash. Use for hard `window.location.href` navigations —
+ * especially cross-origin ones (tenant custom domains), where sessionStorage
+ * doesn't follow and the params must be carried explicitly.
+ */
+export function appendEmbedContext(url: string): string {
+  const qs = embedContextQuery().replace(/^\?/, '');
+  if (!qs) return url;
+  const [beforeHash, hash] = url.split('#');
+  const sep = beforeHash.includes('?') ? '&' : '?';
+  return `${beforeHash}${sep}${qs}${hash !== undefined ? `#${hash}` : ''}`;
+}

--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -56,6 +56,11 @@ import { Spinner } from '@/components/spinner';
 import { useIsPreviewMode } from '@/hooks/use-is-preview-mode';
 import { ANONYMOUS_USERNAME, MENTOR_VISIBILITY_VALUES } from '@/lib/constants';
 import { useEmbedMode } from '@/hooks/use-embed-mode';
+import {
+  embedContextQuery,
+  appendEmbedContext,
+  persistEmbedContextFromUrl,
+} from '@/lib/embed-context';
 import { use402ErrorCheck } from '@/hooks/subscription/use-402-error-check';
 import { SUBSCRIPTION_CREDIT_LIMIT_ERROR_MESSAGE } from '@/hooks/subscription/constants';
 import { customErrorMessages } from '@/lib/error';
@@ -91,6 +96,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   useOpencodeLearner();
   // Desktop only: a Code-turn 402 (insufficient credit) gets normal chat's UX.
   useOpencode402();
+
+  // Mirror the embed-context params into sessionStorage on first load so embed
+  // mode survives later navigations that rebuild the URL without them — notably
+  // the hard `window.location.href` resets below. See lib/embed-context.
+  useEffect(() => {
+    persistEmbedContextFromUrl();
+  }, []);
 
   useEffect(() => {
     deleteCookieOnAllDomains('ibl_tenant_switching', window.location.hostname);
@@ -272,24 +284,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     saveDmTokenExpires(tokenResponse.dm_token.expires);
   }
 
-  // Preserve the iframe/embed-context params (embed / mode / component /
-  // extra-body-classes) across mentor redirects. They were only forwarded when
-  // landing on '/', but MentorProvider re-resolves the mentor once you're
-  // already on /platform/{tenant}/{mentorId} and calls redirectToMentor again —
-  // there pathname !== '/', so the query was dropped, stripping the embed view.
-  // Carry just those keys from the live URL regardless of the current path (so
-  // we never leak tokens or other one-shot params into the mentor URL).
-  function embedContextQuery() {
-    const current = new URLSearchParams(window.location.search);
-    const preserved = new URLSearchParams();
-    for (const key of ['embed', 'mode', 'component', 'extra-body-classes']) {
-      const value = current.get(key);
-      if (value !== null) preserved.set(key, value);
-    }
-    const qs = preserved.toString();
-    return qs ? `?${qs}` : '';
-  }
-
+  // `embedContextQuery()` (from lib/embed-context) carries the embed params
+  // across mentor redirects: MentorProvider re-resolves the mentor once you're
+  // already on /platform/{tenant}/{mentorId} and calls redirectToMentor again,
+  // where the query would otherwise be dropped, stripping the embed view. It
+  // reads the live URL first, then the persisted copy, so it works even after a
+  // hard reset has wiped the query.
   function redirectToNoMentorsPage() {
     router.push(`/platform/${tenantKey}/explore${embedContextQuery()}`);
   }
@@ -594,7 +594,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
             console.log(
               '[TenantProvider] Tenant mismatch - redirecting to home',
             );
-            window.location.href = '/';
+            // Carry embed params onto '/' so an embedded iframe isn't flipped
+            // back to the full app by this hard reset (sessionStorage also
+            // recovers them on the '/' load; this makes it immediate).
+            window.location.href = appendEmbedContext('/');
           }}
         >
           {useMentorProvider ? (


### PR DESCRIPTION
## Problem

An `agent-ai`-embedded mentor iframe (e.g. in skillsai) sometimes renders the **full** mentor app instead of the stripped-down embed view — no embed query params on the URL. Logging out and back in fixes it (fresh iframe). It's intermittent and correlated with a **tenant switch** happening elsewhere in the same browser.

## Root cause

The embed params (`embed`/`mode`/`component`/`extra-body-classes`) live **only in the iframe URL's query string**. The `agent-ai` component sets the iframe `src` once (with the params) and never re-navigates it — so the loss happens inside the mentor app.

In embed mode the nav sidebar is hidden, so the sidebar `router.push` paths aren't user-reachable. The drop comes from two **automatic** hard navigations that rebuild the URL and can't carry a query string forward:

- `providers/index.tsx` `onTenantMismatch` → `window.location.href = '/'` — fires when the iframe's route tenant no longer matches the session's current tenant (i.e. after a tenant switch, once the switch-suppression TTL expires). Hard reset to `/` with no query → embed view lost.
- `hooks/use-tenant-redirect.ts` → `window.location.href = <tenant custom domain>` — same effect, cross-origin.

`ab6194d8` fixed the *MentorProvider re-resolve* path (same-URL) but not these hard resets, where the params are wiped before the preservation logic reads them.

## Fix

Stop relying solely on the URL. `lib/embed-context.ts` mirrors the params into **`sessionStorage`** — scoped per browsing context (the iframe), survives same-origin hard navigations including `window.location.href='/'`, and storage-partitioned so it never leaks into a standalone first-party tab. Readers prefer the live URL, then fall back to the stored copy.

- `providers/index.tsx`: persist on mount; `onTenantMismatch` now carries the params onto `/`.
- `hooks/use-tenant-redirect.ts`: append params to the cross-origin domain redirect (sessionStorage can't follow cross-origin).
- `hooks/use-embed-mode.ts`: falls back to the persisted context.

This fixes the whole class at once (tenant-mismatch, custom-domain, and any future navigation) instead of patching individual call sites.

## Testing

- New `lib/__tests__/embed-context.test.ts` (14 tests), including **recovery of embed mode after a simulated `window.location.href='/'`** — the exact bug. 100% line coverage on the new file.
- Existing `use-embed-mode` (10) and `use-tenant-redirect` (23) suites still green; typecheck clean.

No e2e journey coverage change (behavioral persistence fix; nothing removed).