### PR TITLE
fix(ci): make a mistyped release tag visible, and buildable

### DIFF
--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -1,0 +1,45 @@
+name: Tag Guard
+
+# A mistyped release tag used to produce NOTHING — no run, no annotation, no clue.
+# `trigger-docker-build.yml` only fires on `v*`, so pushing `0.139.0-patch-1` (no `v`)
+# created no workflow run at all, which presents as "the build workflow didn't pick up"
+# with an empty Actions tab and nowhere to look. Happened 2026-09-03 on os
+# `0.139.0-patch-1` and lms `0.76.1-patch-1`.
+#
+# This fires on EVERY tag so a version-shaped tag that cannot build fails loudly instead.
+# It builds nothing and needs no secrets.
+on:
+  push:
+    tags: ['**']
+
+run-name: "Tag guard — ${{ github.ref_name }}"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: "Will this tag build?"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the tag matches a build trigger
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Keep in step with the `on.push.tags` filters in this repo's workflows.
+          case "$TAG" in
+            v*|skills-v*|app-v*)
+              echo "OK — '$TAG' matches a build trigger."
+              exit 0 ;;
+          esac
+
+          # Not a build trigger. Is it shaped like a release version someone meant to ship?
+          if printf '%s' "$TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            MSG="'$TAG' looks like a release version but does NOT match the Docker Build trigger"
+            MSG="$MSG ('v*'), so NO image will be built and no other run will appear."
+            MSG="$MSG Re-tag as 'v$TAG': git tag v$TAG $GITHUB_SHA && git push origin v$TAG"
+            echo "::error title=Tag will not build::$MSG"
+            exit 1
+          fi
+
+          echo "'$TAG' is not a version-shaped tag — nothing to check."

--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  # Recovery path. The tag filter above is the ONLY trigger this workflow had, so a tag that
+  # did not match it (e.g. `0.139.0-patch-1`, missing the `v`) left NO way to build at all —
+  # the fix was to push another tag. Dispatch lets you build any existing ref, including a
+  # mistyped tag, by selecting it in the ref dropdown. See also tag-guard.yml, which makes the
+  # mistake visible instead of silent.
+  workflow_dispatch:
 
 run-name: 'Build os ${{ github.ref_name }}'
 

--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -23,6 +23,22 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+      # A dispatch MUST target a tag. The reusable names the image from package.json and also
+      # moves `latest`, so dispatching from a branch would rebuild an already-released image tag
+      # and repoint `latest` at it. Before workflow_dispatch existed the only entry was a `v*` tag
+      # push — a deliberate release act — and this keeps that property: dispatch is a RECOVERY
+      # path for a ref that is already tagged, not a way to build a branch.
+      - name: Refuse a dispatch that is not a tag
+        if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          MSG="This workflow builds and pushes an image named from package.json, and also moves"
+          MSG="$MSG 'latest'. Running it against '$REF_NAME' would overwrite a released image tag."
+          MSG="$MSG Select a TAG in the ref dropdown instead."
+          echo "::error title=Dispatch must target a tag::$MSG"
+          exit 1
+
       - uses: actions/checkout@v4
 
       - name: Extract version from package.json


### PR DESCRIPTION
A manually pushed tag that does not match the Docker Build trigger produces **nothing** — no run, no annotation, nothing in the Actions tab.

On 2026-09-03, `os 0.139.0-patch-1` and `lms 0.76.1-patch-1` were pushed manually. `trigger-docker-build.yml` fires only on `v*`, so **GitHub never created a run**. It presented as "the build workflow didn't pick up", with an empty Actions tab and nowhere to look.

## Root cause

Missing `v` prefix. That is the whole of it — `v0.36.9-patch-1` already exists in lms, so the `-patch-N` convention was right.

The version bumps were correct too: `package.json` at both tags already carried the `-patch-1` suffix, and since the image is named from `package.json` rather than the tag, they would have published as **new** ECR tags without overwriting `0.139.0` or `0.76.1`.

**The deeper defect is that there was no recovery path.** The tag filter was the *only* trigger on this workflow, so a mistyped tag could not be built at all — the only fix was to push another tag — and the mistake generated zero signal.

## Changes

**`tag-guard.yml` (new)** — fires on `tags: ['**']`. A version-shaped tag that cannot build now fails loudly:

```
::error title=Tag will not build::'0.139.0-patch-1' looks like a release version but does NOT
match the Docker Build trigger ('v*'), so NO image will be built and no other run will appear.
Re-tag as 'v0.139.0-patch-1': git tag v0.139.0-patch-1 <sha> && git push origin v0.139.0-patch-1
```

It builds nothing and needs no secrets. Non-version tags are ignored.

**`workflow_dispatch` on `trigger-docker-build.yml`** — lets you build any existing ref, including a mistyped tag, by picking it in the ref dropdown.

## What I deliberately did not do

Broaden the tag filter to accept bare semver. That fragments the convention and permits a double build if both `X` and `vX` get pushed. One convention, enforced visibly, is the safer shape.

## Verification

| check | result |
|---|---|
| YAML parse | passes |
| `actionlint` | no new findings (both repos had 1 pre-existing) |
| `bash -n` on the guard script | passes |
| guard executed, `TAG=v0.139.0` | exit 0, "matches a build trigger" |
| guard executed, `TAG=0.139.0-patch-1` | exit 1, error with the re-tag command |
| all 7 tag shapes (`v*`, `skills-v*`, `app-v*`, bare semver, non-version) | classified correctly |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
