### PR TITLE
fix(embed): only save and reload when the host's auth data actually changed

### DIFF
--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -138,10 +138,24 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           return;
         }
       }
-      if (payload?.axd_token) {
-        saveUserObjectToLocalStorage(payload);
-        window.location.reload();
+      if (!payload?.axd_token) {
+        return;
       }
+
+      // The host re-sends its auth data every time we announce ourselves
+      // (`ready`/`loaded`), and saving it reloads us — which announces us
+      // again. Acting on an identical payload therefore loops forever: save,
+      // reload, receive the same data, save. Only act on a real change.
+      const unchanged =
+        localStorage.getItem('axd_token') === payload.axd_token &&
+        localStorage.getItem('dm_token') === payload.dm_token &&
+        localStorage.getItem('tenant') === payload.tenant;
+      if (unchanged) {
+        return;
+      }
+
+      saveUserObjectToLocalStorage(payload);
+      window.location.reload();
     },
   });
 


### PR DESCRIPTION
## The loop

The host re-sends its auth data every time the embed announces itself (`ready` / `loaded`). The handler did:

```ts
saveUserObjectToLocalStorage(payload);
window.location.reload();
```

The reload makes the embed announce itself again, so an **unchanged** payload loops forever: save → reload → receive the same data → save.

In the production capture, one save every ~5 seconds, each followed by a fresh bootstrap:

```
11:46:36  saveUserObjectToLocalStorage clearing local storage
11:46:38  Pathname changed to: /platform/demo/…      ← reloaded
11:46:43  saveUserObjectToLocalStorage clearing local storage
11:46:45  Pathname changed to: /platform/demo/…      ← reloaded
…
```

This was **latent until iblai/os#484**. Before that, string payloads were dropped, so nothing saved and nothing reloaded. Making them actionable also made the identical re-sends actionable.

## The change

Skip when `axd_token`, `dm_token` and `tenant` all match what is already stored. A genuine change — a real tenant switch, refreshed tokens — still saves and reloads exactly as before.

## Verified

- `tsc --noEmit` clean
- providers suite **120/120**

## Correction to iblai/os#485

I previously attributed this loop to the embed writing the shared auth cookies, which supposedly made the **host** refresh. That was wrong: the host logs `Cookie sync detected changes … refreshing page` but also logs `navigation did not occur` and `skipping redirect` **5 times each** — skillsai never actually reloads. The reloading frame is the embed, and the cause is its own handler. #485 should not be merged on that reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)