### PR TITLE
Fix code mode: silent mid-turn opencode crash recovery, IBLAI_USERNAM…

### DIFF
--- a/e2e-tauri/COVERAGE.md
+++ b/e2e-tauri/COVERAGE.md
@@ -1,6 +1,6 @@
 # Tauri Desktop E2E Coverage — Journey Checklist
 
-> Last updated: 2026-08-15 | 29 checkpoints (18 covered, 11 pending) | 3 journeys | 100% of reproducible checkpoints covered | Driver: WebdriverIO + tauri-driver
+> Last updated: 2026-08-22 | 30 checkpoints (18 covered, 12 pending) | 3 journeys | 100% of reproducible checkpoints covered | Driver: WebdriverIO + tauri-driver
 
 This is the desktop counterpart to the web `e2e/COVERAGE.md`. It tracks only what
 is exercised by driving the **built desktop binary** through `tauri-driver` (see
@@ -63,7 +63,7 @@ Windows (`msedgedriver`) only — `tauri-driver` has no macOS support.
 
 ---
 
-## Journey 3: Code Mode (opencode) (19 checkpoints: 11 covered, 8 pending) — `journeys/03-code-mode.spec.ts`
+## Journey 3: Code Mode (opencode) (20 checkpoints: 11 covered, 9 pending) — `journeys/03-code-mode.spec.ts`
 
 > **Partly covered.** The installer and per-chat state (code-01…07) run against
 > the REAL compiled binary through the live Tauri IPC bridge (`window.__TAURI__`):
@@ -107,7 +107,7 @@ Windows (`msedgedriver`) only — `tauri-driver` has no macOS support.
 - [x] `code-11` The app keeps answering IPC while opencode downloads and extracts _(setup-freeze regression)_
 - [x] `code-12` `set_opencode_skills` materialises a mentor's Agent Skills as SKILL.md packages (frontmatter + text resources), with hostile slugs/filenames confined to the staging dir
 - [x] `code-13` A skills rewrite drops deselected skills, an empty sync clears the tree, and `skills: null` ends a sync without touching it
-- [x] `code-16` `ensure_vibe_skills` installs the shared iblai/vibe skill set into the app data dir (live tarball fetch, daily sha-gated)
+- [x] `code-16` `ensure_vibe_skills` installs the shared iblai/vibe skill set into the app data dir (live tarball fetch of the latest GitHub release, checked on every look — app startup and each Code enable — always latest, never pinned)
 - [ ] `code-08` A permission prompt in one chat does not block another chat's turn _(needs a tool-calling model)_
 - [ ] `code-09` The 5-session cap evicts the least-recently-used idle opencode process _(needs a tool-calling model)_
 - [ ] `code-10` The permission prompt renders in the chat that raised it _(needs a tool-calling model)_
@@ -116,3 +116,4 @@ Windows (`msedgedriver`) only — `tauri-driver` has no macOS support.
 - [ ] `code-17` New Chat in the sidebar evicts the previous chat's opencode process while Code is on _(needs an authenticated UI session; covered meanwhile by the app-sidebar Vitest eviction cases)_
 - [ ] `code-18` A Code turn's opencode process runs inside the OS sandbox (bwrap / sandbox-exec) — only the workspace and tool caches writable, ~/.ssh empty _(needs a tool-calling model; the bwrap argv, SBPL profile and decoy home are covered by the Rust sandbox tests in `opencode_acp.rs`)_
 - [ ] `code-19` A second New Chat in one app run gets its own fresh workspace, and a chat's folder follows it from the ephemeral first-turn key to its real session id _(needs an authenticated UI session; covered meanwhile by the Rust `adopt_prior_mapping` tests and the SDK per-chat key Vitest cases)_
+- [ ] `code-20` Killing the opencode process mid-turn: the answer continues in the same bubble with no visible interruption (one silent respawn re-sends the prompt), and a second kill in the same turn surfaces `ollama:error` _(needs a tool-calling model; covered meanwhile by the Rust crash-retry tests in `opencode_acp.rs` — `should_retry`, `reader_gone`, `closing` — and the proxy rebind/read-timeout tests)_

--- a/e2e-tauri/coverage.json
+++ b/e2e-tauri/coverage.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "lastUpdated": "2026-08-15",
+  "lastUpdated": "2026-08-22",
   "summary": {
-    "totalCheckpoints": 29,
+    "totalCheckpoints": 30,
     "coveredCheckpoints": 18,
-    "pendingCheckpoints": 11,
+    "pendingCheckpoints": 12,
     "deprecatedCheckpoints": 0,
     "notReproducibleCheckpoints": 0,
     "percent": 100,
@@ -196,6 +196,11 @@
         {
           "id": "code-19",
           "description": "A second New Chat in one app run gets its own fresh workspace, and a chat’s folder follows it from the ephemeral first-turn key to its real session id",
+          "status": "pending"
+        },
+        {
+          "id": "code-20",
+          "description": "Killing the opencode process mid-turn: the answer continues in the same bubble with no visible interruption (one silent respawn re-sends the prompt), and a second kill in the same turn surfaces ollama:error",
           "status": "pending"
         }
       ]

--- a/hooks/__tests__/use-opencode-skill-sync.test.tsx
+++ b/hooks/__tests__/use-opencode-skill-sync.test.tsx
@@ -337,4 +337,63 @@ describe('useOpencodeSkillSync', () => {
       mentorUniqueId: MENTOR,
     });
   });
