### PR TITLE
fix(pr-gate): defer only to a sibling run that is still running

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -113,12 +113,16 @@ jobs:
               return;
             }
 
-            // Never let an older run overwrite a newer one's verdict. Run ids increase
-            // monotonically, so a higher id for this same sha is strictly more recent.
+            // Never let an older run overwrite a newer one's verdict — but only defer to a
+            // sibling that is STILL RUNNING. A completed sibling has had its turn: if it was
+            // cancelled it wrote nothing and never will. Deferring on id alone deadlocked
+            // lms#232: the same-second double-fire cancelled the HIGHER-id run (…781) and the
+            // lower-id run (…626) survived and passed, so the passing verdict was never written
+            // and the check sat on "pending" with nothing left to move it.
             const { data: siblings } = await github.rest.actions.listWorkflowRuns({
               owner, repo, workflow_id: run.workflow_id, head_sha: sha, per_page: 100,
             });
-            if (siblings.workflow_runs.some(r => r.id > run.id)) {
+            if (siblings.workflow_runs.some(r => r.id > run.id && r.status !== 'completed')) {
               core.info(`newer run exists for ${sha.slice(0, 8)} — deferring to it`);
               return;
             }


### PR DESCRIPTION
**Fixes a deadlock introduced by the previous `pr-gate` fix** (lms#233 / os#473). It bit lms#232 within two hours of merging.

That fix added a stale-write guard: *if a sibling run with a higher id exists for this sha, defer to it.* The assumption was that the higher id is the run that will write the verdict. **It isn't.**

On lms#232, two labels applied in the same second created two runs. Concurrency cancelled the **higher**-id run (`…781`); the **lower**-id run (`…626`) survived and passed. When its `workflow_run` event fired:

```
17:49:25  newer run exists for 2e7d8a5e — deferring to it
```

…and it returned. The sibling it deferred to was cancelled and would never write. Nothing else could. `PR Validation` sat on **pending** with a fully green run behind it.

## The fix

One condition:

```diff
-            if (siblings.workflow_runs.some(r => r.id > run.id)) {
+            if (siblings.workflow_runs.some(r => r.id > run.id && r.status !== 'completed')) {
```

Defer only to a sibling that is **still running**. A completed run — whatever its conclusion — has already had its turn to write, so there is nothing to wait for. The guard still does its real job: if a genuinely newer run is mid-flight, the older result stays out of its way.

YAML parses, `actionlint` clean, both `github-script` bodies pass `node --check` wrapped as async functions.

`lms` and `os` are byte-identical here, so this goes to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYQu2C7bgYqgM13fmzaZnN
