### PR TITLE
fix(ci): remove the paths filter that deadlocks the required PR Validation check

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -4,25 +4,14 @@ on:
   pull_request:
     branches: [main]
     types: [labeled, unlabeled, synchronize]
-    paths:
-      - 'app/**'
-      - 'components/**'
-      - 'hooks/**'
-      - 'lib/**'
-      - 'store/**'
-      - 'styles/**'
-      - 'public/**'
-      - 'e2e/**'
-      - 'src-tauri/**'
-      - '__tests__/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'next.config.*'
-      - 'tsconfig*.json'
-      - 'tailwind.config.*'
-      - 'postcss.config.*'
-      - 'vitest.config.*'
-      - 'playwright.config.*'
+    # NO `paths:` filter — deliberately. `pr-gate.yml` posts the required
+    # `PR Validation` status as *pending* whenever the run-tests label is present,
+    # then resolves it from this workflow's `workflow_run` completion. A paths
+    # filter here makes the two disagree: a labelled PR touching no listed path
+    # never starts this workflow, so `workflow_run` never fires and the required
+    # status stays pending forever with no way to clear it (os#462 sat blocked on
+    # `providers/index.tsx`, which no pattern matched). The label is already the
+    # deliberate opt-in; a second, narrower gate here only creates that deadlock.
 
 run-name: 'PR E2E — mentor #${{ github.event.pull_request.number }} → stg1 (chrome)'
 


### PR DESCRIPTION
## Root cause

`pr-gate.yml` and `pr-e2e-tests.yml` gate on **different conditions**, so they can disagree — and when they do, the required check deadlocks.

`pr-gate.yml` decides on the **label alone**:

```js
if (!labels.includes('run-tests')) → state: 'failure'   // recoverable: add the label
else                               → state: 'pending'   // "Waiting for PR E2E Tests to complete..."
```

and only ever resolves that pending status from `workflow_run: ['PR E2E Tests (Required)'] types: [completed]`.

But this workflow fired on **label AND a `paths:` match**. For a labelled PR touching no listed path:

```
pr-gate       label present   → PR Validation = pending
pr-e2e-tests  paths no match  → never runs
workflow_run  never fires     → nothing ever clears the pending status
```

`PR Validation` is a **required** check with no terminal state, so the PR can never merge. The only escape is the "bypass rules" checkbox.

Note the asymmetry: the missing-label case sets `failure`, which the author can fix by adding the label. The paths mismatch sets `pending`, which **no action on the PR can clear**.

## The trigger vs the cause

os#462 changed `CHANGELOG.md`, `providers/index.tsx`, `providers/__tests__/index.test.tsx` and sat blocked for 5+ hours. None matched:

- `providers/**` was never in the list
- `__tests__/**` is **root-anchored** — it does not match `providers/__tests__/...`, which is exactly where someone adding tests would put them

Adding `providers/**` would unblock that one PR and leave the defect in place: the next PR touching any unlisted path deadlocks identically. The cause is that `pr-gate` assumes *label ⇒ e2e runs*, which the paths filter makes untrue.

## Fix

Drop `paths:` and let the `run-tests` label be the single source of truth — it is already the deliberate opt-in, so the filter was a second, narrower gate whose only distinct effect was to create this divergence. Both workflows now key on exactly the same condition, which makes the deadlock unrepresentable rather than merely unlikely.

The `gate` job (label + fork check) still short-circuits everything downstream, so an unlabelled PR remains cheap.

## Cost

Only labelled PRs whose files fall outside the old allowlist now run the suite. Those PRs today **hang forever instead of testing**, so this trades a deadlock for coverage that was intended in the first place — os#462 is a real code change to `providers/index.tsx` that should have been tested.

## Scope

Same defect, same fix, in **os** and **lms** (both have `pr-gate.yml` + an 18-entry filter). `iblai-web-frontend` has no `pr-gate.yml`, so it cannot deadlock this way and is left alone.

## Verification

- `ruby -ryaml` parses both files
- Only the `on.pull_request.paths` block changed — `types`, `branches`, jobs and every downstream gate are untouched
- Existing behaviour for unlabelled PRs is unchanged (`gate` job still blocks)