### PR TITLE
fix(sso): prefer localStorage redirect-to, override only for embed URLs

### DIFF
--- a/app/sso-login-complete/page.tsx
+++ b/app/sso-login-complete/page.tsx
@@ -4,6 +4,7 @@ import React, { Suspense, useEffect } from 'react';
 import { SsoLogin as SsoLoginComponent } from '@iblai/iblai-js/web-containers/next';
 import { LOCAL_STORAGE_KEYS } from '@/lib/constants';
 import { hideInitialLoader } from '@/lib/initial-loader';
+import { resolveSsoRedirectPath } from '@/lib/sso-redirect';
 
 // Prevent static generation - this page uses browser APIs
 export const dynamic = 'force-dynamic';
@@ -26,40 +27,16 @@ function SsoLoginCompleteContent() {
       resolveRedirectPath={(
         redirectPath: string,
         parsedData: Record<string, string>,
-      ): string => {
-        // Prefer an explicit `?redirect-path=` on the URL over any value
-        // SsoLogin resolved from localStorage. The Chrome side-panel routes the
-        // partitioned mentor iframe through this page to install the session,
-        // and a prior failed-auth cycle can leave a stale `redirect-to` in that
-        // iframe's storage that would otherwise win and drop the embed params
-        // (embed / mode / component / extra-body-classes) the panel asked for.
-        //
-        // Only honor an in-app, same-origin path: SsoLogin navigates to
-        // `location.origin + redirectPath`, so an unvalidated value like
-        // `@evil.com` or `//evil.com` would be an open redirect. Require a
-        // single leading slash with no protocol-relative `//` or `/\` authority.
-        if (typeof window !== 'undefined') {
-          const explicit = new URLSearchParams(window.location.search).get(
-            'redirect-path',
-          );
-          if (explicit && /^\/(?![/\\])/.test(explicit)) {
-            redirectPath = explicit;
-          }
-        }
-
-        // Check if redirectPath contains a platform key that doesn't match the authenticated tenant
-        const platformKeyMatch = redirectPath.match(/^\/platform\/([^/]+)/);
-        if (platformKeyMatch) {
-          const pathPlatformKey = platformKeyMatch[1];
-          const authenticatedTenant = parsedData.tenant;
-
-          if (authenticatedTenant && pathPlatformKey !== authenticatedTenant) {
-            // Platform key in path doesn't match authenticated tenant, reset to default
-            redirectPath = '/';
-          }
-        }
-        return redirectPath;
-      }}
+      ): string =>
+        // localStorage `redirect-to` wins by default; an explicit same-origin
+        // `?redirect-path=` overrides it only when it carries embed context
+        // (the Chrome side-panel case). See resolveSsoRedirectPath.
+        resolveSsoRedirectPath(
+          redirectPath,
+          parsedData,
+          typeof window !== 'undefined' ? window.location.search : '',
+        )
+      }
     />
   );
 }

--- a/lib/__tests__/sso-redirect.test.ts
+++ b/lib/__tests__/sso-redirect.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveSsoRedirectPath } from '../sso-redirect';
+
+// Build a `?redirect-path=<value>` search string with the value encoded the way
+// the auth SPA / side-panel put it on the URL.
+const search = (redirectPath: string) =>
+  `?redirect-path=${encodeURIComponent(redirectPath)}&data=%7B%7D`;
+
+describe('resolveSsoRedirectPath', () => {
+  it('prefers the localStorage-resolved path over a plain ?redirect-path=/ (the regression)', () => {
+    // Tenant-switch flow: SsoLogin resolved the real mentor path from
+    // localStorage; the URL only carries the default redirect-path=/.
+    expect(
+      resolveSsoRedirectPath(
+        '/platform/acme/m1',
+        { tenant: 'acme' },
+        search('/'),
+      ),
+    ).toBe('/platform/acme/m1');
+  });
+
+  it('lets an explicit same-origin path override ONLY when it carries embed=true', () => {
+    const embedPath = '/platform/acme/m1?embed=true&mode=chat&component=chat';
+    expect(
+      resolveSsoRedirectPath('/', { tenant: 'acme' }, search(embedPath)),
+    ).toBe(embedPath);
+  });
+
+  it('does NOT override with an explicit path that lacks embed=true', () => {
+    expect(
+      resolveSsoRedirectPath(
+        '/platform/acme/m1',
+        { tenant: 'acme' },
+        search('/somewhere-else'),
+      ),
+    ).toBe('/platform/acme/m1');
+  });
+
+  it('rejects an open-redirect explicit value even with embed=true', () => {
+    for (const evil of ['//evil.com?embed=true', '/\\evil.com?embed=true']) {
+      expect(
+        resolveSsoRedirectPath(
+          '/platform/acme/m1',
+          { tenant: 'acme' },
+          search(evil),
+        ),
+      ).toBe('/platform/acme/m1');
+    }
+  });
+
+  it('resets a cross-tenant /platform path to the default', () => {
+    expect(
+      resolveSsoRedirectPath('/platform/other/m1', { tenant: 'acme' }, ''),
+    ).toBe('/');
+  });
+
+  it('keeps a /platform path that matches the authenticated tenant', () => {
+    expect(
+      resolveSsoRedirectPath('/platform/acme/m1', { tenant: 'acme' }, ''),
+    ).toBe('/platform/acme/m1');
+  });
+});