+
+  it('a failed vibe install retries by itself and recovers', async () => {
+    vi.useFakeTimers();
+    try {
+      // First attempt: absent. Second (the 30s retry): installed.
+      let vibeCalls = 0;
+      invoke.mockImplementation(async (cmd: unknown) => {
+        if (cmd === 'ensure_vibe_skills') {
+          vibeCalls += 1;
+          return { present: vibeCalls >= 2 };
+        }
+        if (cmd === 'set_opencode_skills') return '/staging/dir';
+        return undefined;
+      });
+
+      const { result } = renderSync();
+      await vi.waitFor(() => expect(result.current.state).toBe('error'));
+      expect(vibeCalls).toBe(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      expect(vibeCalls).toBe(2);
+      expect(result.current).toEqual({ state: 'synced', count: 1 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('vibe retries stop after the cap — the amber note is the end state', async () => {
+    vi.useFakeTimers();
+    try {
+      let vibeCalls = 0;
+      invoke.mockImplementation(async (cmd: unknown) => {
+        if (cmd === 'ensure_vibe_skills') {
+          vibeCalls += 1;
+          return { present: false };
+        }
+        if (cmd === 'set_opencode_skills') return '/staging/dir';
+        return undefined;
+      });
+
+      const { result } = renderSync();
+      await vi.waitFor(() => expect(result.current.state).toBe('error'));
+
+      // All three backoff steps fire, then nothing more — ever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000 + 120_000 + 600_000);
+      });
+      expect(vibeCalls).toBe(1 + 3);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_600_000);
+      });
+      expect(vibeCalls).toBe(1 + 3);
+      expect(result.current.state).toBe('error');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/hooks/use-opencode-skill-sync.ts
+++ b/hooks/use-opencode-skill-sync.ts
@@ -24,6 +24,13 @@ const MENTOR_KEY = 'ibl_coding_mode_mentor';
 const SYNC_PAGE_SIZE = 100;
 /** Backstop for a server that ignores `limit`: never loop forever. */
 const MAX_PAGES = 50;
+/**
+ * A vibe install that failed (network hiccup at launch, fresh machine behind a
+ * flaky link) retries by itself at these delays — the effect's deps settle
+ * once, so without this a single failure meant no skills for the whole app
+ * run. Bounded: after the last attempt the popover's amber note is the signal.
+ */
+const VIBE_RETRY_DELAYS_MS = [30_000, 120_000, 600_000];
 
 export interface OpencodeSkillSync {
   state: 'idle' | 'syncing' | 'synced' | 'error';
@@ -67,8 +74,10 @@ const asList = <T>(data: T[] | { results?: T[] } | undefined): T[] =>
  *
  * `state: 'syncing'` spans the mentor fetch AND the vibe download — it drives
  * the Code pill's spinner. `state: 'error'` (catalog 403, network, vibe absent
- * with no cache) surfaces as the popover's amber note; on error the staging
- * tree is left untouched — a stale skill set beats a wrongly-emptied one.
+ * with no cache) surfaces as the popover's amber note; a vibe-absent error
+ * additionally self-retries on a bounded backoff and flips to synced when a
+ * later attempt lands. On error the staging tree is left untouched — a stale
+ * skill set beats a wrongly-emptied one.
  */
 export function useOpencodeSkillSync({
   org,
@@ -138,6 +147,23 @@ export function useOpencodeSkillSync({
       if (!cancelled) setSync(next);
     };
 
+    // Bounded self-retry of the VIBE half alone (the mentor skills already
+    // landed by the time this is scheduled; re-running the whole sync would
+    // re-fetch them for nothing). Recovering flips the state to synced.
+    let vibeRetryTimer: ReturnType<typeof setTimeout> | undefined;
+    const retryVibe = (attempt: number, count: number) => {
+      if (cancelled || attempt >= VIBE_RETRY_DELAYS_MS.length) return;
+      vibeRetryTimer = setTimeout(() => {
+        callTauri<{ present?: boolean }>('ensure_vibe_skills')
+          .then((vibe) => {
+            if (cancelled) return;
+            if (vibe?.present === false) retryVibe(attempt + 1, count);
+            else safeSet({ state: 'synced', count });
+          })
+          .catch(() => retryVibe(attempt + 1, count));
+      }, VIBE_RETRY_DELAYS_MS[attempt]);
+    };
+
     void (async () => {
       safeSet({ state: 'syncing' });
       try {
@@ -194,11 +220,12 @@ export function useOpencodeSkillSync({
             skills: [],
           });
           const vibe = await vibePromise;
-          safeSet(
-            vibe?.present === false
-              ? { state: 'error' }
-              : { state: 'synced', count: 0 },
-          );
+          if (vibe?.present === false) {
+            safeSet({ state: 'error' });
+            retryVibe(0, 0);
+          } else {
+            safeSet({ state: 'synced', count: 0 });
+          }
           return;
         }
 
@@ -277,11 +304,12 @@ export function useOpencodeSkillSync({
           skills: payload,
         });
         const vibe = await vibePromise;
-        safeSet(
-          vibe?.present === false
-            ? { state: 'error' }
-            : { state: 'synced', count: payload.length },
-        );
+        if (vibe?.present === false) {
+          safeSet({ state: 'error' });
+          retryVibe(0, payload.length);
+        } else {
+          safeSet({ state: 'synced', count: payload.length });
+        }
       } catch {
         await bail();
       }
@@ -289,6 +317,7 @@ export function useOpencodeSkillSync({
 
     return () => {
       cancelled = true;
+      clearTimeout(vibeRetryTimer);
     };
   }, [inTauri, codeEnabled, org, mentorUniqueId]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2239,6 +2239,15 @@ pub fn run() {
             // =====================
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             {
+                // Vibe skills track the latest GitHub release with no freshness
+                // window — resolve-and-sync in the background on every launch, so
+                // Coding Mode always starts from the newest published set (and a
+                // fresh machine has them before Code is ever enabled).
+                let vibe_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let _ = opencode_installer::ensure_vibe_skills(vibe_handle).await;
+                });
+
                 // Initialize web cache with app data directory
                 let app_data_dir = app
                     .path()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2195,6 +2195,15 @@ fn main() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
+            // Vibe skills track the latest GitHub release with no freshness
+            // window — resolve-and-sync in the background on every launch, so
+            // Coding Mode always starts from the newest published set (and a
+            // fresh machine has them before Code is ever enabled).
+            let vibe_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let _ = opencode_installer::ensure_vibe_skills(vibe_handle).await;
+            });
+
             // Initialize web cache with app data directory
             let app_data_dir = app
                 .path()

--- a/src-tauri/src/opencode_acp.rs
+++ b/src-tauri/src/opencode_acp.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -122,6 +122,12 @@ impl TurnState {
         self.pending_delta.clear();
         self.last_emit = Instant::now();
     }
+
+    /// A turn is streaming — updates arriving with no generation in flight
+    /// (the spawn-time `session/load` history replay) must not reach the UI.
+    fn in_flight(&self) -> bool {
+        !self.generation_id.is_empty()
+    }
 }
 
 /// A live `opencode acp` process + its ACP session.
@@ -144,7 +150,16 @@ struct Session {
     /// is never reaped — so this MUST be decremented on every exit path, including
     /// errors, or the session pins itself alive forever.
     active_turns: AtomicUsize,
+    /// Set by every intentional teardown (close/evict/reap/model-switch) before
+    /// the kill, so the mid-turn crash-retry can tell a close from a crash.
+    closing: AtomicBool,
 }
+
+/// `Session::request`'s error prefixes when the child vanished mid-request
+/// (died before responding, or before the write even landed). The mid-turn
+/// crash-retry keys on these, so they live as consts the check can't drift from.
+const CHILD_GONE: &str = "opencode closed before responding";
+const CHILD_WRITE_FAILED: &str = "failed writing to opencode";
 
 impl Session {
     fn new_id(&self) -> i64 {
@@ -158,9 +173,7 @@ impl Session {
         self.pending.lock().await.insert(id, tx);
         let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         write_line(&self.stdin, &msg).await?;
-        let resp = rx
-            .await
-            .map_err(|_| format!("opencode closed before responding to {method}"))?;
+        let resp = rx.await.map_err(|_| format!("{CHILD_GONE} to {method}"))?;
         if let Some(err) = resp.get("error") {
             return Err(format!("opencode error on {method}: {err}"));
         }
@@ -183,7 +196,7 @@ async fn write_line(stdin: &Arc<Mutex<ChildStdin>>, msg: &Value) -> Result<(), S
     guard
         .write_all(line.as_bytes())
         .await
-        .map_err(|e| format!("failed writing to opencode: {e}"))?;
+        .map_err(|e| format!("{CHILD_WRITE_FAILED}: {e}"))?;
     guard.flush().await.map_err(|e| e.to_string())
 }
 
@@ -1243,9 +1256,39 @@ async fn reader_loop(
             handle_update(&app, &v, &turn).await;
         }
     }
+    reader_gone(&session_id, &pending).await;
+}
+
+/// Cleanup after the reader saw child EOF (crash, kill, or intentional close).
+async fn reader_gone(session_id: &str, pending: &Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>>) {
+    // Identity-checked removal: a respawn may already have replaced this entry
+    // (or close_session already removed it) — never tear down the successor.
+    // The config-dir delete stays behind this gate for the same reason.
+    let removed = {
+        let mut reg = registry().lock().await;
+        match reg.get(session_id) {
+            Some(s) if Arc::ptr_eq(&s.pending, pending) => reg.remove(session_id),
+            _ => None,
+        }
+    };
+    if removed.is_some() {
+        teardown(session_id, removed).await;
+    }
+    // Dropping the senders resolves every in-flight `request()` with
+    // [`CHILD_GONE`] immediately — the turn stops hanging and either retries
+    // on a fresh process (crash) or surfaces through the existing
+    // `ollama:error` arm. This runs on intentional closes too: an evicted
+    // mid-turn session's prompt used to hang exactly this way.
+    pending.lock().await.clear();
 }
 
 async fn handle_update(app: &AppHandle, v: &Value, turn: &Arc<Mutex<TurnState>>) {
+    // No generation in flight → this is the `session/load` history replay at
+    // spawn time (or a stray post-turn notification): drop it, never re-stream
+    // old turns into the UI.
+    if !turn.lock().await.in_flight() {
+        return;
+    }
     let update = match v.get("params").and_then(|p| p.get("update")) {
         Some(u) => u,
         None => return,
@@ -1601,6 +1644,11 @@ fn foundry_result(model: &str, endpoint: Option<String>) -> Value {
 }
 
 /// Spawn `opencode acp`, run the ACP handshake, and register the session.
+///
+/// `resume` carries the previous ACP session id after a mid-turn crash: when
+/// the agent advertises `loadSession`, the fresh process re-loads that session
+/// (conversation context survives); otherwise — or when the load fails — a
+/// fresh `session/new` is created and only the re-sent prompt carries over.
 #[allow(clippy::too_many_arguments)]
 async fn spawn_session(
     app: &AppHandle,
@@ -1612,6 +1660,7 @@ async fn spawn_session(
     workspace: &PathBuf,
     mentor: Option<String>,
     generation_id: &str,
+    resume: Option<String>,
 ) -> Result<Arc<Session>, String> {
     ensure_workspace(workspace)?;
 
@@ -1675,7 +1724,14 @@ async fn spawn_session(
                 .as_deref()
                 .map(mentor_skills_dir)
                 .is_some_and(|d| d.is_dir());
-        crate::opencode_proxy::register(&secret, upstream, token.to_string(), skills_wired).await;
+        crate::opencode_proxy::register(
+            &secret,
+            upstream,
+            token.to_string(),
+            tenant.to_string(),
+            skills_wired,
+        )
+        .await;
         (
             format!("http://127.0.0.1:{port}/v1"),
             secret.clone(),
@@ -1706,6 +1762,16 @@ async fn spawn_session(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
+
+    // Attribution/config for the agent's shell — NOT credentials (the DM token
+    // stays in the proxy; the rule is that no secret enters the child env).
+    // The vibe skills read these instead of asking the user who/where they are.
+    if let Some(user) = crate::opencode_proxy::learner_username().await {
+        cmd.env("IBLAI_USERNAME", user);
+    }
+    if !tenant.is_empty() {
+        cmd.env("IBLAI_PLATFORM_KEY", tenant);
+    }
 
     let mut child = cmd.spawn().map_err(|e| {
         if cfg!(target_os = "linux") {
@@ -1758,11 +1824,12 @@ async fn spawn_session(
         turn,
         last_used: Mutex::new(Instant::now()),
         active_turns: AtomicUsize::new(0),
+        closing: AtomicBool::new(false),
     };
 
     // 1) initialize — we advertise NO fs/terminal capabilities so opencode uses its
     //    own built-in file/shell tools directly on the workspace.
-    session
+    let init = session
         .request(
             "initialize",
             json!({
@@ -1772,20 +1839,50 @@ async fn spawn_session(
             }),
         )
         .await?;
+    let can_load = init
+        .get("agentCapabilities")
+        .and_then(|c| c.get("loadSession"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
-    // 2) session/new with the workspace cwd.
-    let new_res = session
-        .request(
-            "session/new",
-            json!({ "cwd": workspace.to_string_lossy(), "mcpServers": [] }),
-        )
-        .await?;
-    let acp_session_id = new_res
-        .get("sessionId")
-        .and_then(|s| s.as_str())
-        .ok_or("session/new returned no sessionId")?
-        .to_string();
-    session.acp_session_id = acp_session_id;
+    // 2) After a crash, resume the previous ACP session when the agent can —
+    //    opencode persists sessions under its (shared) data dir, which our
+    //    teardown never deletes. The load's history replay streams as
+    //    `session/update` with no turn in flight, so `handle_update` drops it.
+    //    Any failure falls back to a fresh session: context lost, but the
+    //    re-sent prompt still completes.
+    let mut acp_session_id: Option<String> = None;
+    if can_load {
+        if let Some(prev) = resume.as_deref() {
+            if session
+                .request(
+                    "session/load",
+                    json!({ "sessionId": prev, "cwd": workspace.to_string_lossy(), "mcpServers": [] }),
+                )
+                .await
+                .is_ok()
+            {
+                acp_session_id = Some(prev.to_string());
+            }
+        }
+    }
+    // 3) …or session/new with the workspace cwd.
+    session.acp_session_id = match acp_session_id {
+        Some(id) => id,
+        None => {
+            let new_res = session
+                .request(
+                    "session/new",
+                    json!({ "cwd": workspace.to_string_lossy(), "mcpServers": [] }),
+                )
+                .await?;
+            new_res
+                .get("sessionId")
+                .and_then(|s| s.as_str())
+                .ok_or("session/new returned no sessionId")?
+                .to_string()
+        }
+    };
 
     Ok(Arc::new(session))
 }
@@ -1806,10 +1903,13 @@ async fn get_or_spawn(
     workspace: &PathBuf,
     mentor: Option<String>,
     generation_id: &str,
+    resume: Option<String>,
 ) -> Result<Arc<Session>, String> {
     let live = { registry().lock().await.get(session_id).cloned() };
     if let Some(s) = live {
-        if s.requested_model.as_deref() == model.as_deref() {
+        // A dead child can sit here for a beat before its reader's EOF cleanup
+        // lands — never hand it out; fall through to the respawn below.
+        if !child_exited(&s).await && s.requested_model.as_deref() == model.as_deref() {
             *s.last_used.lock().await = Instant::now();
             if let Some(secret) = &s.proxy_secret {
                 crate::opencode_proxy::set_token(secret, token).await;
@@ -1817,7 +1917,7 @@ async fn get_or_spawn(
             return Ok(s);
         }
     }
-    // Missing or the model switched → (re)spawn.
+    // Missing, dead, or the model switched → (re)spawn.
     close_session(session_id).await;
     evict_for_new_session(session_id).await;
     start_reaper();
@@ -1831,6 +1931,7 @@ async fn get_or_spawn(
         workspace,
         mentor,
         generation_id,
+        resume,
     )
     .await?;
     registry()
@@ -1893,6 +1994,12 @@ fn pick_eviction(states: &[SessionState], cap: usize) -> Option<String> {
             .map(|s| s.session_id.clone())
     };
     lru(true).or_else(|| lru(false))
+}
+
+/// Has this session's opencode process already exited? An `Err` from
+/// `try_wait` reads as "alive" — the same answer as before the probe existed.
+async fn child_exited(s: &Session) -> bool {
+    s.child.lock().await.try_wait().is_ok_and(|st| st.is_some())
 }
 
 /// Sessions the reaper should close: idle past the timeout AND doing nothing. A chat
@@ -1969,21 +2076,49 @@ fn start_reaper() {
 }
 
 async fn close_session(session_id: &str) {
+    let s = registry().lock().await.remove(session_id);
+    if let Some(s) = &s {
+        // Intentional teardown (close/evict/reap/model-switch): mark it so the
+        // mid-turn crash-retry never resurrects a session someone chose to end.
+        s.closing.store(true, Ordering::SeqCst);
+    }
+    teardown(session_id, s).await;
+}
+
+/// The teardown half of [`close_session`], for callers that already pulled the
+/// registry entry (or found none): release pending permission cards, drop the
+/// proxy credentials, kill the child, delete the per-session config dir.
+async fn teardown(session_id: &str, s: Option<Arc<Session>>) {
     // Anything waiting on the user can never be answered now — release it so the
     // dying process isn't blocked mid-teardown.
     deny_pending_for(session_id).await;
-    if let Some(s) = registry().lock().await.remove(session_id) {
+    if let Some(s) = s {
         if let Some(secret) = &s.proxy_secret {
             crate::opencode_proxy::unregister(secret).await;
         }
-        let mut child = s.child.lock().await;
-        let _ = child.start_kill();
+        let _ = s.child.lock().await.start_kill();
     }
     // The session's opencode config is rewritten on every spawn, so leaving it behind
     // just accumulates one dead directory per chat the user ever opened. Synced Agent
     // Skills deliberately live elsewhere (`mentor_skills_dir`) — a reaped session
     // must find them again on respawn.
     let _ = std::fs::remove_dir_all(config_home(session_id));
+}
+
+/// Attempts (original + respawns) one prompt gets. 2 = exactly one respawn: a
+/// transient crash (OOM kill, opencode bug, dropped pipe) is fixed by one fresh
+/// process, while a prompt that deterministically kills the child would turn a
+/// higher cap into a crash loop that only delays the inevitable error — and
+/// each `session/new` fallback retry loses more context anyway.
+const PROMPT_ATTEMPTS: usize = 2;
+
+/// Should this failed `session/prompt` be retried on a fresh process? Only a
+/// crash: the child vanished (not a JSON-RPC error from a live one), nobody
+/// intentionally closed the session, and the budget isn't spent.
+fn should_retry(err: &str, closing: bool, attempt: usize) -> bool {
+    attempt < PROMPT_ATTEMPTS
+        && !closing
+        && (err.starts_with(CHILD_GONE) || err.starts_with(CHILD_WRITE_FAILED))
 }
 
 /// Stream one Coding-Mode turn through opencode, emitting `ollama:*` +
@@ -2053,31 +2188,74 @@ pub async fn opencode_chat_stream(
         );
     }
 
-    let session = get_or_spawn(
-        &app,
-        &session_id,
-        &tenant,
-        &token,
-        model,
-        api_base,
-        &workspace,
-        mentor,
-        &generation_id,
-    )
-    .await?;
-    let _turn_guard = TurnGuard::new(session.clone());
-
-    session.turn.lock().await.reset(generation_id.clone());
-
-    let res = session
-        .request(
-            "session/prompt",
-            json!({
-                "sessionId": session.acp_session_id,
-                "prompt": [ { "type": "text", "text": prompt_text } ]
-            }),
+    // One transparent respawn on a mid-turn crash: the prompt is re-sent
+    // verbatim into the same generation, so the user sees the answer continue
+    // rather than an interruption. `should_retry` keeps this to genuine
+    // crashes (never intentional closes or live-child errors) and to
+    // [`PROMPT_ATTEMPTS`] total tries.
+    let mut resume: Option<String> = None;
+    let mut turn_guard = None;
+    let mut attempt = 1;
+    let (session, res) = loop {
+        let session = match get_or_spawn(
+            &app,
+            &session_id,
+            &tenant,
+            &token,
+            model.clone(),
+            api_base.clone(),
+            &workspace,
+            mentor.clone(),
+            &generation_id,
+            resume.take(),
         )
-        .await;
+        .await
+        {
+            Ok(s) => s,
+            Err(e) if attempt > 1 => {
+                // The recovery respawn itself failed — that IS the loud failure.
+                let _ = app.emit(
+                    "ollama:error",
+                    json!({ "generation_id": generation_id, "error": e }),
+                );
+                return Err(e);
+            }
+            // First spawn: keep today's invoke-rejection (a missing binary
+            // stays immediately loud in the UI's own error path).
+            Err(e) => return Err(e),
+        };
+        // Replace (and thereby drop) the previous attempt's guard, if any.
+        drop(turn_guard.take());
+        turn_guard = Some(TurnGuard::new(session.clone()));
+        session.turn.lock().await.reset(generation_id.clone());
+
+        let res = session
+            .request(
+                "session/prompt",
+                json!({
+                    "sessionId": session.acp_session_id,
+                    "prompt": [ { "type": "text", "text": prompt_text } ]
+                }),
+            )
+            .await;
+
+        match &res {
+            Err(e) if should_retry(e, session.closing.load(Ordering::SeqCst), attempt) => {
+                eprintln!(
+                    "[opencode] child died mid-turn ({e}) — respawning silently, attempt {}",
+                    attempt + 1
+                );
+                // Machine event only — the SDK clears the partial stream for
+                // this generation; nothing user-visible marks the seam.
+                let _ = app.emit("ollama:restart", json!({ "generation_id": generation_id }));
+                resume = Some(session.acp_session_id.clone());
+                attempt += 1;
+            }
+            _ => break (session, res),
+        }
+    };
+    // Held to fn end, as before — busy until after the done/error emit.
+    let _turn_guard = turn_guard;
 
     match res {
         Ok(result) => {
@@ -2107,6 +2285,10 @@ pub async fn opencode_chat_stream(
             Ok(())
         }
         Err(e) => {
+            // A JSON-RPC error from a live child, an intentional close, or a
+            // spent retry budget — the crash-retry above already consumed the
+            // recoverable case. A live child keeps its session (conversation
+            // state survives); a dead one was torn down by `reader_gone`.
             let _ = app.emit(
                 "ollama:error",
                 json!({ "generation_id": generation_id, "error": e }),
@@ -2752,5 +2934,204 @@ mod tests {
             !skills_syncs().lock().await.contains_key(&key),
             "an expired entry must be cleaned up"
         );
+    }
+
+    /// Spawns `program` with piped stdio and wraps it in a real `Session`, for
+    /// the crash/close lifecycle tests. A `cat` child self-cleans: dropping the
+    /// Session drops its stdin pipe and cat exits; crashed-path tests kill it
+    /// through `teardown` anyway.
+    #[cfg(unix)]
+    fn test_session(program: &str) -> Arc<Session> {
+        let mut child = Command::new(program)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let stdin = Arc::new(Mutex::new(child.stdin.take().unwrap()));
+        Arc::new(Session {
+            child: Mutex::new(child),
+            stdin,
+            next_id: AtomicI64::new(1),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            acp_session_id: "acp-test".to_string(),
+            requested_model: Some("m".to_string()),
+            proxy_secret: None,
+            turn: Arc::new(Mutex::new(TurnState {
+                generation_id: String::new(),
+                full_content: String::new(),
+                pending_delta: String::new(),
+                last_emit: Instant::now(),
+            })),
+            last_used: Mutex::new(Instant::now()),
+            active_turns: AtomicUsize::new(0),
+            closing: AtomicBool::new(false),
+        })
+    }
+
+    /// The retry decision in one place: crashes retry, everything else stays loud.
+    #[test]
+    fn only_a_crash_on_an_open_session_retries_and_only_within_budget() {
+        let gone = format!("{CHILD_GONE} to session/prompt");
+        let pipe = format!("{CHILD_WRITE_FAILED}: Broken pipe (os error 32)");
+        assert!(should_retry(&gone, false, 1));
+        assert!(
+            should_retry(&pipe, false, 1),
+            "died-before-send is a crash too"
+        );
+        assert!(
+            !should_retry(&gone, true, 1),
+            "an intentional close never resurrects"
+        );
+        assert!(
+            !should_retry("opencode error on session/prompt: boom", false, 1),
+            "a live child's JSON-RPC error is not a crash"
+        );
+        assert!(
+            !should_retry(&gone, false, PROMPT_ATTEMPTS),
+            "budget spent → loud error"
+        );
+    }
+
+    /// THE lost-connection bug: a dead child used to leave `session/prompt`
+    /// hanging forever on a sender nobody would ever fire. `reader_gone` must
+    /// fail it immediately — as the crash shape the retry keys on — and free
+    /// the registry slot so the next spawn isn't blocked by a corpse.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_dead_reader_fails_inflight_requests_and_frees_its_session() {
+        let sid = format!("dead-reader-{}", std::process::id());
+        let s = test_session("cat");
+        registry().lock().await.insert(sid.clone(), s.clone());
+
+        let inflight = {
+            let s = s.clone();
+            tokio::spawn(async move { s.request("session/prompt", json!({})).await })
+        };
+        // Wait until the request has parked its sender.
+        while s.pending.lock().await.is_empty() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        reader_gone(&sid, &s.pending).await;
+
+        let err = tokio::time::timeout(Duration::from_secs(2), inflight)
+            .await
+            .expect("request must FAIL now, not hang — this hang IS the lost-connection bug")
+            .unwrap()
+            .expect_err("a cleared sender is an error, not a response");
+        assert!(err.starts_with(CHILD_GONE), "{err}");
+        assert!(
+            should_retry(&err, false, 1),
+            "and it is the retryable crash shape"
+        );
+        assert!(
+            !registry().lock().await.contains_key(&sid),
+            "the corpse must leave the registry"
+        );
+    }
+
+    /// The old reader's EOF may land AFTER a respawn replaced the session; its
+    /// cleanup must not tear down (or deregister) the successor.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reader_cleanup_never_touches_a_replacement_session() {
+        let sid = format!("replaced-{}", std::process::id());
+        let dead = test_session("cat");
+        let replacement = test_session("cat");
+        registry()
+            .lock()
+            .await
+            .insert(sid.clone(), replacement.clone());
+
+        reader_gone(&sid, &dead.pending).await;
+
+        let still = registry().lock().await.get(&sid).cloned();
+        let still = still.expect("the replacement must survive the old reader's cleanup");
+        assert!(Arc::ptr_eq(&still, &replacement));
+        assert!(
+            !child_exited(&replacement).await,
+            "and its child is untouched"
+        );
+        registry().lock().await.remove(&sid);
+    }
+
+    /// `get_or_spawn` must not hand out a session whose process is gone.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_session_whose_child_exited_reads_as_dead() {
+        let alive = test_session("cat");
+        assert!(!child_exited(&alive).await);
+
+        let exited = test_session("true");
+        let start = Instant::now();
+        while !child_exited(&exited).await {
+            assert!(start.elapsed() < Duration::from_secs(5), "`true` must exit");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// `closing` is the crash/close discriminator: `close_session` sets it,
+    /// `reader_gone` must not — a model switch, Stop, reap or shutdown must
+    /// never be resurrected by the crash-retry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_intentional_close_is_distinguishable_from_a_crash() {
+        // Crash leg: reader cleanup leaves `closing` false → retry allowed.
+        let sid = format!("crash-leg-{}", std::process::id());
+        let crashed = test_session("cat");
+        registry().lock().await.insert(sid.clone(), crashed.clone());
+        reader_gone(&sid, &crashed.pending).await;
+        assert!(!crashed.closing.load(Ordering::SeqCst));
+
+        // Close leg: an intentional close vetoes any retry.
+        let sid2 = format!("close-leg-{}", std::process::id());
+        let closed = test_session("cat");
+        registry().lock().await.insert(sid2.clone(), closed.clone());
+        close_session(&sid2).await;
+        assert!(closed.closing.load(Ordering::SeqCst));
+        assert!(!should_retry(
+            &format!("{CHILD_GONE} to session/prompt"),
+            true,
+            1
+        ));
+    }
+
+    /// The second crash shape, end to end: the child died before the send.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn writing_to_a_dead_child_reads_as_child_gone() {
+        let s = test_session("cat");
+        s.child.lock().await.start_kill().unwrap();
+        let _ = s.child.lock().await.wait().await;
+        // One write can slip into the pipe buffer instead of EPIPE-ing: a
+        // sibling test fork-exec'ing in parallel briefly holds a dup of the
+        // read end. Keep writing until the kernel reports the pipe broken.
+        let err = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Err(e) = write_line(&s.stdin, &json!({ "probe": true })).await {
+                    break e;
+                }
+            }
+        })
+        .await
+        .expect("a dead child's pipe must eventually report broken");
+        assert!(err.starts_with(CHILD_WRITE_FAILED), "{err}");
+        assert!(should_retry(&err, false, 1));
+    }
+
+    /// The spawn-time `session/load` replay window: no generation in flight →
+    /// updates are dropped; a reset opens the gate.
+    #[test]
+    fn updates_between_turns_are_not_emitted() {
+        let mut ts = TurnState {
+            generation_id: String::new(),
+            full_content: String::new(),
+            pending_delta: String::new(),
+            last_emit: Instant::now(),
+        };
+        assert!(!ts.in_flight(), "fresh spawn: replay must be droppable");
+        ts.reset("g1".to_string());
+        assert!(ts.in_flight());
     }
 }

--- a/src-tauri/src/opencode_installer.rs
+++ b/src-tauri/src/opencode_installer.rs
@@ -47,13 +47,22 @@ const CONFIG_TEMPLATE: &str = r#"{
 "#;
 
 /// iblai/vibe — the public dev-toolkit skills repo, synced for Coding Mode.
-/// Tarball of the default branch; unauthenticated (public repo).
-const VIBE_TARBALL_URL: &str = "https://github.com/iblai/vibe/archive/refs/heads/main.tar.gz";
-/// Latest-commit probe for the freshness check. Unauthenticated is plenty at
-/// ~1/day; api.github.com rejects requests without a User-Agent.
-const VIBE_COMMITS_URL: &str = "https://api.github.com/repos/iblai/vibe/commits/main";
-/// How often to even look upstream. The sha marker's mtime is the clock.
-const VIBE_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+/// Every look resolves the LATEST GitHub Release and syncs to it — releases
+/// are what ship (the repo's release workflow cuts one on every landing),
+/// never the moving branch head, and no version is ever pinned here. There is
+/// deliberately NO freshness window: the app resolves latest at every launch
+/// (and on Code enable) and downloads only when the tag moved.
+///
+/// github.com, not api.github.com: this URL's redirect names the tag, the
+/// probe shares the tarball's host (one reachability question), and the
+/// unauthenticated API rate limit never applies.
+const VIBE_LATEST_RELEASE_URL: &str = "https://github.com/iblai/vibe/releases/latest";
+
+/// Source tarball for a release tag — github.com (not the API host), so no
+/// User-Agent requirement, same shape the branch download always had.
+fn vibe_tag_tarball_url(tag: &str) -> String {
+    format!("https://github.com/iblai/vibe/archive/refs/tags/{tag}.tar.gz")
+}
 
 fn create_command(program: &str) -> Command {
     let cmd = Command::new(program);
@@ -266,18 +275,19 @@ async fn download_and_install(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// `<data>/skills/vibe.sha` — upstream commit sha of the current vibe copy; the
-/// file's mtime doubles as the "last checked" stamp.
+/// `<data>/skills/vibe.sha` — release tag of the current vibe copy: a change
+/// detector, never a pin ("did latest move since the last sync?"). Pre-release
+/// copies stored a commit sha here — it matches no tag, so they self-heal with
+/// one re-download.
 fn vibe_sha_marker() -> PathBuf {
     crate::opencode_acp::vibe_skills_dir().with_extension("sha")
 }
 
-fn vibe_marker_is_fresh(marker: &Path, max_age: std::time::Duration) -> bool {
-    std::fs::metadata(marker)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.elapsed().ok())
-        .map(|age| age < max_age)
+/// "Installed" means a populated dir: an empty `skills/vibe/` (interrupted
+/// swap, manual poking) must read as absent so the next look re-installs.
+fn dir_is_populated(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut d| d.next().is_some())
         .unwrap_or(false)
 }
 
@@ -293,26 +303,55 @@ fn find_extracted_skills(tmp: &Path) -> Option<PathBuf> {
     None
 }
 
-async fn fetch_latest_vibe_sha() -> Option<String> {
-    let resp = reqwest::Client::new()
-        .get(VIBE_COMMITS_URL)
+/// The tag a `releases/latest` redirect points at (`…/releases/tag/<tag>`).
+/// A redirect anywhere else — notably plain `/releases` when no release has
+/// ever been published — is `None`: never guess a version.
+fn tag_from_location(location: &str) -> Option<String> {
+    let (_, tag) = location.split_once("/releases/tag/")?;
+    let tag = tag.trim_end_matches('/');
+    (!tag.is_empty() && !tag.contains('/')).then(|| tag.to_string())
+}
+
+/// Resolve the latest release tag from `probe_url` WITHOUT following the
+/// redirect — the `Location` header names the tag.
+async fn resolve_latest_tag(probe_url: &str) -> Option<String> {
+    let resp = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .ok()?
+        .get(probe_url)
         .header("User-Agent", "iblai-desktop")
-        .header("Accept", "application/vnd.github+json")
         .timeout(std::time::Duration::from_secs(10))
         .send()
         .await
-        .ok()?
-        .error_for_status()
         .ok()?;
-    let v: serde_json::Value = resp.json().await.ok()?;
-    Some(v.get("sha")?.as_str()?.to_string())
+    if !resp.status().is_redirection() {
+        return None;
+    }
+    tag_from_location(
+        resp.headers()
+            .get(reqwest::header::LOCATION)?
+            .to_str()
+            .ok()?,
+    )
 }
 
-/// Download the vibe tarball and swap its `skills/` over `dest`. The old copy
-/// survives any failure (extract to temp, rename with a backup).
-async fn download_vibe_skills(app: &AppHandle, dest: &Path) -> Result<(), String> {
+/// Whatever the latest published release is right now — resolved fresh on
+/// every look, never cached beyond the marker's change detection.
+async fn fetch_latest_vibe_tag() -> Option<String> {
+    resolve_latest_tag(VIBE_LATEST_RELEASE_URL).await
+}
+
+/// Download the vibe tarball at `url` and swap its `skills/` over `dest`. The
+/// old copy survives any failure (extract to temp, rename with a backup).
+async fn download_vibe_skills(app: &AppHandle, dest: &Path, url: &str) -> Result<(), String> {
     log(app, "downloading iblai/vibe skills");
-    let bytes = reqwest::get(VIBE_TARBALL_URL)
+    let bytes = reqwest::Client::new()
+        .get(url)
+        // Bounded so a stalled download can't pin the sync lock (and the Code
+        // pill spinner) forever; the archive is a few MB.
+        .timeout(std::time::Duration::from_secs(120))
+        .send()
         .await
         .map_err(|e| format!("vibe download failed: {e}"))?
         .error_for_status()
@@ -365,13 +404,15 @@ async fn download_vibe_skills(app: &AppHandle, dest: &Path) -> Result<(), String
 /// Sync the iblai/vibe skills for Coding Mode (shared across mentors and sessions).
 ///
 /// Standalone from `install_opencode` on purpose: the Code pill's spinner covers
-/// skills, never the binary install. At most one upstream look per
-/// [`VIBE_REFRESH_INTERVAL`]; an actual download registers an in-flight entry so
-/// the spawn path holds instead of snapshotting a half-written dir. Failures keep
-/// the cached copy and never error the command — the caller reads `present`.
+/// skills, never the binary install. NO freshness window: every call (app
+/// startup spawns one, and each Code enable re-invokes) resolves the latest
+/// release and downloads only when the tag moved — always latest, never
+/// pinned. An actual download registers an in-flight entry so the spawn path
+/// holds instead of snapshotting a half-written dir. Failures keep the cached
+/// copy and never error the command — the caller reads `present`.
 #[command]
 pub async fn ensure_vibe_skills(app: AppHandle) -> Result<serde_json::Value, String> {
-    // One flight at a time: several composers mount the sync hook.
+    // One flight at a time: startup plus several composers can all invoke.
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     let _guard = LOCK
         .get_or_init(|| tokio::sync::Mutex::new(()))
@@ -380,42 +421,48 @@ pub async fn ensure_vibe_skills(app: AppHandle) -> Result<serde_json::Value, Str
 
     let dir = crate::opencode_acp::vibe_skills_dir();
     let marker = vibe_sha_marker();
-    let cached = dir.is_dir();
+    let cached = dir_is_populated(&dir);
 
-    if cached && vibe_marker_is_fresh(&marker, VIBE_REFRESH_INTERVAL) {
-        return Ok(json!({ "present": true, "refreshed": false }));
-    }
-
-    let latest = fetch_latest_vibe_sha().await;
+    let latest = fetch_latest_vibe_tag().await;
     if cached {
         match &latest {
-            Some(latest_sha) => {
+            Some(latest_tag) => {
                 let stored = std::fs::read_to_string(&marker).unwrap_or_default();
-                if stored.trim() == latest_sha.trim() {
-                    // Up to date — restamp the marker so the daily clock resets.
-                    let _ = std::fs::write(&marker, latest_sha);
+                if stored.trim() == latest_tag.trim() {
+                    // Already on the latest release.
                     return Ok(json!({ "present": true, "refreshed": false }));
                 }
             }
             None => {
-                // Offline/unreachable with a cache: keep it quietly; the next call
-                // past the interval tries again.
+                // Offline/unreachable with a cache: keep it quietly; the next
+                // look (startup or Code enable) tries again.
                 log(&app, "vibe skills check unreachable — keeping cached copy");
                 return Ok(json!({ "present": true, "refreshed": false }));
             }
         }
     }
 
-    // Something to fetch: first install, or upstream moved.
+    // Something to fetch: first install, or upstream cut a new release.
+    let Some(tag) = latest else {
+        // No release info and no cache (the cached case returned above). A
+        // fallback to branch head would silently ship unreleased skills —
+        // don't; the sync hook retries with backoff, and the next launch
+        // tries again at startup.
+        log(
+            &app,
+            "vibe release lookup unreachable — skills not installed yet",
+        );
+        return Ok(json!({ "present": dir_is_populated(&dir), "refreshed": false }));
+    };
     crate::opencode_acp::begin_skills_sync_entry(crate::opencode_acp::VIBE_SYNC_KEY.to_string())
         .await;
-    let downloaded = download_vibe_skills(&app, &dir).await;
+    let downloaded = download_vibe_skills(&app, &dir, &vibe_tag_tarball_url(&tag)).await;
     crate::opencode_acp::end_skills_sync_entry(crate::opencode_acp::VIBE_SYNC_KEY).await;
 
     match downloaded {
         Ok(()) => {
-            let _ = std::fs::write(&marker, latest.as_deref().unwrap_or("unknown"));
-            log(&app, "vibe skills installed");
+            let _ = std::fs::write(&marker, &tag);
+            log(&app, &format!("vibe skills installed ({tag})"));
             Ok(json!({ "present": true, "refreshed": true }))
         }
         Err(e) => {
@@ -586,20 +633,90 @@ mod tests {
     fn the_extracted_skills_dir_is_located_not_assumed() {
         let s = Scratch::new("vibe-locate");
         assert!(find_extracted_skills(s.path()).is_none());
-        let root = s.path().join("vibe-main");
+        // A release-tag archive root (`vibe-<tag>`), not the old `vibe-main`:
+        // the locator must not care what the tag is.
+        let root = s.path().join("vibe-1.18.0");
         std::fs::create_dir_all(root.join("skills").join("iblai-vibe-auth")).unwrap();
         assert_eq!(find_extracted_skills(s.path()), Some(root.join("skills")));
     }
 
-    /// The marker's mtime is the daily clock: fresh short-circuits the upstream
-    /// look, missing (first run) and stale do not.
+    /// "Installed" is a populated dir: missing and empty both mean absent, so
+    /// an interrupted swap can't masquerade as a working skill set.
     #[test]
-    fn a_fresh_marker_short_circuits_and_a_missing_one_does_not() {
-        let s = Scratch::new("vibe-marker");
-        let marker = s.path().join("vibe.sha");
-        assert!(!vibe_marker_is_fresh(&marker, VIBE_REFRESH_INTERVAL));
-        std::fs::write(&marker, "abc").unwrap();
-        assert!(vibe_marker_is_fresh(&marker, VIBE_REFRESH_INTERVAL));
-        assert!(!vibe_marker_is_fresh(&marker, std::time::Duration::ZERO));
+    fn an_empty_or_missing_skills_dir_reads_as_not_installed() {
+        let s = Scratch::new("vibe-populated");
+        let dir = s.path().join("vibe");
+        assert!(!dir_is_populated(&dir), "missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!dir_is_populated(&dir), "empty");
+        std::fs::create_dir_all(dir.join("iblai-vibe-auth")).unwrap();
+        assert!(dir_is_populated(&dir), "populated");
+    }
+
+    /// Skills track whatever release is latest — the tag is read out of the
+    /// `releases/latest` redirect every time, never configured.
+    #[test]
+    fn the_release_tag_is_read_from_the_redirect_never_configured() {
+        assert_eq!(
+            tag_from_location("https://github.com/iblai/vibe/releases/tag/v9.9.9").as_deref(),
+            Some("v9.9.9")
+        );
+        assert_eq!(
+            tag_from_location("https://github.com/iblai/vibe/releases/tag/v9.9.9/").as_deref(),
+            Some("v9.9.9"),
+            "a trailing slash is tolerated"
+        );
+        assert_eq!(
+            tag_from_location("https://github.com/iblai/vibe/releases"),
+            None,
+            "no release published → no tag, never a guess"
+        );
+        assert_eq!(tag_from_location("https://github.com/"), None);
+        assert_eq!(
+            tag_from_location("https://x/releases/tag/a/b"),
+            None,
+            "a path after the tag is not a tag"
+        );
+    }
+
+    /// End to end against a canned redirect: the latest tag comes from the
+    /// `Location` header on github.com — no API host, no rate limit. A
+    /// non-redirect answer yields None instead of a guessed version.
+    #[tokio::test]
+    async fn the_latest_tag_comes_from_the_releases_redirect() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // First connect: the redirect. Second: a plain 200 (no release).
+            for response in [
+                "HTTP/1.1 302 Found\r\nlocation: https://github.com/iblai/vibe/releases/tag/v9.9.9\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            ] {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let probe = format!("http://{addr}/releases/latest");
+        assert_eq!(resolve_latest_tag(&probe).await.as_deref(), Some("v9.9.9"));
+        assert_eq!(
+            resolve_latest_tag(&probe).await,
+            None,
+            "a non-redirect answer must not invent a tag"
+        );
+    }
+
+    /// The download URL is the tag's source archive on github.com — not the
+    /// API host (which would demand a User-Agent) and not any branch head.
+    #[test]
+    fn the_tarball_url_is_the_tags_source_archive() {
+        assert_eq!(
+            vibe_tag_tarball_url("v1.18.0"),
+            "https://github.com/iblai/vibe/archive/refs/tags/v1.18.0.tar.gz"
+        );
     }
 }

--- a/src-tauri/src/opencode_proxy.rs
+++ b/src-tauri/src/opencode_proxy.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::extract::Request;
@@ -70,6 +71,9 @@ struct Upstream {
     base: String,
     /// The real DM token — held here, never handed to the agent.
     token: String,
+    /// The platform (tenant) key this session serves — surfaced to the agent
+    /// in the injected guidance so skills know which org they act on.
+    tenant: String,
     /// Whether this session has skills wired — the gate for injecting
     /// [`IBLAI_INSTRUCTIONS`] into its chat/completions calls.
     inject_guidance: bool,
@@ -120,10 +124,32 @@ pub async fn set_learner(username: &str) {
     *learner().write().await = (!name.is_empty()).then(|| name.to_string());
 }
 
+/// The signed-in learner's username, for the child's `IBLAI_USERNAME` env var
+/// at spawn and the identity line in the injected guidance. `None` until a
+/// non-empty username arrives — callers add nothing then.
+pub async fn learner_username() -> Option<String> {
+    learner().read().await.clone()
+}
+
+/// Longest silence tolerated between upstream read operations. Generous — a
+/// model can legitimately think for minutes between SSE chunks — but bounded,
+/// so a wedged upstream fails the turn instead of hanging it forever.
+/// Deliberately a per-read timeout, never a total one: a healthy streamed
+/// completion may stay open far longer than any total budget, and the DM side
+/// heartbeats every ~15s, so this only trips on a genuinely dead path.
+// ponytail: 300s guess; shrink if wedged turns linger, grow if long thinks get cut.
+const UPSTREAM_READ_TIMEOUT: Duration = Duration::from_secs(300);
+
+fn http_client(read_timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .read_timeout(read_timeout)
+        .build()
+        .expect("reqwest client")
+}
+
 fn http() -> &'static reqwest::Client {
     static C: OnceLock<reqwest::Client> = OnceLock::new();
-    // No timeout: a streamed completion legitimately stays open for minutes.
-    C.get_or_init(reqwest::Client::new)
+    C.get_or_init(|| http_client(UPSTREAM_READ_TIMEOUT))
 }
 
 /// The OpenAI-compatible paths the model client actually calls. Anything else 404s,
@@ -157,24 +183,31 @@ pub fn new_secret() -> String {
     hex::encode(h.finalize())
 }
 
-/// Start the proxy on an OS-assigned loopback port (once) and return the port.
+/// Start the proxy on an OS-assigned loopback port and return the port,
+/// re-binding when a previously started server no longer answers — the server
+/// task dies with its runtime (tests) or on a fatal accept error, and a
+/// memoized dead port would wedge every future session until an app restart.
 pub async fn ensure_started() -> Result<u16, String> {
-    static PORT: OnceLock<u16> = OnceLock::new();
-    static START: OnceLock<Mutex<()>> = OnceLock::new();
+    static PORT: Mutex<Option<u16>> = Mutex::const_new(None);
 
-    if let Some(p) = PORT.get() {
-        return Ok(*p);
-    }
-    let _guard = START.get_or_init(|| Mutex::new(())).lock().await;
-    if let Some(p) = PORT.get() {
-        return Ok(*p);
+    // Holding the lock across probe + bind serializes concurrent starts.
+    let mut port = PORT.lock().await;
+    if let Some(p) = *port {
+        // Probe, don't trust: one loopback connect per session spawn.
+        if tokio::net::TcpStream::connect(("127.0.0.1", p))
+            .await
+            .is_ok()
+        {
+            return Ok(p);
+        }
+        eprintln!("[opencode-proxy] server on port {p} is gone — rebinding");
     }
 
     // Port 0 → the OS picks a free ephemeral port. Never a fixed one.
     let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await
         .map_err(|e| format!("model proxy bind failed: {e}"))?;
-    let port = listener
+    let p = listener
         .local_addr()
         .map_err(|e| format!("model proxy addr failed: {e}"))?
         .port();
@@ -185,19 +218,28 @@ pub async fn ensure_started() -> Result<u16, String> {
             eprintln!("[opencode-proxy] server stopped: {e}");
         }
     });
-    let _ = PORT.set(port);
-    Ok(port)
+    *port = Some(p);
+    Ok(p)
 }
 
 /// Register a session's upstream + real token against its throwaway secret.
-/// `inject_guidance` marks a session with skills wired: its chat/completions
-/// calls get [`IBLAI_INSTRUCTIONS`] injected as a system message.
-pub async fn register(secret: &str, base: String, token: String, inject_guidance: bool) {
+/// `tenant` is the platform key the session serves (surfaced in the injected
+/// guidance); `inject_guidance` marks a session with skills wired: its
+/// chat/completions calls get [`IBLAI_INSTRUCTIONS`] injected as a system
+/// message.
+pub async fn register(
+    secret: &str,
+    base: String,
+    token: String,
+    tenant: String,
+    inject_guidance: bool,
+) {
     sessions().write().await.insert(
         secret.to_string(),
         Upstream {
             base,
             token,
+            tenant,
             inject_guidance,
         },
     );
@@ -216,11 +258,38 @@ pub async fn unregister(secret: &str) {
     sessions().write().await.remove(secret);
 }
 
-/// Insert [`IBLAI_INSTRUCTIONS`] as a system message into a chat/completions
-/// body — after the last LEADING system message, so opencode's own system
-/// prompt keeps first position. `None` = forward the body untouched (not
-/// JSON, no `messages` array, or the guidance is somehow already present).
-fn inject_system_guidance(body: &[u8]) -> Option<Vec<u8>> {
+/// The identity bullets appended to the guidance: who is signed in and which
+/// platform the session serves, plus the env vars carrying the same values —
+/// so skills never have to ask (or guess) the username or platform key.
+fn identity_lines(learner: Option<&str>, tenant: Option<&str>) -> String {
+    let mut out = String::new();
+    if let Some(l) = learner {
+        out.push_str(&format!(
+            "- The signed-in platform username is `{l}` (also exported to your \
+shell as the IBLAI_USERNAME environment variable) — use it wherever a skill \
+needs the platform username.\n"
+        ));
+    }
+    if let Some(t) = tenant {
+        out.push_str(&format!(
+            "- The active platform (tenant) key is `{t}` (also exported as the \
+IBLAI_PLATFORM_KEY environment variable) — use it wherever a skill needs the \
+platform key.\n"
+        ));
+    }
+    out
+}
+
+/// Insert [`IBLAI_INSTRUCTIONS`] (plus the caller's [`identity_lines`]) as a
+/// system message into a chat/completions body — after the last LEADING system
+/// message, so opencode's own system prompt keeps first position. `None` =
+/// forward the body untouched (not JSON, no `messages` array, or the guidance
+/// is somehow already present).
+fn inject_system_guidance(
+    body: &[u8],
+    learner: Option<&str>,
+    tenant: Option<&str>,
+) -> Option<Vec<u8>> {
     let mut v: serde_json::Value = serde_json::from_slice(body).ok()?;
     let messages = v.get_mut("messages")?.as_array_mut()?;
     if messages.iter().any(|m| {
@@ -234,9 +303,10 @@ fn inject_system_guidance(body: &[u8]) -> Option<Vec<u8>> {
         .iter()
         .take_while(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
         .count();
+    let content = format!("{IBLAI_INSTRUCTIONS}{}", identity_lines(learner, tenant));
     messages.insert(
         at,
-        serde_json::json!({ "role": "system", "content": IBLAI_INSTRUCTIONS }),
+        serde_json::json!({ "role": "system", "content": content }),
     );
     serde_json::to_vec(&v).ok()
 }
@@ -311,12 +381,14 @@ async fn forward(req: Request) -> Response {
     let Some(secret) = bearer(&parts.headers) else {
         return (StatusCode::UNAUTHORIZED, "missing key").into_response();
     };
-    let Some((base, token, inject)) = sessions()
-        .read()
-        .await
-        .get(&secret)
-        .map(|u| (u.base.clone(), u.token.clone(), u.inject_guidance))
-    else {
+    let Some((base, token, tenant, inject)) = sessions().read().await.get(&secret).map(|u| {
+        (
+            u.base.clone(),
+            u.token.clone(),
+            u.tenant.clone(),
+            u.inject_guidance,
+        )
+    }) else {
         return (StatusCode::UNAUTHORIZED, "unknown key").into_response();
     };
 
@@ -333,8 +405,11 @@ async fn forward(req: Request) -> Response {
     };
     // Skills-wired sessions get the ibl.ai guidance injected as a system
     // message, in flight — opencode's own conversation state never sees it.
+    // The identity lines read the app-global learner per request, so a login
+    // that lands mid-session takes effect on the next call.
     let bytes = if inject && path == "chat/completions" {
-        match inject_system_guidance(&bytes) {
+        let tenant_line = (!tenant.is_empty()).then_some(tenant.as_str());
+        match inject_system_guidance(&bytes, learner.as_deref(), tenant_line) {
             Some(patched) => axum::body::Bytes::from(patched),
             None => bytes,
         }
@@ -526,16 +601,25 @@ mod tests {
         assert_eq!(url.query(), Some("learner_id=us+er%26x%3Dy"));
     }
 
+    /// Serializes the tests that talk to the live proxy: `ensure_started()`
+    /// memoizes its port globally and each test's runtime kills the server it
+    /// spawned — the rebind probe recovers from that, but two live tests
+    /// interleaving could still race one another's requests mid-rebind.
+    fn live_proxy_lock() -> std::sync::MutexGuard<'static, ()> {
+        static L: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        L.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     /// The credit gate lives upstream: when the DM answers 402 on
     /// `chat/completions`, the agent must receive that 402 and its body EXACTLY.
     /// The proxy swaps auth — it never rewrites outcomes.
-    ///
-    /// NOTE: `ensure_started()` memoizes its port globally, and the server task it
-    /// spawns lives on THIS test's runtime, which dies when the test ends. Keep
-    /// this the only test that talks to the live proxy, or restructure first.
     #[tokio::test]
     async fn an_upstream_402_reaches_the_agent_unchanged() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let _live = live_proxy_lock();
 
         const BODY: &str = r#"{"error":"Payment required","status_code":402}"#;
 
@@ -573,6 +657,7 @@ mod tests {
             &secret,
             format!("http://{upstream_addr}/v1"),
             "real-dm-token".to_string(),
+            "main-tenant".to_string(),
             false,
         )
         .await;
@@ -612,7 +697,7 @@ mod tests {
         })
         .to_string();
 
-        let out = inject_system_guidance(body.as_bytes()).expect("must inject");
+        let out = inject_system_guidance(body.as_bytes(), None, None).expect("must inject");
         let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
         let msgs = v["messages"].as_array().unwrap();
 
@@ -640,7 +725,7 @@ mod tests {
         })
         .to_string();
 
-        let out = inject_system_guidance(body.as_bytes()).unwrap();
+        let out = inject_system_guidance(body.as_bytes(), None, None).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(v["messages"][0]["role"], "system");
         assert_eq!(v["messages"][1]["role"], "user");
@@ -650,15 +735,142 @@ mod tests {
     /// guidance patch must never break the model call it rides on.
     #[test]
     fn unpatchable_bodies_are_left_untouched() {
-        assert!(inject_system_guidance(b"not json at all").is_none());
-        assert!(inject_system_guidance(br#"{"prompt": "legacy completions"}"#).is_none());
+        assert!(inject_system_guidance(b"not json at all", None, None).is_none());
+        assert!(
+            inject_system_guidance(br#"{"prompt": "legacy completions"}"#, None, None).is_none()
+        );
 
-        // Already carrying the guidance → not doubled.
+        // Already carrying the guidance → not doubled, identity or not.
         let body = serde_json::json!({
             "messages": [{ "role": "system", "content": IBLAI_INSTRUCTIONS }]
         })
         .to_string();
-        assert!(inject_system_guidance(body.as_bytes()).is_none());
+        assert!(inject_system_guidance(body.as_bytes(), None, None).is_none());
+        assert!(inject_system_guidance(body.as_bytes(), Some("codey"), Some("acme")).is_none());
+    }
+
+    /// The agent must be TOLD who it acts for: the identity bullets carry the
+    /// username and platform key plus the env vars that mirror them.
+    #[test]
+    fn identity_lines_land_in_the_guidance() {
+        let body = serde_json::json!({
+            "messages": [{ "role": "user", "content": "deploy this" }]
+        })
+        .to_string();
+
+        let out = inject_system_guidance(body.as_bytes(), Some("codey"), Some("acme")).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let content = v["messages"][0]["content"].as_str().unwrap();
+        assert!(content.contains("username is `codey`"), "{content}");
+        assert!(content.contains("IBLAI_USERNAME"), "{content}");
+        assert!(
+            content.contains("platform (tenant) key is `acme`"),
+            "{content}"
+        );
+        assert!(content.contains("IBLAI_PLATFORM_KEY"), "{content}");
+
+        // No identity known → the guidance is exactly the base text, no stubs.
+        let out = inject_system_guidance(body.as_bytes(), None, None).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["messages"][0]["content"], IBLAI_INSTRUCTIONS);
+
+        // Each line stands alone when only one half is known.
+        assert!(identity_lines(Some("codey"), None).contains("IBLAI_USERNAME"));
+        assert!(!identity_lines(Some("codey"), None).contains("IBLAI_PLATFORM_KEY"));
+        assert!(identity_lines(None, Some("acme")).contains("IBLAI_PLATFORM_KEY"));
+        assert_eq!(identity_lines(None, None), "");
+    }
+
+    /// The env-var half of the same contract: what spawn exports as
+    /// `IBLAI_USERNAME` comes from here, and empty input must yield `None` so
+    /// the variable is not set at all rather than set to "".
+    #[tokio::test]
+    async fn the_signed_in_learner_is_exposed_for_the_child_env() {
+        set_learner("codey").await;
+        assert_eq!(learner_username().await.as_deref(), Some("codey"));
+        set_learner("   ").await;
+        assert_eq!(learner_username().await, None);
+    }
+
+    /// The "can't reconnect" half of the lost-connection bug: the old code
+    /// memoized the port forever, so once the server task died (its runtime
+    /// went away, or accept failed fatally) every future session registered
+    /// against a dead port until an app restart. The probe must detect the
+    /// death and rebind.
+    #[tokio::test]
+    async fn ensure_started_rebinds_after_its_server_dies() {
+        let _live = live_proxy_lock();
+
+        // Start the proxy on a runtime that then dies, taking the server with it.
+        let dead_port = std::thread::spawn(|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(ensure_started()).unwrap()
+            // rt drops here → the spawned axum task and its listener die.
+        })
+        .join()
+        .unwrap();
+        assert!(
+            tokio::net::TcpStream::connect(("127.0.0.1", dead_port))
+                .await
+                .is_err(),
+            "precondition: the old server must actually be gone"
+        );
+
+        // Pre-fix: the memoized dead port comes back and this connect fails.
+        let port = ensure_started().await.unwrap();
+        assert!(
+            tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok(),
+            "ensure_started must hand out a port that answers"
+        );
+    }
+
+    /// A wedged upstream must fail the turn, not hang it forever: the client's
+    /// read timeout is per-read (between chunks), so a stream that stops
+    /// mid-body errors out once the silence exceeds the budget.
+    #[tokio::test]
+    async fn a_stalled_upstream_read_times_out_between_chunks() {
+        use futures_util::StreamExt;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Canned upstream: send headers + a partial body, then hold the socket
+        // open silently forever.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 100\r\n\r\npartial")
+                .await;
+            tokio::time::sleep(Duration::from_secs(600)).await;
+            drop(sock);
+        });
+
+        let resp = http_client(Duration::from_millis(200))
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .unwrap();
+        let mut stream = resp.bytes_stream();
+
+        let first = stream.next().await.expect("the partial chunk arrives");
+        assert_eq!(first.unwrap().as_ref(), b"partial");
+
+        let second = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("the stalled stream must ERROR, not hang — this hang was the wedged-turn bug");
+        assert!(
+            second
+                .expect("stream must yield an item, not end cleanly")
+                .is_err(),
+            "silence past the read timeout is an error"
+        );
     }
 
     /// The guidance must keep its load-bearing content: skill priority, the


### PR DESCRIPTION
…E/IBLAI_PLATFORM_KEY env+prompt injection, vibe skills synced from the latest GitHub release at every launch


## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
  Rust-side fixes for the code-mode → Vercel flow (pairs
  with DM `4.344.0` and the vibe skills PR). No TS
  behavior changes outside the skill-sync hook; no new
  dependencies.

  ## 1. The agent now knows who and where it is

  `spawn_session` exports `IBLAI_USERNAME` (from the
  existing `opencode_proxy::learner()` app-global) and
  `IBLAI_PLATFORM_KEY` (the session tenant) into the
  opencode child, and the proxy's injected system
  guidance now states both values and the env var names
  (`identity_lines`, appended to `IBLAI_INSTRUCTIONS`;
  tenant threaded through `Upstream`/`register`). The
  vibe deploy skill reads these instead of hitting an
  identity endpoint or asking the user.
  Attribution/config only — the
  no-credentials-in-child-env design is untouched; the DM
  token still never leaves the proxy.

  ## 2. Lost-connection fix + silent mid-turn recovery

  The reported "opencode loses connection and can't
  reconnect" decomposed into four gaps, each now closed:
  - **Hung turns:** a dead child left in-flight
  `session/prompt` futures parked forever on senders
  nobody would fire. `reader_gone` (on child EOF) does an
  identity-gated teardown (`Arc::ptr_eq` — a respawned
  successor is never torn down) and drains the pending
  map, so hung requests fail instantly.
  - **Corpse reuse:** `get_or_spawn` now probes
  `child.try_wait()` and respawns instead of handing out
  a dead session.
  - **Dead proxy port:** `ensure_started` replaces the
  `OnceLock` port memo with a probe-and-rebind
  (`Mutex<Option<u16>>` + loopback connect) — a dead
  server task no longer wedges every future session until
  app restart.
  - **Stalled upstream:** the proxy client gets a 300s
  **per-read** timeout (never total — long thinks are
  legit; DM now heartbeats every 15s, so 300s of silence
  means a genuinely dead path).

  On top of that, a mid-turn child crash is now
  **invisible to the user**: the turn respawns once and
  re-sends the same prompt into the same generation
  (`PROMPT_ATTEMPTS = 2` — a deterministically-crashing
  prompt must not respawn-loop). The fresh process
  re-loads the previous ACP session when opencode
  advertises `loadSession` (conversation context
  survives; capability is read from the `initialize`
  response with a `session/new` fallback), and the
  spawn-time history replay is dropped via a
  turn-in-flight gate so old turns never re-stream into
  the UI. A `closing` flag set by `close_session`
  guarantees intentional teardowns (model switch, Stop,
  reap, chat close) are never resurrected. `ollama:error`
  still fires for a second crash in the same turn,
  live-child JSON-RPC errors, and intentional closes. An
  `ollama:restart` machine event marks the seam for the
  SDK; its token handler assigns from `full_content`
  (replace semantics), so the recovered attempt visually
  overwrites the partial text with no SDK change needed.

  Known accepted costs: a recovered attempt can re-run
  attempt-1 tool calls (workspace side effects may
  duplicate; bounded by the single respawn), and
  `session/new`-fallback recovery loses prior-turn
  context.

  ## 3. Vibe skills: always the latest release, resolved
  at every launch

  - The skills tarball now tracks the **latest GitHub
  Release** — releases are what ship, never the branch
  head, and nothing is pinned: the tag is resolved fresh
  on every look and the marker is only a "did latest
  move?" change detector.
  - The tag comes from the `Location` redirect of
  `github.com/iblai/vibe/releases/latest` — same host as
  the tarball, so no api.github.com dependency, no
  unauthenticated 60/hr rate limit (that dependency
  briefly made fresh installs fail when the skills dir
  didn't exist).
  - **No freshness window**: the 24h clock is gone. Both
  builders spawn `ensure_vibe_skills` in the background
  at startup, so a fresh machine has skills before Code
  is ever enabled; enabling Code re-checks as before.
  - Hardening: 120s timeout on the tarball GET (a stall
  used to pin the sync lock and the pill spinner
  forever), an empty `skills/vibe/` reads as
  not-installed, and a failed release lookup with no
  cache stays loud — no silent branch-head fallback.
  - The skill-sync hook self-retries a failed vibe
  install (30s/2m/10m backoff, recovers to `synced`);
  previously one failure meant no skills for the whole
  app run. No new error UI — the popover's amber note
  remains the only signal.

  ## Tests

  `cargo test`: **86 passed × 2 targets**, stable across
  repeated runs. New/adjusted, pre-fix-failing where
  meaningful: the dead-reader hang test (the reported bug
  in miniature — `request()` must fail within 2s, not
  hang), port-rebind-after-server-death, stalled-stream
  read-timeout (verified to fail with the timeout
  removed), crash-vs-close discrimination, retry-budget
  decision table, EPIPE crash shape, replay suppression,
  redirect-tag resolution against a canned 302,
  populated-dir semantics. Vitest: skill-sync hook
  **16/16** (2 new fake-timer retry cases); changed hook
  at **97.34% line coverage** (≥95 gate). `e2e-tauri`
  coverage gains deferred checkpoint `code-20` (kill
  opencode mid-turn → answer continues; second kill
  errors).

  Note: users receive skill fixes only after a vibe
  release is cut (conventional-commit subjects drive that
  repo's auto-release) — land the vibe PR with a
  `fix:`/`feat:` subject.

  🤖 Generated with [Claude
  Code](https://claude.com/claude-code)