### PR TITLE
test(e2e): direct-mentor-URL tenant/mentor redirect invariant (Journey 32)

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -42,6 +42,19 @@ INVITE_USERNAME=
 INVITE_USER_PASSWORD=
 AUTH_NEXTJS_HOST=
 
+# Direct mentor URL SSO-redirect invariant tests (Journey 32).
+# SECOND_TENANT_MENTOR_URL: a mentor URL ({host}/platform/{tenant}/{mentorId})
+# in a SECOND tenant that PLAYWRIGHT_USERNAME also belongs to (distinct from
+# their default tenant). Used to verify a direct visit — logged out, or
+# logged into the default tenant — lands back on THIS exact tenant+mentor.
+SECOND_TENANT_MENTOR_URL=
+# NO_ACCESS_TENANT_MENTOR_URL: a mentor URL in a tenant PLAYWRIGHT_USERNAME
+# does NOT belong to, and which does not allow self-service auto-join
+# (invite-only / joining disabled) — if self-join would succeed, this test
+# can't distinguish "denied" from "silently granted access". Used to verify
+# a no-access visit is denied rather than silently redirected.
+NO_ACCESS_TENANT_MENTOR_URL=
+
 # Canvas LMS embed tests (Journey 11)
 # Set all three to enable canvas-embed/canvas-embed.spec.ts
 CANVAS_URL=

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,6 +1,6 @@
 # MentorAI E2E Coverage — User Journey Checklist
 