--- a/lib/sso-redirect.ts
+++ b/lib/sso-redirect.ts
@@ -1,0 +1,55 @@
+/**
+ * Decide the post-SSO redirect path for `/sso-login-complete`.
+ *
+ * Precedence: the path SsoLogin resolved from localStorage (`redirect-to`) wins
+ * by default — that's where tenant-switch / login flows stash the real return
+ * path (e.g. the mentor the user was on). An explicit same-origin
+ * `?redirect-path=` on the URL only overrides it when it carries embed context
+ * (`embed=true`): the Chrome side-panel routes its partitioned mentor iframe
+ * through this page to install the session, and a prior failed-auth cycle can
+ * leave a stale `redirect-to` in that iframe's storage that would otherwise win
+ * and drop the panel's embed params (embed / mode / component /
+ * extra-body-classes). Normal flows pass `redirect-path=/` (no embed marker), so
+ * the resolved localStorage path is preserved.
+ *
+ * Security: SsoLogin navigates to `location.origin + redirectPath`, so an
+ * unvalidated explicit value like `@evil.com` or `//evil.com` would be an open
+ * redirect — only honor a single leading slash with no protocol-relative `//`
+ * or `/\` authority.
+ *
+ * Finally, if the chosen path targets a `/platform/<key>` that doesn't match the
+ * authenticated tenant, reset to the default `/`.
+ *
+ * @param resolvedPath  the path SsoLogin resolved (from localStorage `redirect-to`)
+ * @param parsedData    the SSO payload (its `tenant` is the authenticated tenant)
+ * @param search        `window.location.search` (passed in to keep this pure)
+ */
+export function resolveSsoRedirectPath(
+  resolvedPath: string,
+  parsedData: Record<string, string>,
+  search: string,
+): string {
+  let redirectPath = resolvedPath;
+
+  const explicit = new URLSearchParams(search).get('redirect-path');
+  if (
+    explicit &&
+    /^\/(?![/\\])/.test(explicit) && // same-origin, no open redirect
+    /[?&]embed=true(?:&|$)/.test(explicit) // extension/embed only
+  ) {
+    redirectPath = explicit;
+  }
+
+  // A path scoped to a different tenant than the one just authenticated is
+  // stale/cross-tenant — fall back to the default.
+  const platformKeyMatch = redirectPath.match(/^\/platform\/([^/]+)/);
+  if (platformKeyMatch) {
+    const pathPlatformKey = platformKeyMatch[1];
+    const authenticatedTenant = parsedData.tenant;
+    if (authenticatedTenant && pathPlatformKey !== authenticatedTenant) {
+      redirectPath = '/';
+    }
+  }
+
+  return redirectPath;
+}


### PR DESCRIPTION
## Problem

`/sso-login-complete`'s `resolveRedirectPath` made an explicit `?redirect-path=` on the URL **always** win over the localStorage `redirect-to` value (added for the Chrome side-panel). That flipped precedence for every flow:

- Tenant-switch / normal login redirects through this page with **`redirect-path=/`**, while `handleTenantSwitch` stashes the real return path (e.g. `/platform/<tenant>/<mentor>`) in localStorage `redirect-to`.
- Explicit-wins therefore sent users to **`/` instead of back to their mentor**.

## Fix

**localStorage `redirect-to` wins by default.** An explicit same-origin `?redirect-path=` overrides it **only when it carries embed context (`embed=true`)** — the side-panel case, where a stale `redirect-to` in the partitioned iframe storage would otherwise drop the panel's embed params (embed / mode / component / extra-body-classes). The open-redirect guard (single leading slash, no `//` or `/\`) and the cross-tenant `/platform` reset are preserved.

- Normal flows (`redirect-path=/`, no embed marker) → localStorage path used → user returns to their mentor. ✅
- Side-panel (`redirect-path=/platform/…?embed=true&…`) → override still applies. ✅

Extracted the logic into a pure `resolveSsoRedirectPath()` (`lib/sso-redirect.ts`) so it's unit-testable.

## Tests
6 unit tests: the regression (plain `/` doesn't clobber localStorage), embed override, embed-absent no-override, open-redirect rejection (incl. with `embed=true`), cross-tenant reset, matching-tenant kept. Typecheck ✓.