### PR TITLE
chore(chrome-ext): prepare Chrome Web Store submission

### DIFF
--- a/.github/workflows/release-chrome-extension.yml
+++ b/.github/workflows/release-chrome-extension.yml
@@ -1,0 +1,100 @@
+name: Release Chrome Extension
+
+# Publishes the side-panel extension (extensions/chrome/) to the Chrome Web
+# Store whenever its manifest version is bumped on main. Also runnable manually.
+#
+# Chrome rejects re-uploading an existing version, so a publish only happens when
+# extensions/chrome/manifest.json "version" changes vs the previous commit — bump
+# it in the same change you want shipped. A manual "Run workflow" always attempts
+# to publish the current version.
+#
+# Requires these repo secrets (Chrome Web Store API — generate for the publishing
+# Google account: https://github.com/fregante/chrome-webstore-upload-keys):
+#   CHROME_EXTENSION_ID    the item's ID in the Web Store developer dashboard
+#   CHROME_CLIENT_ID       OAuth client id
+#   CHROME_CLIENT_SECRET   OAuth client secret
+#   CHROME_REFRESH_TOKEN   OAuth refresh token
+# Until CHROME_EXTENSION_ID is set the job no-ops (logs a notice) instead of failing.
+#
+# NOTE: point panel.html `mentorurl` at the production app (not an ngrok tunnel)
+# before the first real publish — see issue #432.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'extensions/chrome/**'
+  workflow_dispatch:
+
+concurrency:
+  group: release-chrome-extension
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # need HEAD~1 to detect a manifest version bump
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25.3.0'
+
+      - name: Check Web Store credentials are configured
+        id: creds
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          if [ -z "$CHROME_EXTENSION_ID" ]; then
+            echo "::notice::Chrome Web Store secrets not configured — skipping publish."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve version and whether it changed
+        if: steps.creds.outputs.configured == 'true'
+        id: version
+        run: |
+          VERSION=$(node -p "require('./extensions/chrome/manifest.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — will publish v$VERSION."
+            exit 0
+          fi
+          PREV=$(git show HEAD~1:extensions/chrome/manifest.json 2>/dev/null \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{process.stdout.write(String(JSON.parse(s).version))}catch{process.stdout.write('')}})")
+          if [ "$VERSION" != "$PREV" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version bumped ${PREV:-<none>} -> $VERSION — will publish."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::manifest version unchanged ($VERSION) — nothing to publish. Bump extensions/chrome/manifest.json/version to release."
+          fi
+
+      - name: Package extension
+        if: steps.creds.outputs.configured == 'true' && steps.version.outputs.changed == 'true'
+        run: |
+          cd extensions/chrome
+          zip -r "$GITHUB_WORKSPACE/ibl-ai-extension.zip" . -x 'README.md'
+          echo "Packaged contents:" && unzip -l "$GITHUB_WORKSPACE/ibl-ai-extension.zip"
+
+      - name: Upload and publish to the Chrome Web Store
+        if: steps.creds.outputs.configured == 'true' && steps.version.outputs.changed == 'true'
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          npx --yes chrome-webstore-upload-cli@3 upload \
+            --source ibl-ai-extension.zip \
+            --auto-publish
+          echo "::notice::Published ibl.ai extension v${{ steps.version.outputs.version }} to the Chrome Web Store."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### Bug Fixes
 
-* **code-mode:** attach learner_id to compat-proxy calls and surface upstream 402 as the credit UX ([8659bb6](https://github.com/iblai/os/commit/8659bb6c61868b7e98751053d308b87e589f2119))
+- **code-mode:** attach learner_id to compat-proxy calls and surface upstream 402 as the credit UX ([8659bb6](https://github.com/iblai/os/commit/8659bb6c61868b7e98751053d308b87e589f2119))
 
 ### Chores
 
-* **tauri:** release app-v0.95.14 ([923121c](https://github.com/iblai/os/commit/923121cdb927f88d5e0620d2141cf6f143c4fdba))
+- **tauri:** release app-v0.95.14 ([923121c](https://github.com/iblai/os/commit/923121cdb927f88d5e0620d2141cf6f143c4fdba))
 
 ### Tests
 
-* fix failed tests ([8a23269](https://github.com/iblai/os/commit/8a2326967d92fc2c8abc931d6547a35a40c2417b))
+- fix failed tests ([8a23269](https://github.com/iblai/os/commit/8a2326967d92fc2c8abc931d6547a35a40c2417b))
 
 ## [0.128.1](https://github.com/iblai/os/compare/v0.128.0...v0.128.1) (2026-08-18)
 
 ### Chores
 
-* **deps:** bump @iblai/iblai-js to 2.5.1 ([f28d824](https://github.com/iblai/os/commit/f28d82446e2739cf1a009f21dbe8e157df4378e4))
+- **deps:** bump @iblai/iblai-js to 2.5.1 ([f28d824](https://github.com/iblai/os/commit/f28d82446e2739cf1a009f21dbe8e157df4378e4))
 
 ## [0.128.0](https://github.com/iblai/os/compare/v0.127.0...v0.128.0) (2026-08-18)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Build, deploy, and manage intelligent conversational agents — from prototype t
 
 <a href="https://os.ibl.ai"><img src="https://img.shields.io/badge/Use_it_on_the_Web-2563eb?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Use it on the Web" height="42"></a>
 &nbsp;
+<a href="https://chromewebstore.google.com/detail/EXTENSION_ID"><img src="https://img.shields.io/badge/Add_to_Chrome-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Add to Chrome" height="42"></a>
+&nbsp;
 <a href="https://github.com/iblai/os/releases/download/app-v0.95.14/ibl.ai_0.95.14_universal.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="42"></a>
 &nbsp;
 <a href="https://github.com/iblai/os/releases/download/app-v0.95.14/ibl.ai_0.95.14_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="42"></a>
@@ -69,14 +71,15 @@ Most AI apps make you choose a device. ibl.ai/os meets your users wherever they 
 
 <div align="center">
 
-| Platform    |     | Status                                                                                                |
-| ----------- | --- | ----------------------------------------------------------------------------------------------------- |
-| **Web**     | 🌐  | Live at **[os.ibl.ai](https://os.ibl.ai)** — any modern browser                                       |
-| **macOS**   | 🍎  | Native app — [download universal .dmg](docs/DOWNLOADS.md) (Intel + Apple Silicon, signed & notarized) |
-| **Windows** | 🪟  | Native app — [download installer](docs/DOWNLOADS.md) (x64 + ARM64)                                    |
-| **iOS**     | 📱  | Native app — [App Store](https://apps.apple.com/us/app/ibl-ai/id6504929071)                           |
-| **Android** | 🤖  | Native app — [Google Play](https://play.google.com/store/apps/details?id=ai.ibl.mentorai)             |
-| **Linux**   | 🐧  | Native app — [build from source](docs/development.md)                                                 |
+| Platform    |     | Status                                                                                                                               |
+| ----------- | --- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Web**     | 🌐  | Live at **[os.ibl.ai](https://os.ibl.ai)** — any modern browser                                                                      |
+| **Chrome**  | 🧩  | Side-panel extension — [Chrome Web Store](https://chromewebstore.google.com/detail/EXTENSION_ID) (chat with your agents on any page) |
+| **macOS**   | 🍎  | Native app — [download universal .dmg](docs/DOWNLOADS.md) (Intel + Apple Silicon, signed & notarized)                                |
+| **Windows** | 🪟  | Native app — [download installer](docs/DOWNLOADS.md) (x64 + ARM64)                                                                   |
+| **iOS**     | 📱  | Native app — [App Store](https://apps.apple.com/us/app/ibl-ai/id6504929071)                                                          |
+| **Android** | 🤖  | Native app — [Google Play](https://play.google.com/store/apps/details?id=ai.ibl.mentorai)                                            |
+| **Linux**   | 🐧  | Native app — [build from source](docs/development.md)                                                                                |
 
 </div>
 
@@ -233,11 +236,13 @@ If you need full backend infrastructure:
 
 > **Note**: ibl.ai/os requires the ibl.ai backend platform for authentication, AI agent APIs, and data services. The backend is not included in this repository — visit [ibl.ai](https://ibl.ai) to get started.
 
-### Desktop & Mobile
+### Every surface, on your own backend
 
-See [docs/development.md](docs/development.md) for native app build instructions.
+Ship **Web, macOS, Windows/Surface, Linux, iOS, and Android** pointed at your own deployment — one web codebase, with the native apps as webview shells around it:
 
-Full deployment docs: [Docker & Standalone](docs/standalone-deployment.md)
+**→ [Platform deployment guide](docs/platform-deployment.md)** (per-surface build, backend config, and release).
+
+Full deployment docs: [Docker & Standalone](docs/standalone-deployment.md) · [native app dev](docs/development.md)
 
 #### Build-Time Configuration
 

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -27,12 +27,10 @@
   "host_permissions": [
     "https://*.iblai.app/*",
     "https://*.ibl.ai/*",
-    "http://localhost:3001/*",
-    "https://*.ngrok-free.app/*",
     "http://*/*",
     "https://*/*"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.iblai.app https://*.ibl.ai http://localhost:3001 https://*.ngrok-free.app; frame-src https://*.iblai.app https://*.ibl.ai https://accounts.google.com https://appleid.apple.com http://localhost:3001 https://*.ngrok-free.app; child-src https://*.iblai.app https://*.ibl.ai http://localhost:3001 https://*.ngrok-free.app"
+    "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.iblai.app https://*.ibl.ai; frame-src https://*.iblai.app https://*.ibl.ai https://accounts.google.com https://appleid.apple.com; child-src https://*.iblai.app https://*.ibl.ai"
   }
 }

--- a/extensions/chrome/panel.html
+++ b/extensions/chrome/panel.html
@@ -10,7 +10,7 @@
     <!-- Set tenant + mentor for your agent. Sizing lives in panel.css so the
          component fills the side panel (no fixed width / overlay positioning). -->
     <agent-ai
-      mentorurl="https://78a2-3-209-13-28.ngrok-free.app"
+      mentorurl="https://os.ibl.ai"
       authurl="https://login.iblai.app"
       lmsurl="https://learn.iblai.app"
       theme="dark"


### PR DESCRIPTION
Prep for publishing the side-panel extension (`extensions/chrome/`) to the Chrome Web Store.

## Changes
- **`manifest.json`** — drop dev-only `http://localhost:3001/*` and `https://*.ngrok-free.app/*` host permissions (and the matching `connect-src`/`frame-src`/`child-src` CSP entries). The production build now only requests what the stated single purpose needs, avoiding store-review friction. `http://*/*` + `https://*/*` still cover the assistant's page-reading purpose.
- **`panel.html`** — point `mentorurl` at production `https://os.ibl.ai` (it was left on an ngrok tunnel). Fixes #432 — must not ship pointing at a dev tunnel.
- **`README.md`** — add an "Add to Chrome" badge and a **Chrome** row in the platform table.
- **`release-chrome-extension.yml`** (new) — publishes `extensions/chrome/` to the Web Store when `manifest.json` `version` bumps on `main` (or via manual dispatch). Guarded: **no-ops with a notice until the `CHROME_*` repo secrets are configured**, and skips when the version is unchanged.

## Follow-ups before first publish
- Configure repo secrets: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`.
- Replace the `EXTENSION_ID` placeholder in the README store links with the real ID once published.

## Notes
- The 8-line `CHANGELOG.md` diff is an incidental prettier reformat swept in by the repo's `prettier --write .` pre-commit hook (origin/main's CHANGELOG was already prettier-dirty) — not a functional change.
- Extension-, docs-, and CI-only; no app source touched.