### PR TITLE
fix(embed): do not write the shared auth cookies from inside an iframe

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -2737,6 +2737,40 @@ describe('saveUserObjectToLocalStorage - syncAuthDataToCookies coverage', () => 
     vi.clearAllMocks();
   });
 
+  it('does not write the shared auth cookies when embedded in an iframe', () => {
+    // The cookies live on the base domain, so an embed writing them mutates
+    // the host's auth state and drives a refresh loop between the frames.
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'sub.example.com' },
+      writable: true,
+      configurable: true,
+    });
+    const originalTop = window.top;
+    Object.defineProperty(window, 'top', {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      saveUserObjectToLocalStorage({
+        [LOCAL_STORAGE_KEYS.CURRENT_TENANT]: JSON.stringify({ key: 'demo' }),
+      });
+
+      expect(document.cookie).not.toContain('ibl_current_tenant');
+      // The embed still keeps its own copy.
+      expect(localStorageMock.getItem(LOCAL_STORAGE_KEYS.CURRENT_TENANT)).toBe(
+        JSON.stringify({ key: 'demo' }),
+      );
+    } finally {
+      Object.defineProperty(window, 'top', {
+        value: originalTop,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
   it('should sync current_tenant to cookies when present', () => {
     // Setup hostname with more than 2 parts to test baseDomain calculation
     Object.defineProperty(window, 'location', {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1480,8 +1480,17 @@ export function saveUserObjectToLocalStorage(userObject: object) {
     window.dispatchEvent(new StorageEvent('local-storage', { key }));
   }
 
-  // Sync auth data to cookies for cross-SPA synchronization
-  syncAuthDataToCookies(userObject as Record<string, any>);
+  // Sync auth data to cookies for cross-SPA synchronization.
+  //
+  // Never from inside an iframe. These cookies live on the base domain, so an
+  // embed writing them mutates the HOST's auth state: the host's poller reads
+  // "changes from another SPA", refreshes, re-sends its auth data to the
+  // embed, which saves it and rewrites the cookies again — a refresh loop
+  // between the two frames. The embed's tokens are its own; the host owns the
+  // shared cookies.
+  if (!isInIframe()) {
+    syncAuthDataToCookies(userObject as Record<string, any>);
+  }
 }
 
 export const maxDatasetFileSizeInMegaBytes = () => {


### PR DESCRIPTION
Superseded by iblai/os#486.

I attributed the infinite loading to the embed writing the shared auth cookies, which supposedly made the **host** refresh. That was wrong.

The host logs `Cookie sync detected changes from another SPA, refreshing page` — but it also logs `navigation did not occur` and `skipping redirect` **5 times each** in the same capture. skillsai never actually reloads; the redirect is blocked every time.

The frame that reloads is the **embed**, and the cause is its own handler: the host re-sends auth data whenever the embed announces itself, the handler saves it and calls `window.location.reload()`, which announces it again. #486 fixes that at the source.

Closing rather than merging a behaviour change whose stated justification does not hold. Whether an embed should write base-domain auth cookies at all is a fair separate question, but it is not causing this and should not ride along with a production fix.