### PR TITLE
docs: per-surface self-hosting deployment guide + hide Chrome download until store approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Build, deploy, and manage intelligent conversational agents — from prototype t
 
 <a href="https://os.ibl.ai"><img src="https://img.shields.io/badge/Use_it_on_the_Web-2563eb?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Use it on the Web" height="42"></a>
 &nbsp;
-<a href="https://chromewebstore.google.com/detail/EXTENSION_ID"><img src="https://img.shields.io/badge/Add_to_Chrome-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Add to Chrome" height="42"></a>
-&nbsp;
 <a href="https://github.com/iblai/os/releases/download/app-v0.95.14/ibl.ai_0.95.14_universal.dmg"><img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" height="42"></a>
 &nbsp;
 <a href="https://github.com/iblai/os/releases/download/app-v0.95.14/ibl.ai_0.95.14_x64-setup.exe"><img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="42"></a>
@@ -31,6 +29,16 @@ Build, deploy, and manage intelligent conversational agents — from prototype t
 <a href="https://play.google.com/store/apps/details?id=ai.ibl.mentorai"><img src="https://img.shields.io/badge/Download_for_Android-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Download for Android" height="42"></a>
 
 <sub>Windows ARM64 · older builds · Linux → [all downloads](docs/DOWNLOADS.md)</sub>
