### PR TITLE
docs: say "agent" not "mentor", and title every page in Title Case

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# Immutable, deployment-ID static hosting
+# Immutable, Deployment-ID Static Hosting
 
 Eliminates the version-skew problem (a browser on build A fetching a chunk from
 a node on build B → `ChunkLoadError`) that today forces us to drain LB backend

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,8 +120,8 @@ pnpm test:e2e:headed   # run in a visible browser
 os/
 ├── app/                        # Next.js App Router
 │   ├── platform/               # Main authenticated routes
-│   │   └── [tenantKey]/        # Multi-tenant routing (mentor pages nest below)
-│   ├── create-mentor/          # Mentor creation wizard
+│   │   └── [tenantKey]/        # Multi-tenant routing (agent pages nest below)
+│   ├── create-mentor/          # Agent creation wizard
 │   ├── share/                  # Public shared chats
 │   ├── reports/                # Analytics report export
 │   ├── provider-association/   # Stripe / OAuth provider linking
@@ -143,9 +143,9 @@ os/
 │   ├── canvas/                 # Document canvas (artifacts)
 │   ├── header/                 # Top app bar
 │   ├── sidebar/                # Nav + project switcher
-│   ├── mentors/                # Mentor cards, lists, picker
+│   ├── mentors/                # Agent cards, lists, picker
 │   ├── modals/                 # All modal dialogs
-│   │   └── edit-mentor-modal/  # Mentor settings (LLM, datasets, access, …)
+│   │   └── edit-mentor-modal/  # Agent settings (LLM, datasets, access, …)
 │   ├── projects/               # Project management
 │   ├── welcome-chat/           # Landing / welcome screen
 │   ├── workflows/              # Workflow builder UI
@@ -160,7 +160,7 @@ os/
 │   ├── auth/                   # Auth slice
 │   ├── chat/                   # Chat state machine
 │   ├── chat-input/             # Input model
-│   ├── mentors/                # Mentor CRUD
+│   ├── mentors/                # Agent CRUD
 │   ├── messages/               # Message normalization
 │   ├── navigation/             # Sidebar + route state
 │   ├── provider-association/   # Stripe / OAuth flow
@@ -172,7 +172,7 @@ os/
 │
 ├── hooks/                      # 151 custom React hooks
 │   ├── use-voice-chat.ts       # LiveKit voice integration
-│   ├── use-mentors.ts          # Mentor CRUD operations
+│   ├── use-mentors.ts          # Agent CRUD operations
 │   ├── use-history.ts          # Chat history management
 │   ├── use-datasets.ts         # Training data management
 │   ├── subscription/           # Subscription hooks
@@ -221,7 +221,7 @@ The app uses **[@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js)*
 | `NEXT_PUBLIC_IBL_LIVE_KIT_SERVER_URL`              | Yes      | LiveKit voice server URL                                                                             |
 | `NEXT_PUBLIC_MENTOR_URL`                           | Yes      | This app's public URL                                                                                |
 | `NEXT_PUBLIC_IBL_PLATFORM`                         | Yes      | Platform type (`mentor`)                                                                             |
-| `NEXT_PUBLIC_IBL_TEMPLATE_MENTOR`                  | Yes      | Default mentor template slug                                                                         |
+| `NEXT_PUBLIC_IBL_TEMPLATE_MENTOR`                  | Yes      | Default agent template slug                                                                          |
 | `NEXT_PUBLIC_STRIPE_ENABLED`                       | No       | Enable Stripe billing (`true`/`false`)                                                               |
 | `NEXT_PUBLIC_IBL_ALLOW_FREE_TRIAL_BANNER`          | No       | Show free trial banner                                                                               |
 | `NEXT_PUBLIC_ENABLE_ADVERTISING`                   | No       | Enable advertising features                                                                          |
@@ -232,12 +232,12 @@ The app uses **[@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js)*
 | `NEXT_PUBLIC_DISABLED_ANALYTICS_REPORTS`           | No       | Pipe-separated analytics reports to hide                                                             |
 | `NEXT_PUBLIC_MENTOR_TRAINING_MAXIMUM_FILE_SIZE`    | No       | Max dataset upload size in MB                                                                        |
 | `NEXT_PUBLIC_MAXIMUM_CHARACTER_SIZE_TO_COPY`       | No       | Max pasted characters before text becomes a .txt upload                                              |
-| `NEXT_PUBLIC_SHOW_BASE_MENTOR`                     | No       | Show the base/template mentor in the picker                                                          |
-| `NEXT_PUBLIC_MENTOR_SETTINGS_DISCLAIMER`           | No       | Disclaimer line shown under mentor settings                                                          |
+| `NEXT_PUBLIC_SHOW_BASE_MENTOR`                     | No       | Show the base/template agent in the picker                                                           |
+| `NEXT_PUBLIC_MENTOR_SETTINGS_DISCLAIMER`           | No       | Disclaimer line shown under agent settings                                                           |
 | `NEXT_PUBLIC_ENABLE_GRAVATAR_ON_PROFILE_PIC`       | No       | Fall back to Gravatar when no profile pic                                                            |
 | `NEXT_PUBLIC_DEFAULT_EMBED_CSS_URL`                | No       | CSS injected into iframe embeds                                                                      |
 | `NEXT_PUBLIC_IBL_ENABLE_SPECIAL_LOGO_WHEN_IFRAMED` | No       | Swap the logo when running inside an iframe                                                          |
