### PR TITLE
Fix/embed context leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,42 +4,42 @@
 
 ### Chores
 
-* **tauri:** release app-v0.95.16 ([bb25012](https://github.com/iblai/os/commit/bb250126d438c7394d2354ab3abb5de90ed39dda))
+- **tauri:** release app-v0.95.16 ([bb25012](https://github.com/iblai/os/commit/bb250126d438c7394d2354ab3abb5de90ed39dda))
 
 ## [0.130.0](https://github.com/iblai/os/compare/v0.129.2...v0.130.0) (2026-08-21)
 
 ### Features
 
-* add stripe and vercel support for code mode ([690e112](https://github.com/iblai/os/commit/690e112a5294e446983adfc540454980ded5014f))
+- add stripe and vercel support for code mode ([690e112](https://github.com/iblai/os/commit/690e112a5294e446983adfc540454980ded5014f))
 
 ### Bug Fixes
 
-* **code-mode:** enable auto deploy ([e613bfd](https://github.com/iblai/os/commit/e613bfd2f8808c30c3c70f205f9951f0dc83fd03))
+- **code-mode:** enable auto deploy ([e613bfd](https://github.com/iblai/os/commit/e613bfd2f8808c30c3c70f205f9951f0dc83fd03))
 
 ### Chores
 
-* **tauri:** release app-v0.95.15 ([f3bcd7b](https://github.com/iblai/os/commit/f3bcd7b899fe5f894b4dc459f4206580850e27ae))
-* update prompt ([9c111ba](https://github.com/iblai/os/commit/9c111ba2e66bac30c5842fdfc77c367a17b9ba07))
+- **tauri:** release app-v0.95.15 ([f3bcd7b](https://github.com/iblai/os/commit/f3bcd7b899fe5f894b4dc459f4206580850e27ae))
+- update prompt ([9c111ba](https://github.com/iblai/os/commit/9c111ba2e66bac30c5842fdfc77c367a17b9ba07))
 
 ## [0.129.2](https://github.com/iblai/os/compare/v0.129.1...v0.129.2) (2026-08-20)
 
 ### Bug Fixes
 
-* **csp:** allow api.github.com in connect-src ([4a945ad](https://github.com/iblai/os/commit/4a945ad15dbb88fe8bdb1cd71a88b9235992120f))
+- **csp:** allow api.github.com in connect-src ([4a945ad](https://github.com/iblai/os/commit/4a945ad15dbb88fe8bdb1cd71a88b9235992120f))
 
 ### Styles
 
-* apply prettier to CHANGELOG and deployment doc ([053caa2](https://github.com/iblai/os/commit/053caa25a8c81eae5a9c628e43e6e3a89d16e1b8))
+- apply prettier to CHANGELOG and deployment doc ([053caa2](https://github.com/iblai/os/commit/053caa25a8c81eae5a9c628e43e6e3a89d16e1b8))
 
 ### Tests
 
-* **csp:** cover asset-CDN and partner-host branches ([decfa62](https://github.com/iblai/os/commit/decfa6267340f0c93df89ba36c9578928c2378c1))
+- **csp:** cover asset-CDN and partner-host branches ([decfa62](https://github.com/iblai/os/commit/decfa6267340f0c93df89ba36c9578928c2378c1))
 
 ## [0.129.1](https://github.com/iblai/os/compare/v0.129.0...v0.129.1) (2026-08-20)
 
 ### Bug Fixes
 
-* **embed:** persist embed-mode params so they survive hard navigations ([3284b09](https://github.com/iblai/os/commit/3284b09bf95bb9374cba8274b489f0afeebb63cc))
+- **embed:** persist embed-mode params so they survive hard navigations ([3284b09](https://github.com/iblai/os/commit/3284b09bf95bb9374cba8274b489f0afeebb63cc))
 
 ## [0.129.0](https://github.com/iblai/os/compare/v0.128.8...v0.129.0) (2026-08-19)
 

--- a/components/modals/__tests__/embed-tab.test.tsx
+++ b/components/modals/__tests__/embed-tab.test.tsx
@@ -399,6 +399,10 @@ vi.mock('@/lib/utils', () => ({
   cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));
 
+// Hand-listed (not importOriginal): the real module evaluates
+// `config.iblTemplateMentor()` at import time, which isn't wired up here. Keep
+// every export embed-tab.tsx reads defined — QUERY_PARAMS is used in the
+// preview-iframe src.
 vi.mock('@/lib/constants', () => ({
   MENTOR_VISIBILITY: [
     { label: 'Administrators', value: 'viewable_by_tenant_admins' },
@@ -409,6 +413,13 @@ vi.mock('@/lib/constants', () => ({
     ADMINISTRATORS: 'viewable_by_tenant_admins',
     STUDENTS: 'viewable_by_tenant_students',
     ANYONE: 'viewable_by_anyone',
+  },
+  QUERY_PARAMS: {
+    APP: 'app',
+    REDIRECT_TO: 'redirect-to',
+    TENANT: 'tenant',
+    EMBED: 'embed',
+    INTERNAL_PREVIEW: 'internalPreview',
   },
 }));
 

--- a/components/modals/edit-mentor-modal/tabs/embed-tab.tsx
+++ b/components/modals/edit-mentor-modal/tabs/embed-tab.tsx
@@ -63,7 +63,7 @@ import Image from 'next/image';
 import { Tabs, TabsContent, TabsList } from '@/components/ui/tabs';
 import { TabsTrigger } from '@/components/tabs';
 import { Label } from '@/components/ui/label';
-import { MENTOR_VISIBILITY } from '@/lib/constants';
+import { MENTOR_VISIBILITY, QUERY_PARAMS } from '@/lib/constants';
 import type { ChatMode } from '@iblai/iblai-js/web-utils';
 import { toast as sonnerToast } from 'sonner';
 import { cn } from '@/lib/utils';
@@ -1706,7 +1706,7 @@ export function EmbedTab() {
                     <iframe
                       id="embed-mentor-preview"
                       title="embed-mentor-preview"
-                      src={`${window.location.origin}/platform/${tenantKey}/${mentorId}?mentor=${mentorId}&embed=true&internalPreview=true&tenant=${tenantKey}&mode=anonymous&chat=${mode}`}
+                      src={`${window.location.origin}/platform/${tenantKey}/${mentorId}?mentor=${mentorId}&${QUERY_PARAMS.EMBED}=true&${QUERY_PARAMS.INTERNAL_PREVIEW}=true&${QUERY_PARAMS.TENANT}=${tenantKey}&mode=anonymous&chat=${mode}`}
                       style={{
                         height: '100%',
                         minHeight: '580px',

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-08-18 | 665 checkpoints (634 covered, 8 pending/fixme, 11 not-reproducible in default env, 12 deprecated) | 71 journeys (70 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-08-25 | 669 checkpoints (638 covered, 8 pending/fixme, 11 not-reproducible in default env, 12 deprecated) | 72 journeys (71 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -1540,3 +1540,28 @@ mentor (see the checkpoint description below for why).
 - [x] tal-04: Admin adds a per-user spend limit through the Agent Limits manage popup's nested "Per User" sub-tab / user-cap modal (`addUserSpendLimitFromTenantBilling`); reopening the popup confirms the user's row persisted server-side
 - [x] tal-05: Admin deletes the agent spend limit through the manage popup's confirm dialog (local `deleteAgentCapAndAwaitResponse` helper, network-response-gated — see the isolation note above); the tenant-wide unfiltered list only holds configured caps, so the row disappears entirely
 - [x] tal-01: Admin filters Agent Limits to an ALREADY-INDEXED mentor (broad query "E2E Mentor" against the search-index-backed autocomplete, sampling up to 5 results for the first capless one) — the ONE checkpoint that depends on that index, which lags mentor creation by DAYS on this backend (a known product limitation, not a test bug, reported upstream separately — a freshly-created mentor is never searchable in time, so this borrows a mentor from a past run instead of retrying its own) — sees the "Set Spend Limit" empty state, creates that mentor's spend limit (alert-only) from the popup, the row lists it, and the cap is removed again in an unconditional `finally` block so the borrowed (shared-tenant) mentor is left exactly as found; if every sampled candidate already has a cap, verifies the filter → row-visible path on the first one instead (annotated, never a failure)
+
+---
+
+## Journey 70: Embed Tab Preview Must Not Leak Embed Mode Into The App (4 checkpoints) — `journeys/70-embed-preview-must-not-leak-embed-mode.spec.ts`
+
+**Source files:** `lib/embed-context.ts`, `hooks/use-embed-mode.ts`, `providers/index.tsx`, `components/modals/edit-mentor-modal/tabs/embed-tab.tsx`, `app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx`, `app/platform/[tenantKey]/[mentorId]/_components/nav-bar/index.tsx`, `lib/constants.ts`
+
+The inverse of journey 58. Journey 58 guards that the FULL sidebar never leaks
+into a genuine embed; this one guards that the EMBED shell never leaks into the
+full app. A fix that over-corrects either way breaks the other, so both assert
+through the same `SidebarPage` helpers.
+
+The bug: `sessionStorage` is scoped to the tab, not the browsing context, so
+the Embed tab's same-origin `?embed=true&internalPreview=true` preview iframe
+mirrored `ibl:embed-context` into the HOST tab's store. `useEmbedMode` falls
+back to that stored copy when the URL has no embed param, so after visiting the
+Embed tab the next re-render — clicking "New Chat" — collapsed the whole admin
+app into the 3-icon embed rail on a query-less URL, and stayed that way for the
+lifetime of the tab. Real customer embeds are cross-origin and were never
+affected; only the internal preview could reach our storage.
+
+- [x] epl-01: Opening Edit Agent → Embed mounts the same-origin `?embed=true&internalPreview=true` preview iframe WITHOUT writing `ibl:embed-context` into the host tab's sessionStorage (guard 1: `persistEmbedContextFromUrl` no-ops for the internal preview) — polled, not read once, since the old write happened in an effect several seconds after the tab rendered
+- [x] epl-02: After visiting the Embed tab and closing the dialog, clicking "New Chat" keeps the FULL admin sidebar (Agents, Workflows, Projects, Analytics, Support) instead of collapsing to the embed rail, and does not append `embed=true` to the app URL (a poisoned tab also fed `embedContextQuery()`, writing the corruption into its own navigations)
+- [x] epl-03: The full app survives a reload after the Embed tab was visited — the old bug was sticky for the lifetime of the tab because sessionStorage outlived the navigation
+- [x] epl-04: A top-level (non-iframed) tab ignores an `ibl:embed-context` entry it did not get from its own URL, across both a re-render (New Chat) and a reload (guard 2: `readStoredEmbedContext` requires `isInIframe`) — planted directly, so the read-side guard is covered even if some future same-origin iframe starts writing the key again

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "lastUpdated": "2026-08-13",
+  "lastUpdated": "2026-08-25",
   "summary": {
-    "totalCheckpoints": 665,
-    "coveredCheckpoints": 634,
+    "totalCheckpoints": 669,
+    "coveredCheckpoints": 638,
     "deprecatedCheckpoints": 12,
     "notReproducibleCheckpoints": 11,
     "pendingCheckpoints": 8,
     "percent": 100,
-    "totalJourneys": 71,
-    "activeJourneys": 70
+    "totalJourneys": 72,
+    "activeJourneys": 71
   },
   "journeys": [
     {
@@ -4206,6 +4206,42 @@
         {
           "id": "tal-01",
           "description": "Admin filters Agent Limits to an ALREADY-INDEXED mentor (broad query \"E2E Mentor\" against the search-index-backed autocomplete, sampling up to 5 results for the first capless one) — the ONE checkpoint that depends on that index, which lags mentor creation by DAYS on this backend (a known product limitation, not a test bug, reported upstream separately; a freshly-created mentor is never searchable in time, so this borrows a mentor from a past run instead of retrying its own) — sees the \"Set Spend Limit\" empty state, creates that mentor's spend limit (alert-only) from the popup, the row lists it, and the cap is removed again in an unconditional finally-block so the borrowed (shared-tenant) mentor is left exactly as found; if every sampled candidate already has a cap, verifies the filter -> row-visible path on the first one instead (annotated, never a failure)",
+          "status": "covered"
+        }
+      ]
+    },
+    {
+      "id": "embed-preview-embed-mode-leak",
+      "name": "Embed Tab Preview Must Not Leak Embed Mode Into The App",
+      "spec": "70-embed-preview-must-not-leak-embed-mode.spec.ts",
+      "sourceFiles": [
+        "lib/embed-context.ts",
+        "hooks/use-embed-mode.ts",
+        "providers/index.tsx",
+        "components/modals/edit-mentor-modal/tabs/embed-tab.tsx",
+        "app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx",
+        "app/platform/[tenantKey]/[mentorId]/_components/nav-bar/index.tsx",
+        "lib/constants.ts"
+      ],
+      "checkpoints": [
+        {
+          "id": "epl-01",
+          "description": "Opening Edit Agent → Embed mounts the same-origin `?embed=true&internalPreview=true` preview iframe WITHOUT writing `ibl:embed-context` into the host tab's sessionStorage (guard 1: persistEmbedContextFromUrl no-ops for the internal preview)",
+          "status": "covered"
+        },
+        {
+          "id": "epl-02",
+          "description": "After visiting the Embed tab and closing the dialog, clicking \"New Chat\" keeps the FULL admin sidebar (Agents, Workflows, Projects, Analytics, Support) instead of collapsing to the 3-icon embed rail, and does not append `embed=true` to the app URL",
+          "status": "covered"
+        },
+        {
+          "id": "epl-03",
+          "description": "The full app survives a reload after the Embed tab was visited — the old bug was sticky for the lifetime of the tab because sessionStorage outlived the navigation",
+          "status": "covered"
+        },
+        {
+          "id": "epl-04",
+          "description": "A top-level (non-iframed) tab ignores an `ibl:embed-context` entry it did not get from its own URL, across both a re-render (New Chat) and a reload (guard 2: readStoredEmbedContext requires isInIframe)",
           "status": "covered"
         }
       ]

--- a/e2e/journeys/70-embed-preview-must-not-leak-embed-mode.spec.ts
+++ b/e2e/journeys/70-embed-preview-must-not-leak-embed-mode.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Journey 70 — Embed Tab Preview Must Not Leak Embed Mode Into The App
+ *
+ * Regression guard for a bug where opening the Edit Agent → Embed tab flipped
+ * the SURROUNDING app into the stripped-down embed shell. After visiting that
+ * tab, the next re-render (clicking "New Chat" is the common one) replaced the
+ * full admin sidebar with the 3-icon embed rail — no Agents, Workflows,
+ * Projects, Analytics, Management, no LLM selector, no User/Admin toggle —
+ * on a plain mentor URL with no query string at all. It then survived a
+ * reload, so the tab stayed broken until it was closed.
+ *
+ * ── Root cause ────────────────────────────────────────────────────────────
+ *
+ * `sessionStorage` is scoped to the TAB, not to the browsing context, so a
+ * SAME-ORIGIN iframe writes into its parent tab's store. The Embed tab renders
+ * a live preview of the app at `?embed=true&internalPreview=true`
+ * (`embed-tab.tsx`), pointed at `window.location.origin`. That preview booted a
+ * full copy of the app, whose `Providers` effect called
+ * `persistEmbedContextFromUrl()` (`lib/embed-context.ts`) and mirrored
+ * `ibl:embed-context` into what was really the HOST tab's storage.
+ *
+ * `useEmbedMode` checks the URL first, then falls back to that stored copy —
+ * so with the key present, every subsequent render of the host app resolved to
+ * embed mode. It is read during render and is not reactive, which is why the
+ * flip surfaced on the next re-render rather than immediately.
+ *
+ * Real customer embeds are CROSS-origin (the `agent-ai` web component iframes
+ * mentorai from the host site), so their storage is partitioned away and they
+ * never had this problem — only the internal preview did.
+ *
+ * ── The fix (lib/embed-context.ts) ────────────────────────────────────────
+ *
+ *   1. `persistEmbedContextFromUrl()` no-ops when `internalPreview=true`, so
+ *      the preview never writes at all.
+ *   2. `readStoredEmbedContext()` returns null unless `isInIframe()`, so a
+ *      top-level tab ignores a stored copy no matter who wrote it.
+ *
+ * Test 1 covers guard 1 via the real UI. Test 2 covers guard 2 by planting the
+ * key directly — that half must hold even if some future same-origin iframe
+ * starts writing it again.
+ *
+ * ── Why assert the FULL sidebar (the inverse of journey 58) ───────────────
+ *
+ * Journey 58 guards the opposite direction: inside a genuine embed, the full
+ * sidebar must NEVER leak to students. This journey guards that the embed
+ * shell must never leak into the full app. The two are complementary — a fix
+ * that over-corrects either way breaks the other, so both assert on the same
+ * `SidebarPage` helpers.
+ */
+
+import { test, expect } from '../fixtures/mentor-test';
+import { navigateToMentorApp, checkAdminStatus } from '../utils/auth';
+import { waitForPageReady } from '../utils/resilient';
+
+/** The sessionStorage key the embed context is mirrored into. */
+const EMBED_CONTEXT_KEY = 'ibl:embed-context';
+
+/**
+ * Asserts the FULL admin app chrome is present: the sections that embed mode
+ * strips must all still be there. This is the assertion that failed before the
+ * fix — every one of these disappeared once the tab was poisoned.
+ */
+async function assertFullAppSidebar(
+  sidebarPage: import('../page-objects/sidebar.page').SidebarPage,
+  context: string,
+): Promise<void> {
+  await expect(sidebarPage.newChatButton).toBeVisible({ timeout: 15_000 });
+
+  for (const name of ['Agents', 'Workflows', 'Projects', 'Analytics']) {
+    const visible = await sidebarPage.isSectionTriggerVisible(name, 10_000);
+    expect(
+      visible,
+      `"${name}" must still be PRESENT in the full app (${context})`,
+    ).toBe(true);
+  }
+
+  const supportVisible = await sidebarPage.isSupportLinkVisible(10_000);
+  expect(
+    supportVisible,
+    `Support link must still be PRESENT in the full app (${context})`,
+  ).toBe(true);
+}
+
+/** Reads the mirrored embed context out of the HOST tab's sessionStorage. */
+async function readEmbedContext(
+  page: import('@playwright/test').Page,
+): Promise<string | null> {
+  return page.evaluate(
+    (key) => window.sessionStorage.getItem(key),
+    EMBED_CONTEXT_KEY,
+  );
+}
+
+test.describe('Journey 70: Embed preview must not leak embed mode', () => {
+  test.setTimeout(180_000);
+
+  test.beforeEach(async ({ page, createMentorPage }) => {
+    await navigateToMentorApp(page);
+    const isAdmin = await checkAdminStatus(page);
+    if (!isAdmin) {
+      test.skip(true, 'Requires admin access to create a mentor');
+      return;
+    }
+
+    // Per-project convention: each test creates its own fresh agent, so the
+    // Embed tab opens against a mentor no other test is mutating.
+    await createMentorPage.openAndCreate();
+    await waitForPageReady(page);
+  });
+
+  test('opening the Embed tab does not flip the app into embed mode on the next New Chat', async ({
+    page,
+    sidebarPage,
+    editMentorPage,
+  }) => {
+    // ── Step 1: baseline — the full app, and a clean store ───────────────────
+    await assertFullAppSidebar(sidebarPage, 'before opening the Embed tab');
+    expect(
+      await readEmbedContext(page),
+      'embed context must not be set before the Embed tab is opened',
+    ).toBeNull();
+
+    // ── Step 2: open Edit Agent → Embed, which mounts the preview iframe ─────
+    await editMentorPage.open('Embed');
+
+    // Wait for the preview iframe to actually boot. Without this the test can
+    // pass vacuously: the old code only poisoned the store once the iframe's
+    // own `Providers` effect ran, several seconds after the tab rendered.
+    const preview = page.locator('iframe#embed-mentor-preview');
+    await expect(preview).toBeAttached({ timeout: 30_000 });
+    const previewFrame = preview.contentFrame();
+    await expect(
+      previewFrame.locator('body'),
+      'the preview iframe must render the app before we assert on storage',
+    ).toBeVisible({ timeout: 60_000 });
+
+    // ── Step 3: guard 1 — the preview must not have written to our store ─────
+    // Poll rather than read once: the write was an effect, so a single early
+    // read could miss it and pass against the buggy build.
+    await expect
+      .poll(() => readEmbedContext(page), {
+        message:
+          'the same-origin preview iframe must NEVER write ibl:embed-context into the host tab',
+        timeout: 20_000,
+        intervals: [1_000, 2_000, 3_000],
+      })
+      .toBeNull();
+
+    // ── Step 4: close the dialog and click New Chat — the reported trigger ───
+    await editMentorPage.close();
+    await waitForPageReady(page);
+
+    await sidebarPage.newChatButton.click();
+
+    // ── Step 5: the regression assertion ────────────────────────────────────
+    await assertFullAppSidebar(sidebarPage, 'after clicking New Chat');
+
+    // The URL must still be a plain mentor URL — a poisoned tab also fed
+    // `embedContextQuery()`, which appended `?embed=true` to the app's own
+    // navigations and wrote the corruption into the URL.
+    expect(
+      new URL(page.url()).searchParams.get('embed'),
+      'New Chat must not add embed=true to the app URL',
+    ).toBeNull();
+
+    // ── Step 6: and it must not come back after a reload ────────────────────
+    await page.reload();
+    await waitForPageReady(page);
+    await assertFullAppSidebar(sidebarPage, 'after reload');
+  });
+
+  test('a top-level tab ignores a stored embed context it did not get from its own URL', async ({
+    page,
+    sidebarPage,
+  }) => {
+    await assertFullAppSidebar(sidebarPage, 'before planting the stored copy');
+
+    // Plant exactly what the preview iframe used to write. This models any
+    // same-origin iframe writing the key — the read-side guard must hold
+    // regardless of who the writer was.
+    await page.evaluate(
+      ([key, value]) => window.sessionStorage.setItem(key, value),
+      [
+        EMBED_CONTEXT_KEY,
+        JSON.stringify({ embed: 'true', mode: 'anonymous' }),
+      ] as const,
+    );
+
+    expect(
+      await readEmbedContext(page),
+      'the stored copy must actually be present for this test to mean anything',
+    ).not.toBeNull();
+
+    // Re-render the shell the same way the reported bug did.
+    await sidebarPage.newChatButton.click();
+    await assertFullAppSidebar(
+      sidebarPage,
+      'after New Chat with a planted stored copy',
+    );
+
+    // A reload re-reads the store from scratch — the guard must hold there too.
+    await page.reload();
+    await waitForPageReady(page);
+    await assertFullAppSidebar(
+      sidebarPage,
+      'after reload with a planted stored copy',
+    );
+  });
+});

--- a/hooks/use-is-preview-mode.ts
+++ b/hooks/use-is-preview-mode.ts
@@ -2,6 +2,7 @@ import { useSearchParams } from 'next/navigation';
 import { useMentorSettings } from './use-mentors/use-mentor-settings';
 import { useUsername } from './use-user';
 import { useAppSelector } from '@/lib/hooks';
+import { QUERY_PARAMS } from '@/lib/constants';
 import { selectTokenEnabled } from '@iblai/iblai-js/web-utils';
 
 export function useIsPreviewMode(): boolean {
@@ -18,6 +19,7 @@ export function useIsPreviewMode(): boolean {
     !tokenEnabled;
 
   return (
-    searchParams.get('internalPreview') === 'true' || userIsNotAllowedToChat
+    searchParams.get(QUERY_PARAMS.INTERNAL_PREVIEW) === 'true' ||
+    userIsNotAllowedToChat
   );
 }

--- a/lib/__tests__/embed-context.test.ts
+++ b/lib/__tests__/embed-context.test.ts
@@ -14,12 +14,26 @@ function setUrl(pathWithQuery: string) {
   window.history.replaceState({}, '', pathWithQuery);
 }
 
+/** Model an iframe: `window.top` is some other browsing context. */
+function framed() {
+  Object.defineProperty(window, 'top', {
+    value: { name: 'host-page' },
+    configurable: true,
+  });
+}
+
+/** Model a standalone tab: `window.top` is this window. */
+function topLevel() {
+  Object.defineProperty(window, 'top', { value: window, configurable: true });
+}
+
 const EMBED_URL =
   '/platform/acme/bot-1?embed=true&mode=anonymous&component=chat&extra-body-classes=iframed-externally';
 
 beforeEach(() => {
   window.sessionStorage.clear();
   setUrl('/');
+  topLevel();
 });
 
 describe('not in embed mode', () => {
@@ -64,6 +78,7 @@ describe('reading embed context from the live URL', () => {
 describe('surviving a hard navigation that wipes the query (the bug)', () => {
   it('recovers embed mode from sessionStorage after window.location goes to "/"', () => {
     // 1. Embedded iframe loads with the params and persists them.
+    framed();
     setUrl(EMBED_URL);
     persistEmbedContextFromUrl();
 
@@ -81,6 +96,7 @@ describe('surviving a hard navigation that wipes the query (the bug)', () => {
   });
 
   it('the live URL wins over a stale stored copy', () => {
+    framed();
     setUrl('/platform/acme/bot-1?embed=true&component=analytics-overview');
     persistEmbedContextFromUrl();
     // A fresh embedded load with a different component.
@@ -119,6 +135,7 @@ describe('appendEmbedContext', () => {
 
 describe('resilience', () => {
   it('ignores a stored copy whose embed flag is not "true"', () => {
+    framed();
     setUrl('/');
     window.sessionStorage.setItem(
       'ibl:embed-context',
@@ -129,6 +146,7 @@ describe('resilience', () => {
   });
 
   it('ignores malformed JSON in storage', () => {
+    framed();
     setUrl('/');
     window.sessionStorage.setItem('ibl:embed-context', '{not json');
     expect(getEmbedContext()).toBeNull();
@@ -143,6 +161,51 @@ describe('resilience', () => {
       });
     expect(() => persistEmbedContextFromUrl()).not.toThrow();
     spy.mockRestore();
+  });
+});
+
+describe('the Embed tab preview must not leak embed mode into the tab', () => {
+  const PREVIEW_URL =
+    '/platform/acme/bot-1?mentor=bot-1&embed=true&internalPreview=true&tenant=acme&mode=anonymous&chat=default';
+
+  it('the internal preview never writes to sessionStorage', () => {
+    framed();
+    setUrl(PREVIEW_URL);
+    persistEmbedContextFromUrl();
+    expect(window.sessionStorage.getItem('ibl:embed-context')).toBeNull();
+  });
+
+  it('the internal preview is still in embed mode via its own URL', () => {
+    framed();
+    setUrl(PREVIEW_URL);
+    expect(isEmbedMode()).toBe(true);
+  });
+
+  it('a top-level tab ignores a stored copy a same-origin iframe wrote', () => {
+    window.sessionStorage.setItem(
+      'ibl:embed-context',
+      JSON.stringify({ embed: 'true', mode: 'anonymous' }),
+    );
+    setUrl('/platform/acme/bot-1');
+    expect(isEmbedMode()).toBe(false);
+    expect(getEmbedContext()).toBeNull();
+    expect(embedContextQuery()).toBe('');
+  });
+
+  it('opening the Embed tab leaves the surrounding app out of embed mode', () => {
+    // The app tab sits on a plain chat URL.
+    setUrl('/platform/acme/bot-1');
+    expect(isEmbedMode()).toBe(false);
+
+    // The preview iframe boots inside it and runs its own Providers effect.
+    framed();
+    setUrl(PREVIEW_URL);
+    persistEmbedContextFromUrl();
+
+    // Back in the top-level tab: still the full app, on re-render and reload.
+    topLevel();
+    setUrl('/platform/acme/bot-1');
+    expect(isEmbedMode()).toBe(false);
   });
 });
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,6 +25,8 @@ export const QUERY_PARAMS = {
   APP: 'app',
   REDIRECT_TO: 'redirect-to',
   TENANT: 'tenant',
+  EMBED: 'embed',
+  INTERNAL_PREVIEW: 'internalPreview',
 };
 
 // URL patterns

--- a/lib/embed-context.ts
+++ b/lib/embed-context.ts
@@ -9,13 +9,22 @@
 // the parent (which is why logging out and back in "fixes" it).
 //
 // To make embed mode survive ANY navigation — including hard resets — we mirror
-// the params into `sessionStorage`, which is scoped per browsing context (the
-// iframe), persists across same-origin page loads within that context, and is
-// storage-partitioned so it never leaks into a standalone (first-party) tab.
-// Readers prefer the live URL and fall back to the stored copy.
+// the params into `sessionStorage` and let readers fall back to the stored copy
+// when the live URL has none.
+//
+// `sessionStorage` is scoped to the TAB, not to the browsing context: a
+// same-origin iframe writes into its parent tab's store. A real host embed is
+// cross-origin, so its storage is partitioned away from ours — but the Embed
+// tab's own `internalPreview` iframe is same-origin, and its write would flip
+// the surrounding app into embed mode on the next render. Hence the two guards
+// below: we never persist from the internal preview, and we only trust the
+// stored copy when this document is actually framed (`isInIframe`).
+
+import { QUERY_PARAMS } from '@/lib/constants';
+import { isInIframe } from '@/lib/utils';
 
 export const EMBED_CONTEXT_KEYS = [
-  'embed',
+  QUERY_PARAMS.EMBED,
   'mode',
   'component',
   'extra-body-classes',
@@ -25,10 +34,19 @@ const STORAGE_KEY = 'ibl:embed-context';
 
 type EmbedContext = Record<string, string>;
 
+/** The Embed tab's same-origin preview iframe, which must never persist. */
+function isInternalPreview(): boolean {
+  return (
+    new URLSearchParams(window.location.search).get(
+      QUERY_PARAMS.INTERNAL_PREVIEW,
+    ) === 'true'
+  );
+}
+
 function readUrlEmbedContext(): EmbedContext | null {
   if (typeof window === 'undefined') return null;
   const params = new URLSearchParams(window.location.search);
-  if (params.get('embed') !== 'true') return null;
+  if (params.get(QUERY_PARAMS.EMBED) !== 'true') return null;
   const ctx: EmbedContext = {};
   for (const key of EMBED_CONTEXT_KEYS) {
     const value = params.get(key);
@@ -38,12 +56,12 @@ function readUrlEmbedContext(): EmbedContext | null {
 }
 
 function readStoredEmbedContext(): EmbedContext | null {
-  if (typeof window === 'undefined') return null;
+  if (!isInIframe()) return null;
   try {
     const raw = window.sessionStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as EmbedContext;
-    return parsed?.embed === 'true' ? parsed : null;
+    return parsed?.[QUERY_PARAMS.EMBED] === 'true' ? parsed : null;
   } catch {
     return null;
   }
@@ -55,6 +73,7 @@ function readStoredEmbedContext(): EmbedContext | null {
  * after they've wiped the URL query. No-op when the URL isn't in embed mode.
  */
 export function persistEmbedContextFromUrl(): void {
+  if (typeof window === 'undefined' || isInternalPreview()) return;
   const ctx = readUrlEmbedContext();
   if (!ctx) return;
   try {


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## The bug

- Clicking **New Chat** collapsed the whole app into the stripped-down embed
  shell — 3-icon rail instead of the full sidebar, no Agents / Workflows /
  Projects / Analytics / Management, no LLM selector, no User/Admin toggle,
  no credits, no notifications.
- It happened on a plain mentor URL with **no query string at all**.
- Preceded by visiting **Edit Agent → Embed** at any point earlier in the
  session. New Chat was just the first thing that re-rendered afterwards —
  any re-render did it.
- **Sticky**: survived a reload, so the tab stayed broken until it was closed.
  Logging out and back in "fixed" it, which is what made it look random.
  
https://github.com/user-attachments/assets/826acab9-3c22-4e1e-b1ed-e56ed56a241f

## Root cause

- `sessionStorage` is scoped to the **tab**, not the browsing context, so a
  **same-origin** iframe writes into its parent tab's store.
- The Embed tab renders a live preview iframe at
  `?embed=true&internalPreview=true` pointed at `window.location.origin`
  (`embed-tab.tsx:1709`).
- That preview boots a full copy of the app. Its `Providers` effect calls
  `persistEmbedContextFromUrl()`, mirroring `ibl:embed-context` into what is
  really the **host tab's** storage.
- `useEmbedMode` checks the URL first, then falls back to that stored copy —
  so with the key present, every later render of the host app resolved to
  embed mode. It's read during render and isn't reactive, which is why the
  flip surfaced on the next re-render rather than immediately.
- It also fed `embedContextQuery()` (`providers/index.tsx:294,302`), which
  appended `embed=true` to the app's own navigations and wrote the corruption
  into the URL.
- **Real customer embeds were never affected** — the `agent-ai` web component
  iframes mentorai cross-origin, so its storage is partitioned away from ours.
  Only the internal preview could reach it.
  
  ## Screenshots
https://github.com/user-attachments/assets/2c775ae7-2568-44b1-80f2-6ef58fe0e5e5