+
+<!--
+Chrome extension download — hidden until our extension is approved on the Chrome Web Store.
+Restore EXTENSION_ID and re-add these two spots:
+  1) "Get ibl.ai/os" badge row (after the "Use it on the Web" badge):
+     <a href="https://chromewebstore.google.com/detail/EXTENSION_ID"><img src="https://img.shields.io/badge/Add_to_Chrome-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Add to Chrome" height="42"></a>
+     &nbsp;
+  2) "Every platform, one codebase" table (after the Web row):
+     | **Chrome**  | 🧩  | Side-panel extension — [Chrome Web Store](https://chromewebstore.google.com/detail/EXTENSION_ID) (chat with your agents on any page) |
+-->
 
 <br>
 
@@ -71,15 +79,14 @@ Most AI apps make you choose a device. ibl.ai/os meets your users wherever they 
 
 <div align="center">
 
-| Platform    |     | Status                                                                                                                               |
-| ----------- | --- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Web**     | 🌐  | Live at **[os.ibl.ai](https://os.ibl.ai)** — any modern browser                                                                      |
-| **Chrome**  | 🧩  | Side-panel extension — [Chrome Web Store](https://chromewebstore.google.com/detail/EXTENSION_ID) (chat with your agents on any page) |
-| **macOS**   | 🍎  | Native app — [download universal .dmg](docs/DOWNLOADS.md) (Intel + Apple Silicon, signed & notarized)                                |
-| **Windows** | 🪟  | Native app — [download installer](docs/DOWNLOADS.md) (x64 + ARM64)                                                                   |
-| **iOS**     | 📱  | Native app — [App Store](https://apps.apple.com/us/app/ibl-ai/id6504929071)                                                          |
-| **Android** | 🤖  | Native app — [Google Play](https://play.google.com/store/apps/details?id=ai.ibl.mentorai)                                            |
-| **Linux**   | 🐧  | Native app — [build from source](docs/development.md)                                                                                |
+| Platform    |     | Status                                                                                                |
+| ----------- | --- | ----------------------------------------------------------------------------------------------------- |
+| **Web**     | 🌐  | Live at **[os.ibl.ai](https://os.ibl.ai)** — any modern browser                                       |
+| **macOS**   | 🍎  | Native app — [download universal .dmg](docs/DOWNLOADS.md) (Intel + Apple Silicon, signed & notarized) |
+| **Windows** | 🪟  | Native app — [download installer](docs/DOWNLOADS.md) (x64 + ARM64)                                    |
+| **iOS**     | 📱  | Native app — [App Store](https://apps.apple.com/us/app/ibl-ai/id6504929071)                           |
+| **Android** | 🤖  | Native app — [Google Play](https://play.google.com/store/apps/details?id=ai.ibl.mentorai)             |
+| **Linux**   | 🐧  | Native app — [build from source](docs/development.md)                                                 |
 
 </div>
 

--- a/docs/platform-deployment.md
+++ b/docs/platform-deployment.md
@@ -1,0 +1,174 @@
+# Deploying ibl.ai/os against your own backend
+
+This guide shows how to ship every surface — **Web, macOS, Windows/Surface, Linux, iOS, Android** (and the Chrome extension) — pointed at **your own** ibl.ai backend instead of the hosted one.
+
+> Looking for the web asset-hosting / CDN rollout design instead? See [`DEPLOYMENT.md`](DEPLOYMENT.md).
+
+## The mental model (read this first)
+
+There is **one** frontend — the Next.js web app. Every native app is a thin **native webview shell that loads that web app**. So there are only two things to configure:
+
+| Layer                                                       | What it is                                                | How you point it at your backend                                        |
+| ----------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Web app**                                                 | The Next.js SPA (also what you self-host at your domain)  | `NEXT_PUBLIC_*` env vars — build-time **or** runtime (`window.__ENV__`) |
+| **Native shells** (macOS / Windows / Linux / iOS / Android) | Tauri wrappers that load your hosted web app in a webview | `TAURI_DEV_URL` **compile-time** env var → your web app's URL           |
+
+So the recipe for every native platform is the same: **deploy the web app at your domain first**, then **build the native shell with `TAURI_DEV_URL=https://your-app.example.com`**.
+
+```
+   your backend services                your web app                 native shells
+ (api / auth / lms / asgi / livekit) ──►  Next.js SPA  ◄────────────  macOS · Windows · Linux
+        set via NEXT_PUBLIC_*           (Docker / host)   TAURI_DEV_URL   iOS · Android
+```
+
+---
+
+## 1. Configure the web app (applies to every surface)
+
+Copy [`.env.example`](../.env.example) → `.env` and point the core URLs at your deployment. The ones that matter for "against your own backend":
+
+| Variable                                                           | Points at                                            | Example                     |
+| ------------------------------------------------------------------ | ---------------------------------------------------- | --------------------------- |
+| `NEXT_PUBLIC_AUTH_URL`                                             | your login / auth SPA                                | `https://login.example.com` |
+| `NEXT_PUBLIC_API_BASE_URL`                                         | your API gateway (SDK derives `/lms`, `/dm`, `/axd`) | `https://api.example.com`   |
+| `NEXT_PUBLIC_LEGACY_LMS_URL`                                       | legacy LMS, if separate                              | `https://learn.example.com` |
+| `NEXT_PUBLIC_BASE_WS_URL`                                          | your ASGI / websocket host                           | `wss://asgi.example.com`    |
+| `NEXT_PUBLIC_IBL_LIVE_KIT_SERVER_URL`                              | your LiveKit server (voice / screen-share)           | `wss://livekit.example.com` |
+| `NEXT_PUBLIC_MENTOR_URL` / `NEXT_PUBLIC_MENTOR_IFRAME_URL`         | your web app's own URL (embeds / deep-links)         | `https://app.example.com`   |
+| `NEXT_PUBLIC_MAIN_TENANT_KEY` / `NEXT_PUBLIC_PLATFORM_BASE_DOMAIN` | your tenant + domain                                 | `main` / `example.com`      |
+
+See [`.env.example`](../.env.example) for the full list (branding, Stripe, feature flags, etc.).
+
+**Build-time vs runtime:** `NEXT_PUBLIC_*` values are baked in at `pnpm build`. For **web / Docker only**, they can also be overridden at container start — `entrypoint.sh` writes them into `public/env.js` as `window.__ENV__`, which `lib/config.ts` prefers over the baked-in values. Native shells have no runtime override; they just load the URL you compile in (below).
+
+---
+
+## 2. Web (Docker / self-hosted)
+
+```bash
+pnpm install
+pnpm build          # → .next/standalone (self-contained Node server)
+node server-wrapper.js
+```
+
+Or with Docker (runtime-configurable — no rebuild to change backends):
+
+```bash
+docker build -t iblos .
+docker run -p 5000:5000 --env-file .env iblos   # entrypoint.sh injects window.__ENV__
+```
+
+- **Full guide:** [`standalone-deployment.md`](standalone-deployment.md) (output mode, env vars, troubleshooting).
+- **Enterprise / Docker images:** README → [Deployment](../README.md#deployment) and [iblai/iblai-infra-cli](https://github.com/iblai/iblai-infra-cli).
+- **Release automation (reference):** `release.yml` bumps + tags `v*` → `trigger-docker-build.yml` → `reusable-spa-docker-build.yml` builds and pushes the image.
+
+---
+
+## 3. macOS (.dmg direct download + Mac App Store)
+
+Build the web frontend, then the signed app — pointing it at your backend via `TAURI_DEV_URL`:
+
+```bash
+# Direct-download .dmg (Developer ID, notarized):
+TAURI_DEV_URL=https://app.example.com pnpm tauri:build:devid
+
+# Mac App Store (sandboxed) build:
+TAURI_DEV_URL=https://app.example.com pnpm tauri:build:mas
+```
+
+Both run `pnpm build` first, then `cargo tauri build` (universal Intel + Apple Silicon). You'll need **your own** Apple signing identity and notarization credentials — replace the IBL identity in [`src-tauri/tauri.conf.json`](../src-tauri/tauri.conf.json) (`bundle.macOS.signingIdentity`, `providerShortName`, `iOS.developmentTeam`).
+
+- **Full guide (MAS vs Developer ID, certs, notarization):** [`macos-builds.md`](macos-builds.md)
+- **Release automation (reference):** a `src-tauri/**` change triggers `tauri-autoversion.yml` → bumps the version, tags `app-v*` → `release-macos-dmg.yml` (→ `reusable-release-macos-dmg.yml`) signs, notarizes, and attaches the DMG to the GitHub Release.
+
+---
+
+## 4. Windows / Surface (NSIS/MSI installer + Microsoft Store)
+
+```bash
+TAURI_DEV_URL=https://app.example.com pnpm tauri:build        # NSIS + MSI
+```
+
+- Builds **x64 and ARM64** (Surface) installers; set your code-signing cert via `bundle.windows.certificateThumbprint` in `tauri.conf.json` (CI injects it from a secret).
+- **Microsoft Store (MSIX):** [`../src-tauri/MSIX-BUILD-GUIDE.md`](../src-tauri/MSIX-BUILD-GUIDE.md) + `src-tauri/build-msix.ps1`.
+- **Release automation (reference):** `release-windows.yml` → `reusable-release-windows.yml` (cert import, sign, attach installers to the Release).
+
+---
+
+## 5. Linux
+
+Build from source (no CI release is published for Linux):
+
+```bash
+TAURI_DEV_URL=https://app.example.com cargo tauri build --target x86_64-unknown-linux-gnu
+# ARM64: --target aarch64-unknown-linux-gnu   (see `make tauri-build-linux-arm`)
+```
+
+Produces a `.deb` / binary under `src-tauri/target/`. See [`development.md`](development.md) and the `tauri-build-linux*` targets in the [`Makefile`](../Makefile).
+
+---
+
+## 6. iOS (TestFlight / App Store)
+
+Tauri generates an Xcode project; you archive and submit it manually.
+
+```bash
+# Local device/simulator dev (auto-detects your machine's IP as the dev URL):
+make dev-mobile        # in one terminal (serves the web app on :3001)
+make tauri-ios-dev     # in another
+
+# Release build → produces the Xcode project to archive:
+make tauri-ios-build
+```
+
+Self-hoster checklist:
+
+- Set **your** Apple `developmentTeam` in `tauri.conf.json` (`bundle.iOS.developmentTeam`).
+- Point the app at your backend with `TAURI_DEV_URL` — see `get_app_url()` in [`../src-tauri/src/lib.rs`](../src-tauri/src/lib.rs) (defaults to `https://os.ibl.ai`).
+- Update the **deep-link / universal-link hosts** in `tauri.conf.json` (`plugins.deep-link.mobile`) to your domains, and serve an [AASA file](handling-existing-users-aasa.md) at `https://your-domain/.well-known/apple-app-site-association`.
+- **Full setup (Xcode, provisioning, device builds, TestFlight):** [`tauri-ios-setup.md`](tauri-ios-setup.md).
+
+> Status: **manual release** — build tooling is automated, but archiving/submitting to App Store Connect is a manual Xcode step (no CI workflow).
+
+---
+
+## 7. Android (Google Play)
+
+```bash
+# Local device dev:
+make tauri-android-dev
+
+# Release artifacts:
+make tauri-android-build       # APK
+make tauri-android-build-aab   # AAB for the Play Store
+```
+
+Self-hoster checklist:
+
+- Provide a signing keystore via `src-tauri/gen/android/key.properties` (kept local / out of git).
+- Point at your backend with `TAURI_DEV_URL`; deep-link schemes are re-injected before each build by `scripts/android-add-deep-link-scheme.sh` (idempotent). Update the deep-link **host** in `tauri.conf.json` to your domain and serve `https://your-domain/.well-known/assetlinks.json`.
+- Submit the AAB via the Google Play Console.
+
+> Status: **build-from-source + manual release** — no CI workflow and no dedicated doc yet; the Tauri-mobile flow mirrors iOS ([`tauri-ios-setup.md`](tauri-ios-setup.md)).
+
+---
+
+## 8. Chrome extension (side panel)
+
+Point `extensions/chrome/panel.html`'s `mentorurl` at your web app, bump `extensions/chrome/manifest.json`'s `version`, and the `release-chrome-extension.yml` workflow publishes to the Chrome Web Store (needs the `CHROME_*` repo secrets configured — see the workflow header).
+
+---
+
+## Reference: what's automated vs. manual
+
+| Surface        | Point at your backend                            | Build                             | Official release path             |
+| -------------- | ------------------------------------------------ | --------------------------------- | --------------------------------- |
+| **Web**        | `NEXT_PUBLIC_*` (build **or** runtime `__ENV__`) | `pnpm build` / Docker             | ✅ CI → Docker image              |
+| **macOS**      | `TAURI_DEV_URL` (compile-time)                   | `pnpm tauri:build:devid` / `:mas` | ✅ CI → signed DMG + Release      |
+| **Windows**    | `TAURI_DEV_URL`                                  | `pnpm tauri:build`                | ✅ CI → signed NSIS (x64 / ARM64) |
+| **Linux**      | `TAURI_DEV_URL`                                  | `cargo tauri build`               | ⚠️ Build from source only         |
+| **iOS**        | `TAURI_DEV_URL` + Team ID                        | `make tauri-ios-build`            | ⚠️ Manual Xcode → App Store       |
+| **Android**    | `TAURI_DEV_URL` + keystore                       | `make tauri-android-build[-aab]`  | ⚠️ Manual → Play Console          |
+| **Chrome ext** | `panel.html` `mentorurl`                         | manifest version bump             | ⚠️ CI (needs `CHROME_*` secrets)  |
+
+**One-line rule:** deploy the web app at your domain, then rebuild each native shell with `TAURI_DEV_URL=https://your-domain` and your own signing credentials.


### PR DESCRIPTION
## What
- **`docs/platform-deployment.md`** — a self-hoster guide for shipping every surface (**Web, macOS, Windows/Surface, Linux, iOS, Android**, + Chrome extension) against **your own** ibl.ai backend.
- **README** — comment out the "Add to Chrome" download badge + the Chrome platform-table row until the extension is approved on the Chrome Web Store (both preserved in an HTML comment with restore notes).

## The guide's core idea
There's one web frontend; the native apps are Tauri webview shells around it. So there are exactly two config knobs, both documented with the real names verified in-repo:
- **Web:** `NEXT_PUBLIC_*` (build-time, or runtime via `window.__ENV__` in Docker) — see `.env.example` / `entrypoint.sh` / `lib/config.ts`.
- **Native:** the compile-time **`TAURI_DEV_URL`** env var (`get_app_url()` in `src-tauri/src/lib.rs`, defaults to `os.ibl.ai`) → point it at your web app and rebuild.

Includes an honest **automated-vs-manual** matrix: Web/macOS/Windows have CI release workflows; **Linux is build-from-source, and iOS/Android are manual store submissions** (no CI yet).

## Notes
- Named `platform-deployment.md` because a `docs/DEPLOYMENT.md` already exists for a different topic (the immutable-CDN static-hosting rollout) — left untouched, cross-linked.
- The Deployment-section link to this guide already landed on `main` via #448, so it's intentionally not re-added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)