-> Last updated: 2026-09-08 | 709 checkpoints (670 covered, 8 pending/fixme, 15 not-reproducible in default env, 16 deprecated) | 75 journeys (74 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
+> Last updated: 2026-09-08 | 718 checkpoints (676 covered, 11 pending/fixme, 15 not-reproducible in default env, 16 deprecated) | 75 journeys (74 active, 1 deprecated in #1431) | 100% covered | Auth: admin + non-admin storageState
 
 ## How This Works
 
@@ -591,7 +591,7 @@ The "Remember past conversations" (`enable_memory_component`) master toggle move
 
 ---
 
-## Journey 32: Multi-Tenancy, Advertising & Auth Customization (11 checkpoints; 1 deprecated) — `journeys/32-multi-tenancy-advertising-and-auth-customization.spec.ts`
+## Journey 32: Multi-Tenancy, Advertising & Auth Customization (15 checkpoints; 1 deprecated) — `journeys/32-multi-tenancy-advertising-and-auth-customization.spec.ts`
 
 **Source files:** `app/platform/[tenantKey]/[mentorId]/page.tsx`, `app/platform/[tenantKey]/[mentorId]/_components/app-sidebar/index.tsx`, `components/modals/create-mentor-modal.tsx`, `app/sso-login/page.tsx`
 
@@ -606,6 +606,10 @@ The "Remember past conversations" (`enable_memory_component`) master toggle move
 - [x] Help Center toggle controls dropdown and embed visibility _(serial mode added to prevent parallel browser interference)_
 - [x] Help Center URL updates correctly in the dropdown and embed menu _(serial mode added)_
 - [x] ~~Enterprise tenant: new mentor can be created from the My Mentors dialog~~ _(deprecated in #1431 — MyMentorsModal removed; covered by sidebar dialog flow above)_
+- [x] Direct-URL redirect invariant: an unauthenticated visit to a mentor URL lands on that exact tenant+mentor after logging in, not the default tenant _(env-gated: set SECOND_TENANT_MENTOR_URL; locks in the `resolveSsoRedirectPath` fix in `lib/sso-redirect.ts`)_
+- [x] Direct-URL redirect invariant: visiting a second tenant's mentor URL while signed into a different tenant lands on that exact tenant+mentor _(env-gated: SECOND_TENANT_MENTOR_URL)_
+- [x] Direct-URL redirect invariant: visiting a mentor URL while already signed into that same tenant lands there directly with no auth/tenant-switch detour
+- [x] Direct-URL redirect invariant: a user with no access to the visited tenant is denied (routed to `/error/403`), not silently redirected to the default or visited tenant _(env-gated: set NO_ACCESS_TENANT_MENTOR_URL to a tenant with self-join disabled; see the discovery notes in the spec — there is no 409 "no access" page in the current codebase)_
 
 ---
 

--- a/e2e/coverage.json
+++ b/e2e/coverage.json
@@ -2,8 +2,8 @@
   "version": 2,
   "lastUpdated": "2026-09-08",
   "summary": {
-    "totalCheckpoints": 712,
-    "coveredCheckpoints": 670,
+    "totalCheckpoints": 718,
+    "coveredCheckpoints": 676,
     "deprecatedCheckpoints": 16,
     "notReproducibleCheckpoints": 15,
     "pendingCheckpoints": 11,
@@ -2092,7 +2092,8 @@
       "spec": "32-multi-tenancy-advertising-and-auth-customization.spec.ts",
       "sourceFiles": [
         "app/platform/[tenantKey]/[mentorId]/page.tsx",
-        "app/sso-login/page.tsx"
+        "app/sso-login/page.tsx",
+        "app/sso-login-complete/page.tsx"
       ],
       "checkpoints": [
         {
@@ -2151,6 +2152,26 @@
           "status": "deprecated",
           "deprecatedIn": "#1431",
           "deprecatedReason": "MyMentorsModal removed; sidebar New Mentor flow covered by mt-01"
+        },
+        {
+          "id": "mt-12",
+          "description": "Direct-URL redirect invariant: unauthenticated visit to a mentor URL lands on that exact tenant+mentor after login (not the default tenant)",
+          "status": "covered"
+        },
+        {
+          "id": "mt-13",
+          "description": "Direct-URL redirect invariant: visiting a second tenant's mentor URL while signed into a different tenant lands on that exact tenant+mentor (locks in the resolveSsoRedirectPath fix)",
+          "status": "covered"
+        },
+        {
+          "id": "mt-14",
+          "description": "Direct-URL redirect invariant: visiting a mentor URL while already signed into that same tenant lands there directly with no auth/tenant-switch detour",
+          "status": "covered"
+        },
+        {
+          "id": "mt-15",
+          "description": "Direct-URL redirect invariant: a user with no access to the visited tenant is denied (routed to /error/403) rather than silently redirected to the default or visited tenant",
+          "status": "covered"
         }
       ]
     },

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -15,6 +15,25 @@ export const ADVERTISING_TENANT_MENTOR_URL =
   process.env.ADVERTISING_TENANT_MENTOR_URL || '';
 export const AUTH_NEXTJS_HOST = process.env.AUTH_NEXTJS_HOST || '';
 
+// Full mentor URL (`{host}/platform/{tenantKey}/{mentorId}`) for a SECOND
+// tenant that the primary `PLAYWRIGHT_USERNAME` account also belongs to,
+// distinct from their default/home tenant. Used to lock in the direct-URL
+// SSO-redirect invariant: visiting this URL while unauthenticated, or while
+// signed into the primary/home tenant, must land back on THIS exact
+// tenant+mentor rather than the default tenant (the regression fixed by
+// resolveSsoRedirectPath in lib/sso-redirect.ts).
+export const SECOND_TENANT_MENTOR_URL =
+  process.env.SECOND_TENANT_MENTOR_URL || '';
+
+// Full mentor URL for a tenant the primary `PLAYWRIGHT_USERNAME` account does
+// NOT belong to, and which does not allow self-service auto-join (invite-only
+// / join disabled) — self-join succeeding would silently grant access and
+// defeat the point of this fixture. Used to verify that a user with no access
+// is denied (see the "no access" test in Journey 32) rather than silently
+// bounced to the default tenant or the visited tenant.
+export const NO_ACCESS_TENANT_MENTOR_URL =
+  process.env.NO_ACCESS_TENANT_MENTOR_URL || '';
+
 // ── Credentials ──────────────────────────────────────────────────────────────
 
 export const PLAYWRIGHT_USERNAME = process.env.PLAYWRIGHT_USERNAME || '';

--- a/e2e/journeys/32-multi-tenancy-advertising-and-auth-customization.spec.ts
+++ b/e2e/journeys/32-multi-tenancy-advertising-and-auth-customization.spec.ts
@@ -3,15 +3,21 @@ import {
   navigateToMentorApp,
   checkAdminStatus,
   authenticate,
+  getPlatformContext,
 } from '../utils/auth';
 import { safeWaitForURL } from '../utils/navigation';
 import { waitForPageReady } from '../utils/resilient';
 import {
   MENTOR_NEXTJS_HOST,
+  AUTH_HOST,
   FORDHAM_HOST,
   ADVERTISING_TENANT_MENTOR_URL,
+  SECOND_TENANT_MENTOR_URL,
+  NO_ACCESS_TENANT_MENTOR_URL,
   AUTH_NEXTJS_HOST,
   ENABLE_ADVERTISING_LOGIN_TEST,
+  PLAYWRIGHT_USERNAME,
+  PLAYWRIGHT_PASSWORD,
 } from '../fixtures/test-data';
 
 test.describe('Journey 32: Multi-Tenancy — Non-Admin', () => {
@@ -307,6 +313,213 @@ test.describe('Journey 32: Multi-Tenancy — Cross-Tenant Navigation', () => {
       exact: true,
     });
     await expect(advertisingChatInput).toBeVisible({ timeout: 30_000 });
+  });
+});
+
+// Locks in the direct-URL SSO-redirect invariant fixed in lib/sso-redirect.ts
+// (resolveSsoRedirectPath, used by app/sso-login-complete/page.tsx): visiting
+// `/platform/<tenantKey>/<mentorId>` directly must always land the user back
+// on THAT exact tenant+mentor — never silently on the default tenant. The
+// regression this guards against: an explicit `?redirect-path=/` on the
+// SSO-complete URL (the normal shape for a tenant-switch round trip) used to
+// win over the localStorage `redirect-to` value that holds the real
+// requested path, bouncing users to `/` instead of the mentor they asked for.
+//
+// Each assertion below checks the exact `/platform/<tenant>/<mentor>` path —
+// not just "some /platform/ URL" — because the regression's failure mode
+// (landing on the default tenant) would still satisfy a looser
+// `url.includes('/platform/')` check.
+test.describe('Journey 32: Multi-Tenancy — Direct Mentor URL Redirect Invariant', () => {
+  test('unauthenticated user visits a mentor URL directly and lands on that exact tenant+mentor after logging in', async ({
+    browser,
+  }) => {
+    test.skip(
+      !SECOND_TENANT_MENTOR_URL,
+      'Set SECOND_TENANT_MENTOR_URL to enable the direct-URL redirect invariant tests',
+    );
+
+    const expectedPath = new URL(SECOND_TENANT_MENTOR_URL).pathname;
+
+    const anonContext = await browser.newContext({ storageState: undefined });
+    const anonPage = await anonContext.newPage();
+    try {
+      // authenticate() navigates to SECOND_TENANT_MENTOR_URL first (which
+      // bounces an unauthenticated visitor to the auth SPA login form), logs
+      // in, and already waits through login/complete -> sso-login-complete
+      // -> **/platform/*/*. The extra assertion below is what actually locks
+      // in the invariant: the *exact* mentor path, not just any platform URL.
+      await authenticate(anonPage, SECOND_TENANT_MENTOR_URL);
+
+      expect(new URL(anonPage.url()).pathname).toBe(expectedPath);
+
+      const chatInput = anonPage.getByRole('textbox', {
+        name: 'Ask anything',
+        exact: true,
+      });
+      await expect(chatInput).toBeVisible({ timeout: 30_000 });
+    } finally {
+      await anonContext.close();
+    }
+  });
+
+  test('user logged into a different tenant visits a second tenant mentor URL directly and lands on that exact tenant+mentor', async ({
+    page,
+  }) => {
+    test.skip(
+      !SECOND_TENANT_MENTOR_URL,
+      'Set SECOND_TENANT_MENTOR_URL to enable the direct-URL redirect invariant tests',
+    );
+
+    // Establish a session on the user's own (default/home) tenant first —
+    // this is the "logged in to a DIFFERENT tenant" precondition.
+    await navigateToMentorApp(page);
+    const homeUrl = page.url();
+    expect(new URL(homeUrl).pathname).not.toBe(
+      new URL(SECOND_TENANT_MENTOR_URL).pathname,
+    );
+
+    const expectedPath = new URL(SECOND_TENANT_MENTOR_URL).pathname;
+
+    // Directly navigate to the second tenant's mentor URL (simulates pasting
+    // the URL while already signed into a different tenant). This triggers
+    // TenantProvider's handleTenantSwitch, which round-trips through the auth
+    // SPA and back through /sso-login-complete — exactly the path
+    // resolveSsoRedirectPath fixes.
+    await page.goto(SECOND_TENANT_MENTOR_URL, {
+      waitUntil: 'domcontentloaded',
+      timeout: 80_000,
+    });
+
+    await safeWaitForURL(page, (url) => url.pathname === expectedPath, {
+      timeout: 80_000,
+    });
+
+    await waitForPageReady(page);
+
+    expect(new URL(page.url()).pathname).toBe(expectedPath);
+
+    const chatInput = page.getByRole('textbox', {
+      name: 'Ask anything',
+      exact: true,
+    });
+    await expect(chatInput).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('user already logged into the same tenant visits that tenant mentor URL directly and lands there with no detour', async ({
+    page,
+  }) => {
+    await navigateToMentorApp(page);
+    const { tenantKey, mentorId } = await getPlatformContext(page);
+    const ownUrl = `${MENTOR_NEXTJS_HOST}/platform/${tenantKey}/${mentorId}`;
+
+    // Re-visit the exact URL the user is already signed into (simulates
+    // pasting/reloading the URL). Since currentTenant === requestedTenant,
+    // TenantProvider must NOT trigger a tenant switch / auth round trip.
+    await page.goto(ownUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+    await safeWaitForURL(
+      page,
+      (url) => url.pathname === `/platform/${tenantKey}/${mentorId}`,
+      { timeout: 30_000 },
+    );
+
+    // Never bounced through the auth host on the way there.
+    expect(page.url()).not.toContain(AUTH_HOST);
+
+    await waitForPageReady(page);
+
+    const chatInput = page.getByRole('textbox', {
+      name: 'Ask anything',
+      exact: true,
+    });
+    await expect(chatInput).toBeVisible({ timeout: 30_000 });
+  });
+
+  // EXCEPTION CASE — see the discovery notes above the describe block header.
+  //
+  // The task this test guards against described a "409 you don't have access
+  // to this tenant" page. That page does not exist in the current codebase:
+  // there is no 409 handling anywhere in app/, lib/, providers/, or the
+  // installed @iblai/web-utils SDK (2.8.4) that TenantProvider ships from.
+  //
+  // What actually happens when a user visits a tenant they have no access to
+  // (traced through node_modules/@iblai/web-utils/dist/index.esm.js
+  // `TenantProvider.determineWhichTenantToUse`, and
+  // providers/index.tsx's `onAuthFailure` / `onTenantMismatch` handlers):
+  //   1. TenantProvider tries to auto-join the user to the requested tenant
+  //      (`joinAndActivateTenant` -> POST join). Many tenants allow
+  //      self-service join, in which case the visit silently SUCCEEDS —
+  //      this is why NO_ACCESS_TENANT_MENTOR_URL must point at a tenant with
+  //      self-join disabled, or this test cannot distinguish "denied" from
+  //      "auto-joined".
+  //   2. If the join fails, it sets a sessionStorage guard
+  //      (`tenant_access_attempt_<tenant>`) and calls
+  //      `redirectToAuthSpa(undefined, undefined, /* logout */ true)` — a
+  //      real logout (clears localStorage + auth cookies) that bounces to
+  //      the auth SPA's login page, saving the SAME mentor path as
+  //      `redirect-to` so the user returns to it after logging back in.
+  //   3. On the SECOND pass through TenantProvider (post re-login, same tab
+  //      so sessionStorage survives), the guard is already set, so it skips
+  //      the join retry and calls `onAuthFailure(...)` directly, which
+  //      providers/index.tsx routes to `router.push('/error/403')`.
+  //
+  // So the real invariant is: a no-access visit ends on `/error/403` (NOT a
+  // 409, and NOT silently on `/` or the visited tenant) — but only after two
+  // full login round trips. This is asserted below rather than left as
+  // fiction, but it was authored from static reading of the SDK bundle and
+  // could not be run against live infra during authoring — give it a live
+  // dry run before trusting it in CI.
+  test('user with no access to the visited tenant is denied, not silently redirected', async ({
+    page,
+  }) => {
+    test.skip(
+      !NO_ACCESS_TENANT_MENTOR_URL,
+      'Set NO_ACCESS_TENANT_MENTOR_URL (a tenant PLAYWRIGHT_USERNAME cannot self-join) to enable the no-access test',
+    );
+    test.skip(
+      !AUTH_HOST || !PLAYWRIGHT_USERNAME || !PLAYWRIGHT_PASSWORD,
+      'Requires AUTH_HOST + PLAYWRIGHT_USERNAME/PASSWORD to complete the re-login round trip',
+    );
+    // Two full login round trips (see comment above) comfortably exceed the
+    // default per-test timeout.
+    test.setTimeout(240_000);
+
+    await navigateToMentorApp(page);
+
+    // First pass: direct visit triggers the failed auto-join attempt, then a
+    // real logout + redirect to the auth SPA login page.
+    await page.goto(NO_ACCESS_TENANT_MENTOR_URL, {
+      waitUntil: 'domcontentloaded',
+      timeout: 80_000,
+    });
+    await safeWaitForURL(page, (url) => url.href.includes(AUTH_HOST), {
+      timeout: 80_000,
+    });
+
+    // Re-authenticate. Same interaction sequence as
+    // e2e/utils/auth.ts#reAuthenticate, but the destination differs (this
+    // pass is expected to fail with /error/403, not land on a platform URL).
+    await page.click('button:has-text("Continue with Password")');
+    await expect(page.locator('input[type="email"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.fill('input[type="email"]', PLAYWRIGHT_USERNAME);
+    await page.fill('input[type="password"]', PLAYWRIGHT_PASSWORD);
+    await page.click('button:has-text("Continue")');
+
+    // Second pass through TenantProvider: the sessionStorage guard from the
+    // first attempt is still set (same tab), so this time it fails fast to
+    // /error/403 instead of retrying the join.
+    await safeWaitForURL(page, (url) => url.pathname.startsWith('/error/403'), {
+      timeout: 80_000,
+    });
+
+    expect(page.url()).toContain('/error/403');
+
+    // Never ends up on the tenant it has no access to.
+    expect(page.url()).not.toContain(
+      new URL(NO_ACCESS_TENANT_MENTOR_URL).pathname,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Adds e2e coverage locking in the invariant: **opening `/platform/<tenant>/<mentor>` directly always lands you on that exact tenant+mentor** — so the SSO redirect logic (the `resolveSsoRedirectPath` fix, #500) can't silently regress. New "Direct Mentor URL Redirect Invariant" block in **Journey 32** (`mt-12`…`mt-15`):

| Test | Case |
|---|---|
| `mt-12` | **Not logged in** → auth → visited tenant+mentor |
| `mt-13` | Logged into a **different** tenant → visited tenant+mentor |
| `mt-14` | Logged into the **same** tenant → lands there, no detour |
| `mt-15` | **No access** to the visited tenant → denied (see below) |

All env-gated like the rest of Journey 32 (skip cleanly when unset). New env: `SECOND_TENANT_MENTOR_URL` (mt-12/13), `NO_ACCESS_TENANT_MENTOR_URL` (mt-15); mt-14 needs none. Documented in `e2e/.env.example`.

## ⚠️ There is no 409 "no access" page
The requested 409 page doesn't exist in the app or the installed `@iblai/web-utils` SDK. The **real** no-access flow is: **auto-join attempt → on failure, logout + re-login → second pass routes to `/error/403`** (not 409; and many tenants allow self-service join, so the visit can silently *succeed*). `mt-15` asserts that real 403 outcome, heavily commented — but it was authored from **static SDK analysis only (no live infra)**, so it's the one case that needs a **live dry run** before being trusted in CI. Whether to build a real 409 page is a separate product decision.

## Validation
- `playwright test --list` → all 4 discoverable (chrome/firefox/safari), no errors.
- `check-journey-coverage.mjs --no-regress` → **714 → 718 (+4)**, no regression.