### PR TITLE
Fix/2468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Bug Fixes
 
-* **markdown:** guard the unguarded position reads in @ziloen/remark-math ([a64576f](https://github.com/iblai/os/commit/a64576f7559d26485d040234138ff13d29fc425d)), closes [#2441](https://github.com/iblai/os/issues/2441)
-* **markdown:** stop an em dash dragging prose into an autolink's host ([abb1c31](https://github.com/iblai/os/commit/abb1c311b11603534cf37e57b22e8e8500203535))
+- **markdown:** guard the unguarded position reads in @ziloen/remark-math ([a64576f](https://github.com/iblai/os/commit/a64576f7559d26485d040234138ff13d29fc425d)), closes [#2441](https://github.com/iblai/os/issues/2441)
+- **markdown:** stop an em dash dragging prose into an autolink's host ([abb1c31](https://github.com/iblai/os/commit/abb1c311b11603534cf37e57b22e8e8500203535))
 
 ### Tests
 
-* **e2e:** assert the voice capability toggle instead of skipping past it ([63fe161](https://github.com/iblai/os/commit/63fe1613773b0bba1071daf97f687d703ca2f726))
-* **e2e:** give journey 48 its own agent and stop leaking journey 13's ([efdac49](https://github.com/iblai/os/commit/efdac49c6b1e48fd61b73e93baf87073686db9ff))
-* **e2e:** let project chat settle on a reply or the User Agreement ([214dd59](https://github.com/iblai/os/commit/214dd59c3056f372cab9c8e4abc8e2ea9f82a731))
-* **markdown:** cover the autolink crash the guard actually fixes ([85f4625](https://github.com/iblai/os/commit/85f4625db10f3d1225925fc9e034ac921a0f43de))
+- **e2e:** assert the voice capability toggle instead of skipping past it ([63fe161](https://github.com/iblai/os/commit/63fe1613773b0bba1071daf97f687d703ca2f726))
+- **e2e:** give journey 48 its own agent and stop leaking journey 13's ([efdac49](https://github.com/iblai/os/commit/efdac49c6b1e48fd61b73e93baf87073686db9ff))
+- **e2e:** let project chat settle on a reply or the User Agreement ([214dd59](https://github.com/iblai/os/commit/214dd59c3056f372cab9c8e4abc8e2ea9f82a731))
+- **markdown:** cover the autolink crash the guard actually fixes ([85f4625](https://github.com/iblai/os/commit/85f4625db10f3d1225925fc9e034ac921a0f43de))
 
 ## [0.141.0](https://github.com/iblai/os/compare/v0.140.6...v0.141.0) (2026-09-04)
 

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -9,6 +9,7 @@ import 'katex/contrib/mhchem';
 import { cn } from '@/lib/utils';
 import { normalizeListIndentation } from '@/lib/normalize-list-indentation';
 import { components } from './markdown/markdown-components';
+import { MarkdownErrorBoundary } from './markdown/markdown-error-boundary';
 import { rehypeAlignedMath } from '@/lib/rehype-aligned-math';
 import { rehypeVerbCode } from '@/lib/rehype-verb-code';
 import { remarkLatexIslands } from '@/lib/remark-latex-islands';
@@ -99,39 +100,41 @@ const TABLE_MAX_HEIGHT = 'none';
 export default function Markdown({ children, className }: Props) {
   return (
     <div className={cn('space-y-4', className)}>
-      <Streamdown
-        plugins={plugins}
-        components={components}
-        // Streamdown splits the message into independently parsed blocks
-        // before remark runs, so a blank line inside a `\[...\]` or a
-        // `\begin{env}` tears the pair apart and no remark plugin can see
-        // it. See lib/latex-aware-blocks.ts.
-        parseMarkdownIntoBlocksFn={parseLatexAwareBlocks}
-        // Streamdown's remend pass speculatively closes what a half-arrived
-        // token opened: a mid-stream `**bold` is rendered bold, and a lone
-        // `$` or `\[` is closed into maths that the next token contradicts.
-        // Off, a delimiter stays literal until its partner actually lands,
-        // which is a beat of raw text instead of a formula that flickers
-        // through a wrong shape. See scripts/gallery-cases.ts.
-        parseIncompleteMarkdown={false}
-        linkSafety={linkSafety}
-        controls={controls}
-        tableMaxHeight={TABLE_MAX_HEIGHT}
-        urlTransform={(url) => {
-          // Allow mailto:, tel:, and http(s): protocols
-          if (
-            url.startsWith('mailto:') ||
-            url.startsWith('tel:') ||
-            url.startsWith('http://') ||
-            url.startsWith('https://')
-          ) {
-            return url;
-          }
-          return '';
-        }}
-      >
-        {normalizeListIndentation(children ?? '')}
-      </Streamdown>
+      <MarkdownErrorBoundary source={children ?? ''}>
+        <Streamdown
+          plugins={plugins}
+          components={components}
+          // Streamdown splits the message into independently parsed blocks
+          // before remark runs, so a blank line inside a `\[...\]` or a
+          // `\begin{env}` tears the pair apart and no remark plugin can see
+          // it. See lib/latex-aware-blocks.ts.
+          parseMarkdownIntoBlocksFn={parseLatexAwareBlocks}
+          // Streamdown's remend pass speculatively closes what a half-arrived
+          // token opened: a mid-stream `**bold` is rendered bold, and a lone
+          // `$` or `\[` is closed into maths that the next token contradicts.
+          // Off, a delimiter stays literal until its partner actually lands,
+          // which is a beat of raw text instead of a formula that flickers
+          // through a wrong shape. See scripts/gallery-cases.ts.
+          parseIncompleteMarkdown={false}
+          linkSafety={linkSafety}
+          controls={controls}
+          tableMaxHeight={TABLE_MAX_HEIGHT}
+          urlTransform={(url) => {
+            // Allow mailto:, tel:, and http(s): protocols
+            if (
+              url.startsWith('mailto:') ||
+              url.startsWith('tel:') ||
+              url.startsWith('http://') ||
+              url.startsWith('https://')
+            ) {
+              return url;
+            }
+            return '';
+          }}
+        >
+          {normalizeListIndentation(children ?? '')}
+        </Streamdown>
+      </MarkdownErrorBoundary>
     </div>
   );
 }

--- a/components/markdown/__tests__/markdown-error-boundary.test.tsx
+++ b/components/markdown/__tests__/markdown-error-boundary.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * The failure this pins: a single unparseable message used to unmount the
+ * whole conversation, permanently, because the message is persisted and
+ * re-parses on every load. The boundary has to hold the blast radius to one
+ * message, show that message's own text rather than an apology, and let go
+ * again the moment the content changes.
+ */
+import { render } from '@testing-library/react';
+import * as Sentry from '@sentry/nextjs';
+
+import { MarkdownErrorBoundary } from '../markdown-error-boundary';
+import { resetMarkdownRenderReports } from '@/lib/markdown-render-error-reporter';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  getClient: vi.fn(() => ({})),
+}));
+
+const captureException = vi.mocked(Sentry.captureException);
+
+const FORDHAM = 'Our site—www.fordham.edu—has more.';
+
+/** Throws on render, exactly as a renderer bug does. */
+function Boom({ when = true }: { when?: boolean }) {
+  if (when)
+    throw new TypeError(
+      "Cannot read properties of undefined (reading 'start')",
+    );
+  return <span>rendered</span>;
+}
+
+// React logs every caught boundary error to console.error; the noise would
+// otherwise bury a real failure in the test output.
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetMarkdownRenderReports();
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('MarkdownErrorBoundary', () => {
+  it('renders its children when nothing throws', () => {
+    const { getByText, queryByTestId } = render(
+      <MarkdownErrorBoundary source="hello">
+        <span>hello</span>
+      </MarkdownErrorBoundary>,
+    );
+
+    expect(getByText('hello')).toBeInTheDocument();
+    expect(queryByTestId('markdown-plain-fallback')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw source, not an apology', () => {
+    const { getByTestId, queryByText } = render(
+      <MarkdownErrorBoundary source={FORDHAM}>
+        <Boom />
+      </MarkdownErrorBoundary>,
+    );
+
+    expect(getByTestId('markdown-plain-fallback')).toHaveTextContent(
+      'Our site—www.fordham.edu—has more.',
+    );
+    expect(queryByText('Oops, there was an error!')).not.toBeInTheDocument();
+  });
+
+  it('still announces the failure when there is no source', () => {
+    const { getByTestId, getByText } = render(
+      <MarkdownErrorBoundary>
+        <Boom />
+      </MarkdownErrorBoundary>,
+    );
+
+    expect(getByText(/couldn't be displayed properly/i)).toBeInTheDocument();
+    expect(getByTestId('markdown-plain-fallback')).toHaveTextContent(
+      /couldn't be displayed properly/i,
+    );
+  });
+
+  it('merges a caller className into the fallback', () => {
+    const { getByTestId } = render(
+      <MarkdownErrorBoundary source="x" className="text-sm">
+        <Boom />
+      </MarkdownErrorBoundary>,
+    );
+
+    const fallback = getByTestId('markdown-plain-fallback');
+    expect(fallback).toHaveClass('space-y-2');
+    expect(fallback).toHaveClass('text-sm');
+  });
+
+  it('keeps the blast radius to the one message that threw', () => {
+    const { getByText, getByTestId } = render(
+      <div>
+        <MarkdownErrorBoundary source="first">
+          <span>first message</span>
+        </MarkdownErrorBoundary>
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom />
+        </MarkdownErrorBoundary>
+        <MarkdownErrorBoundary source="third">
+          <span>third message</span>
+        </MarkdownErrorBoundary>
+      </div>,
+    );
+
+    expect(getByText('first message')).toBeInTheDocument();
+    expect(getByText('third message')).toBeInTheDocument();
+    expect(getByTestId('markdown-plain-fallback')).toHaveTextContent(
+      'fordham.edu',
+    );
+  });
+
+  it('still shows the siblings after a remount, as a reload would', () => {
+    const tree = (
+      <div>
+        <MarkdownErrorBoundary source="sibling">
+          <span>sibling message</span>
+        </MarkdownErrorBoundary>
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom />
+        </MarkdownErrorBoundary>
+      </div>
+    );
+
+    const first = render(tree);
+    first.unmount();
+    const { getByText, getByTestId } = render(tree);
+
+    expect(getByText('sibling message')).toBeInTheDocument();
+    expect(getByTestId('markdown-plain-fallback')).toHaveTextContent(
+      'fordham.edu',
+    );
+  });
+
+  describe('mid-stream reset', () => {
+    it('clears the error when more of the message arrives', () => {
+      const { rerender, getByTestId, getByText, queryByTestId } = render(
+        <MarkdownErrorBoundary source="Our site—www.for">
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(getByTestId('markdown-plain-fallback')).toBeInTheDocument();
+
+      rerender(
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom when={false} />
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(queryByTestId('markdown-plain-fallback')).not.toBeInTheDocument();
+      expect(getByText('rendered')).toBeInTheDocument();
+    });
+
+    it('stays in the fallback when the completed message throws again', () => {
+      const { rerender, getByTestId } = render(
+        <MarkdownErrorBoundary source="Our site—www.for">
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      rerender(
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(getByTestId('markdown-plain-fallback')).toHaveTextContent(
+        'fordham.edu',
+      );
+    });
+
+    it('does not reset when an unrelated prop changes', () => {
+      const { rerender, getByTestId } = render(
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      rerender(
+        <MarkdownErrorBoundary source={FORDHAM} className="text-sm">
+          <Boom when={false} />
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(getByTestId('markdown-plain-fallback')).toBeInTheDocument();
+    });
+
+    it('leaves a healthy render alone when the source changes', () => {
+      const { rerender, getByText } = render(
+        <MarkdownErrorBoundary source="one">
+          <span>one</span>
+        </MarkdownErrorBoundary>,
+      );
+
+      rerender(
+        <MarkdownErrorBoundary source="two">
+          <span>two</span>
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(getByText('two')).toBeInTheDocument();
+    });
+  });
+
+  describe('telemetry', () => {
+    it('reports the shape of the message that threw', () => {
+      render(
+        <MarkdownErrorBoundary source={FORDHAM}>
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(captureException.mock.calls[0][1]).toMatchObject({
+        tags: { subsystem: 'markdown', renderer: 'boundary' },
+        extra: {
+          shape: expect.arrayContaining([
+            'autolink-adjacent-unicode-punctuation',
+          ]),
+        },
+      });
+    });
+
+    it('sends no word of the message itself', () => {
+      const secret = 'Patient John Smith, DOB 1980-01-01—www.hospital.org—here';
+
+      render(
+        <MarkdownErrorBoundary source={secret}>
+          <Boom />
+        </MarkdownErrorBoundary>,
+      );
+
+      const [error, context] = captureException.mock.calls[0];
+      const payload = JSON.stringify({
+        message: (error as Error).message,
+        context,
+      });
+      for (const word of secret.split(/\s+/)) {
+        if (word.length < 4) continue;
+        expect(payload).not.toContain(word);
+      }
+    });
+  });
+});

--- a/components/markdown/markdown-error-boundary.tsx
+++ b/components/markdown/markdown-error-boundary.tsx
@@ -1,0 +1,76 @@
+/**
+ * @file markdown-error-boundary.tsx
+ * @input The markdown source a render is about to run on, and that render
+ * @output The render, or -- when it throws -- the source as plain text
+ * @position Inside components/markdown.tsx, around its own Streamdown body,
+ *   so all 28 `<Markdown>` call sites are covered without touching one of
+ *   them.
+ *
+ * Before this, a single unparseable message took the whole conversation down:
+ * React unwound to the ErrorBoundary wrapping the message list in
+ * components/chat/index.tsx, and every message went with it. The message is
+ * persisted, so it re-parsed and re-threw on every load -- the conversation
+ * was unreachable forever, not broken once. Sentry c47052cc reached production
+ * on ordinary prose (an em dash beside a URL) and forced a revert.
+ *
+ * The fallback is the CONTENT, not an apology: `Markdown` is handed the raw
+ * source, so a failed render costs the reader formatting, never information.
+ *
+ * The reset is `componentDidUpdate` comparing the previous source, NOT a React
+ * `key`. Streaming changes the content on every token; a key would remount the
+ * whole Streamdown subtree each time. Comparing instead means a transient
+ * throw on a half-arrived message clears itself the moment more text lands.
+ */
+import { Component, type ReactNode } from 'react';
+import { TriangleAlert } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { reportMarkdownRenderFailure } from '@/lib/markdown-render-error-reporter';
+
+type Props = {
+  source?: string;
+  className?: string;
+  children: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class MarkdownErrorBoundary extends Component<Props, State> {
+  public state: State = { hasError: false };
+
+  public static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error) {
+    reportMarkdownRenderFailure(error, this.props.source ?? '');
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (this.state.hasError && prevProps.source !== this.props.source) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          className={cn('space-y-2', this.props.className)}
+          data-testid="markdown-plain-fallback"
+        >
+          <p className="flex items-center gap-1.5 text-xs text-gray-500">
+            <TriangleAlert className="h-3.5 w-3.5 flex-none" />
+            <span>This message couldn&apos;t be displayed properly.</span>
+          </p>
+          <div className="whitespace-pre-wrap">{this.props.source}</div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default MarkdownErrorBoundary;

--- a/lib/__tests__/markdown-render-error-reporter.test.ts
+++ b/lib/__tests__/markdown-render-error-reporter.test.ts
@@ -1,0 +1,178 @@
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  MarkdownRenderError,
+  reportMarkdownRenderFailure,
+  resetMarkdownRenderReports,
+} from '../markdown-render-error-reporter';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  getClient: vi.fn(() => ({})),
+}));
+
+const captureException = vi.mocked(Sentry.captureException);
+const getClient = vi.mocked(Sentry.getClient);
+
+const FORDHAM = 'Our site—www.fordham.edu—has more.';
+
+describe('reportMarkdownRenderFailure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClient.mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
+    resetMarkdownRenderReports();
+  });
+
+  it('reports the failure with the boundary tags and the source shape', () => {
+    reportMarkdownRenderFailure(
+      new TypeError("Cannot read properties of undefined (reading 'start')"),
+      FORDHAM,
+    );
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [error, context] = captureException.mock.calls[0];
+    expect(error).toBeInstanceOf(MarkdownRenderError);
+    expect((error as Error).name).toBe('MarkdownRenderError');
+    expect((error as Error).message).toBe(
+      "Cannot read properties of undefined (reading 'start')",
+    );
+    expect(context).toMatchObject({
+      tags: {
+        subsystem: 'markdown',
+        renderer: 'boundary',
+        path: 'chat',
+        errorName: 'TypeError',
+      },
+      extra: {
+        shape: expect.arrayContaining([
+          'autolink-adjacent-unicode-punctuation',
+        ]),
+        occurrences: 1,
+      },
+    });
+  });
+
+  it('keeps the thrown error as the cause so the stack survives', () => {
+    const thrown = new TypeError('boom');
+    reportMarkdownRenderFailure(thrown, 'text');
+
+    expect((captureException.mock.calls[0][0] as Error).cause).toBe(thrown);
+  });
+
+  it('accepts a non-Error throw', () => {
+    reportMarkdownRenderFailure('a string was thrown', 'text');
+
+    const [error, context] = captureException.mock.calls[0];
+    expect((error as Error).message).toBe('a string was thrown');
+    expect(context).toMatchObject({ tags: { errorName: 'Error' } });
+  });
+
+  it('accepts an explicit path', () => {
+    reportMarkdownRenderFailure(new Error('boom'), 'text', 'canvas');
+
+    expect(captureException.mock.calls[0][1]).toMatchObject({
+      tags: { path: 'canvas' },
+    });
+  });
+
+  it('tags the tenant when the URL carries a platform key', () => {
+    window.history.pushState({}, '', '/platform/acme/mentor');
+    reportMarkdownRenderFailure(new Error('boom'), 'text');
+    window.history.pushState({}, '', '/');
+
+    expect(captureException.mock.calls[0][1]).toMatchObject({
+      tags: { tenant: 'acme' },
+    });
+  });
+
+  it('omits the tenant tag when there is no window', () => {
+    vi.stubGlobal('window', undefined);
+    reportMarkdownRenderFailure(new Error('boom'), 'text');
+    vi.unstubAllGlobals();
+
+    expect(captureException.mock.calls[0][1]).not.toMatchObject({
+      tags: { tenant: expect.anything() },
+    });
+  });
+
+  it('stays silent without a Sentry client', () => {
+    getClient.mockReturnValue(undefined);
+    reportMarkdownRenderFailure(new Error('boom'), 'text');
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports a repeated failure once per session', () => {
+    for (let i = 0; i < 5; i++) {
+      reportMarkdownRenderFailure(new Error('boom'), FORDHAM);
+    }
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('separates failures that differ only in shape', () => {
+    reportMarkdownRenderFailure(new Error('boom'), FORDHAM);
+    reportMarkdownRenderFailure(new Error('boom'), '| a | b |\n| - | - |');
+
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps the number of distinct signatures it tracks', () => {
+    for (let i = 0; i < 60; i++) {
+      reportMarkdownRenderFailure(new Error(`boom ${i}`), 'text');
+    }
+
+    expect(captureException).toHaveBeenCalledTimes(50);
+  });
+
+  it('forgets its signatures on reset', () => {
+    reportMarkdownRenderFailure(new Error('boom'), 'text');
+    resetMarkdownRenderReports();
+    reportMarkdownRenderFailure(new Error('boom'), 'text');
+
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
+
+  it('never lets a telemetry failure escape', () => {
+    captureException.mockImplementationOnce(() => {
+      throw new Error('sentry is down');
+    });
+
+    expect(() =>
+      reportMarkdownRenderFailure(new Error('boom'), 'text'),
+    ).not.toThrow();
+  });
+});
+
+/**
+ * The invariant the whole reporter exists to hold: the message that crashed
+ * the renderer is the user's conversation, and none of it may leave the
+ * browser. Only the shape does.
+ */
+const SECRETS = [
+  'My password is hunter2 and my card is 4111 1111 1111 1111',
+  'Patient John Smith, DOB 1980-01-01—www.hospital.org—admitted',
+  'Email conrad@example.com about the 250,000 dollar offer',
+];
+
+describe('markdown render telemetry never carries prose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClient.mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
+    resetMarkdownRenderReports();
+  });
+
+  it.each(SECRETS)('sends no fragment of %j', (source) => {
+    reportMarkdownRenderFailure(new TypeError('boom'), source);
+
+    const [error, context] = captureException.mock.calls[0];
+    const payload = JSON.stringify({
+      message: (error as Error).message,
+      context,
+    });
+    for (const word of source.split(/\s+/)) {
+      if (word.length < 4) continue;
+      expect(payload).not.toContain(word);
+    }
+  });
+});

--- a/lib/__tests__/markdown-shape-classifier.test.ts
+++ b/lib/__tests__/markdown-shape-classifier.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The classifier exists so a render crash can be reproduced from its Sentry
+ * event alone. Two things have to hold: the tokens have to be specific enough
+ * to point at the construct that broke (the autolink/em-dash case above all,
+ * which cost days), and no token may ever carry a character of the message.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  classifyMarkdownShape,
+  MARKDOWN_SHAPE_TOKENS,
+} from '../markdown-shape-classifier';
+
+const shapeOf = (source: string) =>
+  classifyMarkdownShape(source).filter((token) => !token.startsWith('length-'));
+
+const lengthOf = (source: string) =>
+  classifyMarkdownShape(source).find((token) => token.startsWith('length-'));
+
+describe('classifyMarkdownShape', () => {
+  it('classifies plain prose as shapeless', () => {
+    expect(shapeOf('Just some ordinary prose about nothing at all.')).toEqual(
+      [],
+    );
+  });
+
+  describe('autolink-adjacent unicode punctuation', () => {
+    // The Fordham crash: an em dash glued to a bare autolink.
+    it('flags an em dash before and after a bare www autolink', () => {
+      expect(shapeOf('Our site—www.fordham.edu—has more.')).toContain(
+        'autolink-adjacent-unicode-punctuation',
+      );
+    });
+
+    it('flags punctuation only before the autolink', () => {
+      expect(shapeOf('Read more—www.fordham.edu')).toContain(
+        'autolink-adjacent-unicode-punctuation',
+      );
+    });
+
+    it('flags a curly quote inside an https autolink run', () => {
+      expect(shapeOf('See https://example.com’s docs')).toContain(
+        'autolink-adjacent-unicode-punctuation',
+      );
+    });
+
+    it('leaves a clean autolink unflagged', () => {
+      const tokens = shapeOf('Our site www.fordham.edu has more.');
+      expect(tokens).toContain('autolink');
+      expect(tokens).not.toContain('autolink-adjacent-unicode-punctuation');
+    });
+
+    it('does not flag ASCII punctuation around an autolink', () => {
+      expect(shapeOf('Visit (www.fordham.edu), then leave.')).not.toContain(
+        'autolink-adjacent-unicode-punctuation',
+      );
+    });
+
+    it('does not flag unicode punctuation separated by whitespace', () => {
+      expect(shapeOf('Our site — www.fordham.edu — has more.')).not.toContain(
+        'autolink-adjacent-unicode-punctuation',
+      );
+    });
+
+    it('finds the flagged autolink even when a clean one comes first', () => {
+      expect(
+        shapeOf('First www.a.com is fine, then www.b.com—broken.'),
+      ).toContain('autolink-adjacent-unicode-punctuation');
+    });
+  });
+
+  it.each([
+    ['math-delimiter', '$$\na = b\n$$'],
+    ['math-delimiter', 'Inline \\(a\\) maths'],
+    ['math-delimiter', 'Prices are $12 apples$ here'],
+    ['latex-environment', '\\begin{tabular}{cc}a\\end{tabular}'],
+    ['code-fence', 'Text\n\n```ts\nconst a = 1;\n```'],
+    ['code-fence', 'Text\n\n~~~\nplain\n~~~'],
+    ['table', '| a | b |\n| - | - |\n| 1 | 2 |'],
+    ['nested-list', '- one\n  - nested\n'],
+    ['nested-list', '1. one\n   1. nested\n'],
+    ['html-block', '<div class="x">hi</div>'],
+    ['html-block', 'a <br/> b'],
+    ['footnote', 'Text[^1]\n\n[^1]: note'],
+    ['image', '![alt](https://example.com/a.png)'],
+    ['image', '![alt][ref]'],
+    ['link-reference', '[ref]: https://example.com'],
+  ])('detects %s', (token, source) => {
+    expect(shapeOf(source)).toContain(token);
+  });
+
+  it('does not call a flat list nested', () => {
+    expect(shapeOf('- one\n- two\n')).not.toContain('nested-list');
+  });
+
+  it('does not call a uniformly indented list nested', () => {
+    expect(shapeOf('  - one\n  - two\n')).not.toContain('nested-list');
+  });
+
+  it('does not call an outdented follow-on item nested', () => {
+    expect(shapeOf('  - indented first\n- then shallower\n')).not.toContain(
+      'nested-list',
+    );
+  });
+
+  it('treats a tab-indented item as nested', () => {
+    expect(shapeOf('- one\n\t- nested\n')).toContain('nested-list');
+  });
+
+  it('reports several shapes at once', () => {
+    const tokens = shapeOf('| a | b |\n| - | - |\n\n```ts\nx\n```\n\n![i](u)');
+    expect(tokens).toEqual(
+      expect.arrayContaining(['table', 'code-fence', 'image']),
+    );
+  });
+
+  it.each([
+    ['length-0-64', ''],
+    ['length-0-64', 'a'.repeat(63)],
+    ['length-64-256', 'a'.repeat(64)],
+    ['length-256-1k', 'a'.repeat(256)],
+    ['length-1k-4k', 'a'.repeat(1024)],
+    ['length-4k-16k', 'a'.repeat(4096)],
+    ['length-16k-plus', 'a'.repeat(16384)],
+  ])('buckets a source length as %s', (bucket, source) => {
+    expect(lengthOf(source)).toBe(bucket);
+  });
+
+  it('always emits exactly one length bucket', () => {
+    const tokens = classifyMarkdownShape('- one\n  - two\n');
+    expect(tokens.filter((t) => t.startsWith('length-'))).toHaveLength(1);
+  });
+});
+
+/**
+ * The invariant, not the examples: for ANY input the tokens come from the
+ * closed vocabulary, so no widening of a detector can start leaking prose.
+ */
+const SENSITIVE = [
+  'My password is hunter2 and my card is 4111 1111 1111 1111',
+  'Patient John Smith, DOB 1980-01-01—www.hospital.org—admitted',
+  'Email conrad@example.com about the 250,000 dollar offer',
+  'The API key is sk-abc123XYZ\n\n```bash\nexport KEY=sk-abc123XYZ\n```',
+  '| Name | Salary |\n| - | - |\n| Jane Doe | 190000 |',
+  '![Jane Doe headshot](https://cdn.internal/jane-doe.png)',
+  '<div data-user="jane.doe@example.com">private</div>',
+  '\\begin{tabular} secret merger terms \\end{tabular}',
+  'Notes[^1]\n\n[^1]: the acquisition closes in March',
+  '- Board minutes\n  - Terminate the Chicago lease\n',
+];
+
+describe('markdown shape telemetry never carries prose', () => {
+  it.each(SENSITIVE)('emits only vocabulary tokens for %j', (source) => {
+    const tokens = classifyMarkdownShape(source);
+    expect(tokens.length).toBeGreaterThan(0);
+    for (const token of tokens) {
+      expect(MARKDOWN_SHAPE_TOKENS).toContain(token);
+      expect(source).not.toContain(token);
+    }
+  });
+
+  it('survives adversarial input without throwing', () => {
+    for (const source of ['', '\0', '\\'.repeat(500), '—'.repeat(500)]) {
+      expect(() => classifyMarkdownShape(source)).not.toThrow();
+    }
+  });
+});

--- a/lib/markdown-render-error-reporter.ts
+++ b/lib/markdown-render-error-reporter.ts
@@ -1,0 +1,85 @@
+/**
+ * @file markdown-render-error-reporter.ts
+ * @input The error a markdown render threw, plus the raw source it threw on
+ * @output Nothing. One Sentry event per distinct failure per session, carrying
+ *   the SHAPE of the source and never the source.
+ * @position Called from components/markdown/markdown-error-boundary.tsx.
+ *
+ * A renderer bug used to take the whole conversation down and force a revert.
+ * With the boundary it takes one message, so the cost of the next one is a
+ * ticket -- provided the ticket says enough to reproduce from. The Fordham
+ * crash (Sentry c47052cc) could not be: the payload had a stack and nothing
+ * else, and the trigger was an em dash beside a URL.
+ *
+ * Message text must never reach Sentry: it is the user's conversation, and it
+ * is exactly what a renderer crash makes tempting to attach. Only
+ * classification tokens go out. See lib/markdown-shape-classifier.ts.
+ *
+ * Streaming re-renders a message on every token, so identical failures are
+ * reported once per session and the signature set is capped. Mirrors the
+ * `send` in lib/markdown-math-error-reporter.ts.
+ */
+import * as Sentry from '@sentry/nextjs';
+
+import { URL_PATTERNS } from './constants';
+import { classifyMarkdownShape } from './markdown-shape-classifier';
+
+const MAX_SIGNATURES = 50;
+
+const occurrences = new Map<string, number>();
+
+export class MarkdownRenderError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'MarkdownRenderError';
+  }
+}
+
+type Path = 'chat' | 'canvas';
+
+/** The dedupe map is session-scoped; tests need a clean slate per case. */
+export function resetMarkdownRenderReports() {
+  occurrences.clear();
+}
+
+export function reportMarkdownRenderFailure(
+  error: unknown,
+  source: string,
+  path: Path = 'chat',
+) {
+  try {
+    if (!Sentry.getClient()) return;
+
+    const thrown = error instanceof Error ? error : new Error(String(error));
+    const shape = classifyMarkdownShape(source);
+    const signature = `${path}|${thrown.name}|${thrown.message}|${shape.join(',')}`;
+
+    const count = (occurrences.get(signature) ?? 0) + 1;
+    if (count === 1 && occurrences.size >= MAX_SIGNATURES) return;
+    occurrences.set(signature, count);
+    if (count > 1) return;
+
+    const platform =
+      typeof window === 'undefined'
+        ? null
+        : window.location.pathname.match(URL_PATTERNS.PLATFORM_KEY);
+
+    Sentry.captureException(
+      new MarkdownRenderError(thrown.message, { cause: thrown }),
+      {
+        tags: {
+          subsystem: 'markdown',
+          renderer: 'boundary',
+          path,
+          errorName: thrown.name,
+          ...(platform ? { tenant: platform[1] } : {}),
+        },
+        // The shape of the source and the length bucket it fell in -- never a
+        // character of the source itself.
+        extra: { shape, occurrences: count },
+      },
+    );
+  } catch {
+    // Telemetry must never break the fallback that replaced the render.
+  }
+}

--- a/lib/markdown-shape-classifier.ts
+++ b/lib/markdown-shape-classifier.ts
@@ -1,0 +1,145 @@
+/**
+ * @file markdown-shape-classifier.ts
+ * @input A message's raw markdown source
+ * @output A CLASSIFICATION of the constructs the source contains -- tokens
+ *   drawn from a closed vocabulary, plus one bucketed length -- never any
+ *   fragment of the source itself.
+ * @position Pure functions, called from
+ *   lib/markdown-render-error-reporter.ts when a render throws.
+ *
+ * When the markdown renderer throws, the message that broke it cannot be sent
+ * anywhere: it is the user's conversation. The Sentry payload for the Fordham
+ * crash (`TypeError: Cannot read properties of undefined (reading 'start')`)
+ * carried a stack and nothing else, and the trigger -- an em dash glued to a
+ * bare autolink -- took days to find. A shape says which constructs were in
+ * play without saying a word of what the user wrote.
+ *
+ * PRIVACY. Every token returned here is a literal from SHAPES or one of the
+ * fixed LENGTH_BUCKETS labels. Nothing is ever interpolated from the source,
+ * so no token can carry prose, a name, a URL or a secret. That closed
+ * vocabulary is what lib/__tests__/markdown-shape-classifier.test.ts pins.
+ */
+import {
+  hasLatexConstruct,
+  sourceEnvironments,
+} from './markdown-latex-residue';
+
+/** A bare autolink literal: what GFM turns into a link without any syntax. */
+const AUTOLINK = /(?:https?:\/\/|www\.)/giu;
+
+/**
+ * Punctuation or symbol outside ASCII. An em dash, an en dash, an ellipsis or
+ * a curly quote beside an autolink is the shape that produced the Fordham
+ * crash, and none of them are in GFM's trailing-punctuation trim set.
+ */
+const UNICODE_PUNCTUATION = /[\p{P}\p{S}]/u;
+
+const isUnicodePunctuation = (char: string | undefined): boolean =>
+  char !== undefined &&
+  char.charCodeAt(0) > 127 &&
+  UNICODE_PUNCTUATION.test(char);
+
+/**
+ * True when a bare autolink literal touches non-ASCII punctuation -- either
+ * immediately before it, or inside the unbroken run that GFM will read as the
+ * link. See lib/remark-trim-autolink-host.ts for why that run is dangerous.
+ */
+function hasAutolinkAdjacentUnicodePunctuation(source: string): boolean {
+  AUTOLINK.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = AUTOLINK.exec(source)) !== null) {
+    if (isUnicodePunctuation(source[match.index - 1])) return true;
+    for (let i = AUTOLINK.lastIndex; i < source.length; i++) {
+      const char = source[i];
+      if (/\s/.test(char)) break;
+      if (isUnicodePunctuation(char)) return true;
+    }
+  }
+  return false;
+}
+
+const hasAutolink = (source: string): boolean => {
+  AUTOLINK.lastIndex = 0;
+  return AUTOLINK.test(source);
+};
+
+/** A GFM pipe row -- the shape a table delimiter row sits in. */
+const TABLE = /^ {0,3}\|.*\|/m;
+
+/** A list item line, capturing its indentation. */
+const LIST_LINE = /^([ \t]*)(?:[-*+]|\d{1,9}[.)]) /;
+
+/** True when some list item is indented further than an earlier, shallower one. */
+function hasNestedList(source: string): boolean {
+  let shallowest = Infinity;
+  for (const line of source.split('\n')) {
+    const match = LIST_LINE.exec(line);
+    if (!match) continue;
+    const indent = match[1].replace(/\t/g, '    ').length;
+    if (indent > shallowest) return true;
+    if (indent < shallowest) shallowest = indent;
+  }
+  return false;
+}
+
+/** Every detector: a fixed token and the test that earns it. */
+const SHAPES: [string, (source: string) => boolean][] = [
+  ['autolink', hasAutolink],
+  [
+    'autolink-adjacent-unicode-punctuation',
+    hasAutolinkAdjacentUnicodePunctuation,
+  ],
+  [
+    'math-delimiter',
+    (source) => hasLatexConstruct(source) || /\\\(|\$[^$\n]+\$/.test(source),
+  ],
+  ['latex-environment', (source) => sourceEnvironments(source).length > 0],
+  ['code-fence', (source) => /^ {0,3}(?:```|~~~)/m.test(source)],
+  ['table', (source) => TABLE.test(source)],
+  ['nested-list', hasNestedList],
+  [
+    'html-block',
+    (source) => /<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^<>]*)?\/?>/.test(source),
+  ],
+  ['footnote', (source) => /\[\^[^\]\s]+\]/.test(source)],
+  ['image', (source) => /!\[[^\]]*\][([]/.test(source)],
+  ['link-reference', (source) => /^ {0,3}\[[^\]]+\]:\s*\S/m.test(source)],
+];
+
+/** Upper bound (exclusive) and the label a source below it earns. */
+const LENGTH_BUCKETS: [number, string][] = [
+  [64, 'length-0-64'],
+  [256, 'length-64-256'],
+  [1024, 'length-256-1k'],
+  [4096, 'length-1k-4k'],
+  [16384, 'length-4k-16k'],
+];
+
+const LENGTH_OVERFLOW = 'length-16k-plus';
+
+function lengthBucket(length: number): string {
+  for (const [limit, label] of LENGTH_BUCKETS) {
+    if (length < limit) return label;
+  }
+  return LENGTH_OVERFLOW;
+}
+
+/**
+ * The constructs `source` contains, as classification tokens, plus the bucket
+ * its length falls in. Never a character of the source itself.
+ */
+export function classifyMarkdownShape(source: string): string[] {
+  const tokens: string[] = [];
+  for (const [token, detect] of SHAPES) {
+    if (detect(source)) tokens.push(token);
+  }
+  tokens.push(lengthBucket(source.length));
+  return tokens;
+}
+
+/** The complete closed vocabulary, for the privacy guard to assert against. */
+export const MARKDOWN_SHAPE_TOKENS: readonly string[] = [
+  ...SHAPES.map(([token]) => token),
+  ...LENGTH_BUCKETS.map(([, label]) => label),
+  LENGTH_OVERFLOW,
+];


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints OpenAPI schema was updated if applicable

## Changes
- Added an Error Boundary to the Markdown Component. Failure in the Markdown component should not bring down the entire chat. We would rather render plain text; the error will still go to Sentry instead of bringing the app down. Closes https://github.com/iblai/iblai-platform/issues/2468

## Error Image
<img width="1600" height="965" alt="WhatsApp Image 2026-09-05 at 20 48 50" src="https://github.com/user-attachments/assets/c7223ccc-1997-48ff-91d9-478099449f11" />


## Screenshots
<img width="2880" height="1665" alt="Screenshot from 2026-09-08 04-57-59" src="https://github.com/user-attachments/assets/8ce8ca33-fed9-4ca5-809e-e5d6dd610639" />
