### PR TITLE
fix(embed): fall back to '*' when the referrer is our own origin

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -647,6 +647,9 @@ export function sendMessageToParentWebsite(payload: unknown) {
   } catch {
     // keep '*' if referrer is unavailable or unparseable
   }
+  if (targetOrigin === window.location.origin) {
+    targetOrigin = '*';
+  }
   window.parent.postMessage(payload, targetOrigin);
 }
 


### PR DESCRIPTION
## The bug

`sendMessageToParentWebsite` derived `targetOrigin` from `document.referrer`. After any navigation **inside** the embed (SSO hop, redirect-to-home), the referrer becomes an `os.ibl.ai` URL — our own origin, not the host's. Every post to the `lms.ibl.ai` parent was then rejected by the browser:

```
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided
does not match the recipient window's origin.
```

In the captured console log that was **~6348 failed calls in a four-second window**, taking `authExpired` and `tenantSwitch` down with them — the embed asked the host to switch tenant, nothing could arrive, and `TenantProvider`'s mismatch poller sent it home four seconds later.

## The fix

A same-origin referrer means we navigated within the embed; it says nothing about who the host is, so fall back to `'*'`.

```ts
if (targetOrigin === window.location.origin) {
  targetOrigin = '*';
}
```

`'*'` was already the default when there is no referrer, and it is what web-utils' own `sendMessageToParentWebsite` (the one `handleTenantSwitch` calls) has always used. The payloads here are control messages — `{ authExpired }`, `{ tenantSwitch, tenant }`, context info — not tokens; the reverse direction, which does carry axd/dm tokens, already posts with `'*'`.

## Known gap

This does not cover a hop through a **third** origin: coming back from the auth SPA leaves `document.referrer` as `auth.ibl.ai`, which is neither the host nor our own origin, so it is still passed through and posts still fail. The durable fix is to record `event.origin` from an inbound host message and prefer that over any inference — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)