### PR TITLE
fix(embed): accept auth data sent as a JSON string from the host

### DIFF
--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -126,8 +126,20 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   useIframeMessageHandler({
     handlers,
     defaultHandler: (data) => {
-      if (data.axd_token) {
-        saveUserObjectToLocalStorage(data);
+      // agent-ai sends auth data either as an object (`userObject`) or as a
+      // JSON string (`iblData`, `JSON.stringify(localStorage)`). Only the
+      // object form was handled, so every string-form reply — including the
+      // one answering a `tenantSwitch` — was dropped without a trace.
+      let payload = data;
+      if (typeof payload === 'string') {
+        try {
+          payload = JSON.parse(payload);
+        } catch {
+          return;
+        }
+      }
+      if (payload?.axd_token) {
+        saveUserObjectToLocalStorage(payload);
         window.location.reload();
       }
     },


### PR DESCRIPTION
## The bug, in one line

```js
const reply = '{"axd_token":"abc","tenant":"demo",…}'   // a STRING
if (reply.axd_token) { … }                              // undefined → never runs
```

Reading `.axd_token` off a **string** gives `undefined` — strings don't have that property, objects do. So the auth data was silently discarded.

## Why the host sends a string

`agent-ai` replies with auth data in two different shapes:

| Source | Shape | Handled before? |
|---|---|---|
| `this.userObject` | object | ✅ yes |
| `this.iblData` (`JSON.stringify({…})`) | **string** | ❌ no |
| `JSON.stringify(localStorage)` | **string** | ❌ no |

`useIframeMessageHandler` routes any non-object to `defaultHandler` with the raw value, and the handler only understood the object form.

## Why this was invisible

Nothing threw. `agent-ai` answered a `tenantSwitch` request through the `iblData` branch — a string — and the embed dropped it. Neither side logged anything, because neither side failed. That is why the message appeared to be sent and received yet have no effect anywhere.

It also affected the `authExpired` recovery paths, which reply through the same string-shaped branches.

## The change

Parse a string payload back into an object before checking it. A payload that isn't valid JSON is ignored rather than throwing.

## Verified

- `tsc --noEmit` clean
- providers suite **120/120**

## Context

With iblai-js 2.8.4, a persistent tenant mismatch in an iframe re-asks the host instead of navigating the embed to `/`. Since every answer was being discarded, that re-ask repeated indefinitely and the embed appeared to load forever — which is what surfaced this. Follows iblai/os#483 (merged), whose branch this fix missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)