-| `NEXT_PUBLIC_IFRAME_FROM_OLD_MENTOR`               | No       | Legacy mentor URL allowed to iframe this app                                                         |
+| `NEXT_PUBLIC_IFRAME_FROM_OLD_MENTOR`               | No       | Legacy agent URL allowed to iframe this app                                                          |
 | `NEXT_PUBLIC_HELP_CENTER_URL`                      | No       | Help center link in the UI                                                                           |
 | `NEXT_PUBLIC_SUPPORT_EMAIL`                        | No       | Support email shown in dialogs                                                                       |
 | `NEXT_PUBLIC_APP_BANNER_TEXT`                      | No       | Top app banner copy                                                                                  |

--- a/docs/macos-builds.md
+++ b/docs/macos-builds.md
@@ -1,4 +1,4 @@
-# macOS builds: Mac App Store vs. Developer ID
+# macOS Builds: Mac App Store vs. Developer ID
 
 The app ships in **two macOS variants** because Cowork (GhostOS) and the
 Mac App Store are mutually exclusive.

--- a/docs/platform-deployment.md
+++ b/docs/platform-deployment.md
@@ -1,4 +1,4 @@
-# Deploying ibl.ai/os against our backend
+# Deploying ibl.ai/os against Our Backend
 
 This guide shows how to ship every surface **Web, macOS, Windows/Surface, Linux, iOS, Android** (and the Chrome extension) — pointed at ibl.ai backend.
 

--- a/docs/running-the-app.md
+++ b/docs/running-the-app.md
@@ -1,4 +1,4 @@
-# Running the Mentor App
+# Running the App
 
 ## Development Mode
 

--- a/docs/standalone-deployment.md
+++ b/docs/standalone-deployment.md
@@ -174,7 +174,7 @@ Handles server startup with error suppression:
 ### GitHub Actions Example
 
 ```yaml
-- name: Build mentor app
+- name: Build the app
   run: |
     cd apps/mentor
     pnpm build


### PR DESCRIPTION
Two passes over `docs/`. Both are wording only — no code, no behaviour, no identifiers.

These pages are mirrored and published at [ibl.ai/developer/os](https://ibl.ai/developer/os), so both problems are visible to every reader of the developer docs, and the page titles become the site's sidebar labels.

---

## 1. "agent", not "mentor"

The docs describe the product's assistants as **"mentors"**. The current name is **agent**. This changes **12 strings a person reads** and nothing else.

**Deliberately NOT changed** — every functional identifier is byte-for-byte alone, because renaming one would break a real path, link or config contract:

| Kept as-is | Why |
|---|---|
| `apps/mentor`, `create-mentor/`, `edit-mentor-modal/`, `use-mentors.ts` | real directories and files |
| `NEXT_PUBLIC_MENTOR_URL` and the other `NEXT_PUBLIC_*MENTOR*` vars | the app's env contract |
| `NEXT_PUBLIC_IBL_PLATFORM=mentor` | a literal value the app expects |
| `mentorai.iblai.app`, `iblai://mentorai/*`, `ai.ibl.mentorai` | live domain, URL scheme, Play Store package |
| `mentor-app` image tag, `panel.html`'s `mentorurl`, `/mentor` base path | real build and config artifacts |

Verified mechanically: every URL, env-var name, package id, docker tag and path token in the touched files is identical before and after.

What changed: 6 tree-diagram comments, 4 env-var *description* cells, 1 page title, 1 Actions step name. Table padding preserved, so the diff is words only.

## 2. Title Case on every page

Three of the ten page titles were sentence case while the rest were Title Case, so the published sidebar mixed styles:

| Before | After |
|---|---|
| Immutable, deployment-ID static hosting | Immutable, Deployment-ID Static Hosting |
| macOS builds: Mac App Store vs. Developer ID | macOS Builds: Mac App Store vs. Developer ID |
| Deploying ibl.ai/os against our backend | Deploying ibl.ai/os against Our Backend |

The convention the untouched titles already follow is Chicago — capitalise the principal words, leave articles, conjunctions and prepositions lowercase. That is why `with` ("Handling Existing Users **with** Cached AASA Files"), `and` and `the` are lowercase in the titles left alone, and why `against` stays lowercase here.

Brand casing preserved verbatim: `macOS`, `ibl.ai/os`, `iOS`, `AASA`, `vs.`. Nothing in the repo links to any of these three headings by anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XddSoBHGcpJEAw3kbQo2PX